### PR TITLE
backport 2.1 tester cmake

### DIFF
--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -30,6 +30,11 @@ set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_EXTENSIONS ON )
 set( CXX_STANDARD_REQUIRED ON )
 
+#adds -pthread. Ubuntu eosio.contracts build breaks without this flag specified
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads)
+
 if ( APPLE )
    set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations" )
 else ( APPLE )
@@ -39,7 +44,7 @@ endif ( APPLE )
 ### Remove after Boost 1.70 CMake fixes are in place
 set( Boost_NO_BOOST_CMAKE ON CACHE STRING "ON or OFF" )
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
-find_package(Boost 1.67 REQUIRED COMPONENTS
+find_package(Boost @Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@ EXACT REQUIRED COMPONENTS
    date_time
    filesystem
    system
@@ -59,9 +64,7 @@ endif()
 
 find_library(libwasm WASM @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
 find_library(libwast WAST @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
-find_library(libwabt wabt @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
 find_library(libir IR     @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
-find_library(libplatform Platform @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
 find_library(liblogging Logging @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
 find_library(libruntime Runtime @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
 find_library(libsoftfloat softfloat @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
@@ -71,12 +74,11 @@ get_filename_component(ssldir @OPENSSL_SSL_LIBRARY@ DIRECTORY)
 find_library(libosssl ssl "${ssldir}" NO_DEFAULT_PATH)
 find_library(libchainbase chainbase @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
 find_library(libbuiltins builtins @CMAKE_INSTALL_PREFIX@/lib64 @CMAKE_INSTALL_PREFIX@/lib NO_DEFAULT_PATH)
-find_library(GMP_LIBRARIES NAMES libgmp.a gmp.lib gmp libgmp-10 mpir
-    HINTS ENV GMP_LIB_DIR
-          ENV GMP_DIR
-    PATH_SUFFIXES lib
-    DOC "Path to the GMP library"
-)
+
+#Ubuntu build requires rt library to be specified explicitly
+if(UNIX AND NOT APPLE)
+  find_library(LIBRT rt)
+endif()
 
 set(EOSIO_WASM_RUNTIMES @EOSIO_WASM_RUNTIMES@)
 if("eos-vm-oc" IN_LIST EOSIO_WASM_RUNTIMES)
@@ -91,9 +93,7 @@ macro(add_eosio_test_executable test_name)
        ${libfc}
        ${libwast}
        ${libwasm}
-       ${libwabt}
        ${libruntime}
-       ${libplatform}
        ${libir}
        ${libsoftfloat}
        ${liboscrypto}
@@ -102,7 +102,7 @@ macro(add_eosio_test_executable test_name)
        ${libchainbase}
        ${libbuiltins}
        ${libsecp256k1}
-       ${GMP_LIBRARIES}
+       @GMP_LIBRARIES@
 
        ${Boost_FILESYSTEM_LIBRARY}
        ${Boost_SYSTEM_LIBRARY}
@@ -116,7 +116,13 @@ macro(add_eosio_test_executable test_name)
        ${PLATFORM_SPECIFIC_LIBS}
 
        ${WRAP_MAIN}
+       Threads::Threads
       )
+   
+   #adds -ltr. Ubuntu eosio.contracts build breaks without this
+   if(UNIX AND NOT APPLE)
+      target_link_libraries(${test_name} ${LIBRT})
+   endif()
 
    target_include_directories( ${test_name} PUBLIC
                                ${Boost_INCLUDE_DIRS}

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -28,6 +28,10 @@ set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_EXTENSIONS ON )
 set( CXX_STANDARD_REQUIRED ON )
 
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads)
+
 if ( APPLE )
    set( CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_CXX_FLAGS} -Wall -Wno-deprecated-declarations" )
 else ( APPLE )
@@ -37,7 +41,7 @@ endif ( APPLE )
 ### Remove after Boost 1.70 CMake fixes are in place
 set( Boost_NO_BOOST_CMAKE ON CACHE STRING "ON or OFF" )
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
-find_package(Boost 1.67 REQUIRED COMPONENTS
+find_package(Boost @Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@ EXACT REQUIRED COMPONENTS
    date_time
    filesystem
    system
@@ -59,8 +63,6 @@ endif()
 find_library(libwasm WASM @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/WASM NO_DEFAULT_PATH)
 find_library(libwast WAST @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/WAST NO_DEFAULT_PATH)
 find_library(libir IR     @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/IR NO_DEFAULT_PATH)
-find_library(libwabt wabt @CMAKE_BINARY_DIR@/libraries/wabt NO_DEFAULT_PATH)
-find_library(libplatform Platform @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/Platform NO_DEFAULT_PATH)
 find_library(liblogging Logging @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/Logging NO_DEFAULT_PATH)
 find_library(libruntime Runtime @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/Runtime NO_DEFAULT_PATH)
 find_library(libsoftfloat softfloat @CMAKE_BINARY_DIR@/libraries/softfloat NO_DEFAULT_PATH)
@@ -70,12 +72,11 @@ get_filename_component(ssldir @OPENSSL_SSL_LIBRARY@ DIRECTORY)
 find_library(libosssl ssl "${ssldir}" NO_DEFAULT_PATH)
 find_library(libchainbase chainbase @CMAKE_BINARY_DIR@/libraries/chainbase NO_DEFAULT_PATH)
 find_library(libbuiltins builtins @CMAKE_BINARY_DIR@/libraries/builtins NO_DEFAULT_PATH)
-find_library(GMP_LIBRARIES NAMES libgmp.a gmp.lib gmp libgmp-10 mpir
-    HINTS ENV GMP_LIB_DIR
-          ENV GMP_DIR
-    PATH_SUFFIXES lib
-    DOC "Path to the GMP library"
-)
+
+#Ubuntu build requires rt library to be specified explicitly
+if(UNIX AND NOT APPLE)
+  find_library(LIBRT rt)
+endif()
 
 set(EOSIO_WASM_RUNTIMES @EOSIO_WASM_RUNTIMES@)
 if("eos-vm-oc" IN_LIST EOSIO_WASM_RUNTIMES)
@@ -90,9 +91,7 @@ macro(add_eosio_test_executable test_name)
        ${libfc}
        ${libwast}
        ${libwasm}
-       ${libwabt}
        ${libruntime}
-       ${libplatform}
        ${libir}
        ${libsoftfloat}
        ${liboscrypto}
@@ -101,7 +100,7 @@ macro(add_eosio_test_executable test_name)
        ${libchainbase}
        ${libbuiltins}
        ${libsecp256k1}
-       ${GMP_LIBRARIES}
+       @GMP_LIBRARIES@
 
        ${Boost_FILESYSTEM_LIBRARY}
        ${Boost_SYSTEM_LIBRARY}
@@ -115,7 +114,13 @@ macro(add_eosio_test_executable test_name)
        ${PLATFORM_SPECIFIC_LIBS}
 
        ${WRAP_MAIN}
+       Threads::Threads
       )
+   
+   #adds -ltr. Ubuntu eosio.contracts build breaks without this
+   if(UNIX AND NOT APPLE)
+      target_link_libraries(${test_name} ${LIBRT})
+   endif()
 
    target_include_directories( ${test_name} PUBLIC
                                ${Boost_INCLUDE_DIRS}


### PR DESCRIPTION
Backport tester cmake changes from 2.1. This fixes building mandel-contracts.