### PR TITLE
enhancements for clsdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,12 @@ if(APPLE AND UNIX AND "${OPENSSL_ROOT_DIR}" STREQUAL "")
    set(OPENSSL_ROOT_DIR "/usr/local/opt/openssl@1.1")
 endif()
 
+option(ENABLE_OC "Enable eosvm-oc on supported platforms" ON)
+
 # WASM runtimes to enable. Each runtime in this list will have:
 #  * definition EOSIO_<RUNTIME>_RUNTIME_ENABLED defined in public libchain interface
 #  * ctest entries with --runtime
-if(CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
+if(ENABLE_OC AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
    if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
       list(APPEND EOSIO_WASM_RUNTIMES eos-vm-oc)
       # EOS VM OC requires LLVM, but move the check up here to a central location so that the EosioTester.cmakes

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ We support the following CMake options:
 -DCMAKE_BUILD_TYPE=DEBUG                Debug builds
 -DDISABLE_WASM_SPEC_TESTS=yes           Speed up builds and skip many tests
 -DCMAKE_INSTALL_PREFIX=/foo/bar         Where to install to
+-DENABLE_OC=no                          Disable OC support; useful when this repo is used
+                                        as a library
 -GNinja                                 Use ninja instead of make
                                         (faster on high-core-count machines)
 ```

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -1,8 +1,13 @@
 add_subdirectory( fc )
 add_subdirectory( builtins )
+
+# Suppress warnings on 3rdParty Library
+add_definitions( -w )
 add_subdirectory( softfloat )
-add_subdirectory( chainbase )
 add_subdirectory( wasm-jit )
+remove_definitions( -w )
+
+add_subdirectory( chainbase )
 add_subdirectory( appbase )
 add_subdirectory( chain )
 add_subdirectory( testing )

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3362,6 +3362,39 @@ fc::optional<chain_id_type> controller::extract_chain_id_from_db( const path& st
    return {};
 }
 
+void controller::replace_producer_keys( const public_key_type& key ) {
+   ilog("Replace producer keys with ${k}", ("k", key));
+   mutable_db().modify( db().get<global_property_object>(), [&]( auto& gp ) {
+      gp.proposed_schedule_block_num = {};
+      gp.proposed_schedule.version = 0;
+      gp.proposed_schedule.producers.clear();
+   });
+   auto version = my->head->pending_schedule.schedule.version;
+   my->head->pending_schedule = {};
+   my->head->pending_schedule.schedule.version = version;
+   for (auto& prod: my->head->active_schedule.producers ) {
+      ilog("${n}", ("n", prod.producer_name));
+      prod.authority.visit([&](auto &auth) {
+         auth.threshold = 1;
+         auth.keys = {key_weight{key, 1}};
+      });
+   }
+}
+
+void controller::replace_account_keys( name account, name permission, const public_key_type& key ) {
+   auto& rlm = get_mutable_resource_limits_manager();
+   auto* perm = db().find<permission_object, by_owner>(boost::make_tuple(account, permission));
+   if (!perm)
+      return;
+   int64_t old_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
+   mutable_db().modify(*perm, [&](auto& p) {
+      p.auth = authority(key);
+   });
+   int64_t new_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
+   rlm.add_pending_ram_usage(account, new_size - old_size);
+   rlm.verify_account_ram_usage(account);
+}
+
 /// Protocol feature activation handlers:
 
 template<>

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -308,7 +308,7 @@ struct controller_impl {
         cfg.reversible_cache_size, false, cfg.db_map_mode ),
     blog( cfg.blocks_dir ),
     fork_db( cfg.state_dir ),
-    wasmif( cfg.wasm_runtime, cfg.eosvmoc_tierup, db, cfg.state_dir, cfg.eosvmoc_config ),
+    wasmif( cfg.wasm_runtime, cfg.eosvmoc_tierup, db, cfg.state_dir, cfg.eosvmoc_config, !cfg.profile_accounts.empty() ),
     resource_limits( db ),
     authorization( s, db ),
     protocol_features( std::move(pfs) ),
@@ -3102,6 +3102,10 @@ bool controller::is_trusted_producer( const account_name& producer) const {
 
 bool controller::contracts_console()const {
    return my->conf.contracts_console;
+}
+
+bool controller::is_profiling(account_name account) const {
+   return my->conf.profile_accounts.find(account) != my->conf.profile_accounts.end();
 }
 
 chain_id_type controller::get_chain_id()const {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -96,6 +96,8 @@ namespace eosio { namespace chain {
             flat_set<account_name>   resource_greylist;
             flat_set<account_name>   trusted_producers;
             uint32_t                 greylist_limit         = chain::config::maximum_elastic_resource_multiplier;
+
+            flat_set<account_name>   profile_accounts;
          };
 
          enum class block_status {
@@ -283,6 +285,8 @@ namespace eosio { namespace chain {
          bool is_trusted_producer( const account_name& producer) const;
 
          bool contracts_console()const;
+
+         bool is_profiling(account_name name) const;
 
          chain_id_type get_chain_id()const;
 

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -354,6 +354,9 @@ namespace eosio { namespace chain {
 
       static fc::optional<chain_id_type> extract_chain_id_from_db( const path& state_dir );
 
+      void replace_producer_keys( const public_key_type& key );
+      void replace_account_keys( name account, name permission, const public_key_type& key );
+
       private:
          friend class apply_context;
          friend class transaction_context;

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -11,6 +11,7 @@ namespace eosio { namespace chain {
          transaction_checktime_timer() = delete;
          transaction_checktime_timer(const transaction_checktime_timer&) = delete;
          transaction_checktime_timer(transaction_checktime_timer&&) = default;
+         transaction_checktime_timer(platform_timer& timer);
          ~transaction_checktime_timer();
 
          void start(fc::time_point tp);
@@ -25,7 +26,6 @@ namespace eosio { namespace chain {
       private:
          platform_timer& _timer;
 
-         transaction_checktime_timer(platform_timer& timer);
          friend controller_impl;
    };
 

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -3,6 +3,7 @@
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/whitelisted_intrinsics.hpp>
 #include <eosio/chain/exceptions.hpp>
+#include <functional>
 #include "Runtime/Linker.h"
 #include "Runtime/Runtime.h"
 
@@ -62,6 +63,10 @@ namespace eosio { namespace chain {
          //Immediately exits currently running wasm. UB is called when no wasm running
          void exit();
 
+         // If substitute_apply is set, then apply calls it before doing anything else. If substitute_apply returns true,
+         // then apply returns immediately.
+         std::function<bool(
+            const digest_type& code_hash, uint8_t vm_type, uint8_t vm_version, apply_context& context)> substitute_apply;
       private:
          unique_ptr<struct wasm_interface_impl> my;
    };

--- a/libraries/chain/include/eosio/chain/wasm_interface.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface.hpp
@@ -41,7 +41,7 @@ namespace eosio { namespace chain {
              }
          }
 
-         wasm_interface(vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config);
+         wasm_interface(vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile);
          ~wasm_interface();
 
          //call before dtor to skip what can be minutes of dtor overhead with some runtimes; can cause leaks

--- a/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
+++ b/libraries/chain/include/eosio/chain/wasm_interface_private.hpp
@@ -58,13 +58,17 @@ namespace eosio { namespace chain {
       };
 #endif
 
-      wasm_interface_impl(wasm_interface::vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config) : db(d), wasm_runtime_time(vm) {
+      wasm_interface_impl(wasm_interface::vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile) : db(d), wasm_runtime_time(vm) {
 #ifdef EOSIO_EOS_VM_RUNTIME_ENABLED
          if(vm == wasm_interface::vm_type::eos_vm)
             runtime_interface = std::make_unique<webassembly::eos_vm_runtime::eos_vm_runtime<eosio::vm::interpreter>>();
 #endif
 #ifdef EOSIO_EOS_VM_JIT_RUNTIME_ENABLED
-         if(vm == wasm_interface::vm_type::eos_vm_jit)
+         if(vm == wasm_interface::vm_type::eos_vm_jit && profile) {
+            eosio::vm::set_profile_interval_us(200);
+            runtime_interface = std::make_unique<webassembly::eos_vm_runtime::eos_vm_profile_runtime>();
+         }
+         if(vm == wasm_interface::vm_type::eos_vm_jit && !profile)
             runtime_interface = std::make_unique<webassembly::eos_vm_runtime::eos_vm_runtime<eosio::vm::jit>>();
 #endif
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
@@ -86,7 +90,7 @@ namespace eosio { namespace chain {
          if(is_shutting_down)
             for(wasm_cache_index::iterator it = wasm_instantiation_cache.begin(); it != wasm_instantiation_cache.end(); ++it)
                wasm_instantiation_cache.modify(it, [](wasm_cache_entry& e) {
-                  e.module.release();
+                  e.module.release()->fast_shutdown();
                });
       }
 

--- a/libraries/chain/include/eosio/chain/webassembly/common.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/common.hpp
@@ -7,8 +7,6 @@
 #include <eosio/vm/span.hpp>
 #include <eosio/vm/types.hpp>
 
-using namespace fc;
-
 namespace eosio { namespace chain { namespace webassembly {
    // forward declaration
    class interface;
@@ -33,10 +31,9 @@ namespace eosio { namespace chain {
    template <typename T, std::size_t Align = alignof(T)>
    using legacy_span = eosio::vm::argument_proxy<eosio::vm::span<T>, Align>;
 
-   struct null_terminated_ptr {
-      null_terminated_ptr(const char* ptr) : ptr(ptr) {}
-      const char* data() const { return ptr; }
-      const char* ptr;
+   struct null_terminated_ptr : eosio::vm::span<const char> {
+      using base_type = eosio::vm::span<const char>;
+      null_terminated_ptr(const char* ptr) : base_type(ptr, strlen(ptr)) {}
    };
 
    struct memcpy_params {
@@ -58,63 +55,64 @@ namespace eosio { namespace chain {
    };
 
    // define the type converter for eosio
-   struct type_converter : public eosio::vm::type_converter<webassembly::interface, eosio::vm::execution_interface> {
-      using base_type = eosio::vm::type_converter<webassembly::interface, eosio::vm::execution_interface>;
-      using base_type::type_converter;
+   template<typename Interface>
+   struct basic_type_converter : public eosio::vm::type_converter<webassembly::interface, Interface> {
+      using base_type = eosio::vm::type_converter<webassembly::interface, Interface>;
+      using eosio::vm::type_converter<webassembly::interface, Interface>::type_converter;
       using base_type::from_wasm;
       using base_type::to_wasm;
-      using base_type::as_value;
-      using base_type::as_result;
-      using base_type::elem_type;
-      using base_type::get_host;
 
-      EOS_VM_FROM_WASM(memcpy_params, (void* dst, const void* src, vm::wasm_size_t size)) {
-         validate_pointer<char>(dst, size);
-         validate_pointer<char>(src, size);
-         validate_pointer<char>(dst, 1);
-         return { dst, src, size };
+      EOS_VM_FROM_WASM(bool, (uint32_t value)) { return value ? 1 : 0; }
+
+      EOS_VM_FROM_WASM(memcpy_params, (vm::wasm_ptr_t dst, vm::wasm_ptr_t src, vm::wasm_size_t size)) {
+         auto d = this->template validate_pointer<char>(dst, size);
+         auto s = this->template validate_pointer<char>(src, size);
+         this->template validate_pointer<char>(dst, 1);
+         return { d, s, size };
       }
 
-      EOS_VM_FROM_WASM(memcmp_params, (const void* lhs, const void* rhs, vm::wasm_size_t size)) {
-         validate_pointer<char>(lhs, size);
-         validate_pointer<char>(rhs, size);
-         return { lhs, rhs, size };
+      EOS_VM_FROM_WASM(memcmp_params, (vm::wasm_ptr_t lhs, vm::wasm_ptr_t rhs, vm::wasm_size_t size)) {
+         auto l = this->template validate_pointer<char>(lhs, size);
+         auto r = this->template validate_pointer<char>(rhs, size);
+         return { l, r, size };
       }
 
-      EOS_VM_FROM_WASM(memset_params, (void* dst, int32_t val, vm::wasm_size_t size)) {
-         validate_pointer<char>(dst, size);
-         validate_pointer<char>(dst, 1);
-         return { dst, val, size };
+      EOS_VM_FROM_WASM(memset_params, (vm::wasm_ptr_t dst, int32_t val, vm::wasm_size_t size)) {
+         auto d = this->template validate_pointer<char>(dst, size);
+         this->template validate_pointer<char>(dst, 1);
+         return { d, val, size };
       }
 
       template <typename T>
-      auto from_wasm(void* ptr) const
+      auto from_wasm(vm::wasm_ptr_t ptr) const
          -> std::enable_if_t< std::is_pointer_v<T>,
                               vm::argument_proxy<T> > {
-         validate_pointer<std::remove_pointer_t<T>>(ptr, 1);
-         return {ptr};
+         auto p = this->template validate_pointer<std::remove_pointer_t<T>>(ptr, 1);
+         return {p};
       }
 
       template <typename T>
-      auto from_wasm(void* ptr, vm::tag<T> = {}) const
+      auto from_wasm(vm::wasm_ptr_t ptr, vm::tag<T> = {}) const
          -> std::enable_if_t< vm::is_argument_proxy_type_v<T> &&
                               std::is_pointer_v<typename T::proxy_type>, T> {
          if constexpr(T::is_legacy()) {
-            EOS_ASSERT(ptr != this->get_interface().get_memory(), wasm_execution_error, "references cannot be created for null pointers");
+            EOS_ASSERT(ptr != 0, wasm_execution_error, "references cannot be created for null pointers");
          }
-         this->template validate_pointer<typename T::pointee_type>(ptr, 1);
-         return {ptr};
+         auto p = this->template validate_pointer<typename T::pointee_type>(ptr, 1);
+         return {p};
       }
 
-      EOS_VM_FROM_WASM(null_terminated_ptr, (const void* ptr)) {
-         validate_null_terminated_pointer(ptr);
-         return {static_cast<const char*>(ptr)};
+      EOS_VM_FROM_WASM(null_terminated_ptr, (vm::wasm_ptr_t ptr)) {
+         auto p = this->validate_null_terminated_pointer(ptr);
+         return {static_cast<const char*>(p)};
       }
       EOS_VM_FROM_WASM(name, (uint64_t e)) { return name{e}; }
       uint64_t to_wasm(name&& n) { return n.to_uint64_t(); }
       EOS_VM_FROM_WASM(float32_t, (float f)) { return ::to_softfloat32(f); }
       EOS_VM_FROM_WASM(float64_t, (double f)) { return ::to_softfloat64(f); }
    };
+
+   using type_converter = basic_type_converter<eosio::vm::execution_interface>;
 
    using eos_vm_host_functions_t = eosio::vm::registered_host_functions<webassembly::interface,
                                                                         eosio::vm::execution_interface,

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm.hpp
@@ -10,6 +10,7 @@
 
 //eos-vm includes
 #include <eosio/vm/backend.hpp>
+#include <eosio/vm/profile.hpp>
 
 namespace eosio { namespace chain { namespace webassembly { namespace eos_vm_runtime {
 
@@ -18,7 +19,7 @@ struct apply_options;
 }}
 
 template <typename Impl>
-using eos_vm_backend_t = eosio::vm::backend<eos_vm_host_functions_t, Impl, webassembly::eos_vm_runtime::apply_options>;
+using eos_vm_backend_t = eosio::vm::backend<eos_vm_host_functions_t, Impl, webassembly::eos_vm_runtime::apply_options, vm::profile_instr_map>;
 
 template <typename Options>
 using eos_vm_null_backend_t = eosio::vm::backend<eos_vm_host_functions_t, eosio::vm::null_backend, Options>;
@@ -33,6 +34,10 @@ void validate(const bytes& code, const whitelisted_intrinsics_type& intrinsics )
 void validate(const bytes& code, const wasm_config& cfg, const whitelisted_intrinsics_type& intrinsics );
 
 struct apply_options;
+
+struct profile_config {
+   boost::container::flat_set<name> accounts_to_profile;
+};
 
 template<typename Backend>
 class eos_vm_runtime : public eosio::chain::wasm_runtime_interface {
@@ -52,6 +57,16 @@ class eos_vm_runtime : public eosio::chain::wasm_runtime_interface {
 
    template<typename Impl>
    friend class eos_vm_instantiated_module;
+};
+
+class eos_vm_profile_runtime : public eosio::chain::wasm_runtime_interface {
+   public:
+      eos_vm_profile_runtime();
+      bool inject_module(IR::Module&) override;
+      std::unique_ptr<wasm_instantiated_module_interface> instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t>,
+                                                                             const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version) override;
+
+      void immediately_exit_currently_running_module() override;
 };
 
 }}}}// eosio::chain::webassembly::eos_vm_runtime

--- a/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/runtime_interface.hpp
@@ -13,6 +13,7 @@ class apply_context;
 class wasm_instantiated_module_interface {
    public:
       virtual void apply(apply_context& context) = 0;
+      virtual void fast_shutdown() {}
 
       virtual ~wasm_instantiated_module_interface();
 };

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -79,6 +79,8 @@ namespace eosio { namespace chain {
    }
 
    void wasm_interface::apply( const digest_type& code_hash, const uint8_t& vm_type, const uint8_t& vm_version, apply_context& context ) {
+      if(substitute_apply && substitute_apply(code_hash, vm_type, vm_version, context))
+         return;
 #ifdef EOSIO_EOS_VM_OC_RUNTIME_ENABLED
       if(my->eosvmoc) {
          const chain::eosvmoc::code_descriptor* cd = nullptr;

--- a/libraries/chain/wasm_interface.cpp
+++ b/libraries/chain/wasm_interface.cpp
@@ -33,8 +33,8 @@
 
 namespace eosio { namespace chain {
 
-   wasm_interface::wasm_interface(vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config)
-     : my( new wasm_interface_impl(vm, eosvmoc_tierup, d, data_dir, eosvmoc_config) ) {}
+   wasm_interface::wasm_interface(vm_type vm, bool eosvmoc_tierup, const chainbase::database& d, const boost::filesystem::path data_dir, const eosvmoc::config& eosvmoc_config, bool profile)
+     : my( new wasm_interface_impl(vm, eosvmoc_tierup, d, data_dir, eosvmoc_config, profile) ) {}
 
    wasm_interface::~wasm_interface() {}
 

--- a/libraries/chain/webassembly/runtimes/eos-vm.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm.cpp
@@ -162,6 +162,72 @@ class eos_vm_instantiated_module : public wasm_instantiated_module_interface {
       std::unique_ptr<backend_t> _instantiated_module;
 };
 
+class eos_vm_profiling_module : public wasm_instantiated_module_interface {
+      using backend_t = eosio::vm::backend<eos_vm_host_functions_t, eosio::vm::jit_profile, webassembly::eos_vm_runtime::apply_options, vm::profile_instr_map>;
+   public:
+      eos_vm_profiling_module(std::unique_ptr<backend_t> mod, const char * code, std::size_t code_size) :
+         _instantiated_module(std::move(mod)),
+         _original_code(code, code + code_size) {}
+
+
+      void apply(apply_context& context) override {
+         _instantiated_module->set_wasm_allocator(&context.control.get_wasm_allocator());
+         apply_options opts;
+         if(context.control.is_builtin_activated(builtin_protocol_feature_t::configurable_wasm_limits)) {
+            const wasm_config& config = context.control.get_global_properties().wasm_configuration;
+            opts = {config.max_pages, config.max_call_depth};
+         }
+         auto fn = [&]() {
+            eosio::chain::webassembly::interface iface(context);
+            _instantiated_module->initialize(&iface, opts);
+            _instantiated_module->call(
+                iface, "env", "apply",
+                context.get_receiver().to_uint64_t(),
+                context.get_action().account.to_uint64_t(),
+                context.get_action().name.to_uint64_t());
+         };
+         profile_data* prof = start(context);
+         try {
+            scoped_profile profile_runner(prof);
+            checktime_watchdog wd(context.trx_context.transaction_timer);
+            _instantiated_module->timed_run(wd, fn);
+         } catch(eosio::vm::timeout_exception&) {
+            context.trx_context.checktime();
+         } catch(eosio::vm::wasm_memory_exception& e) {
+            FC_THROW_EXCEPTION(wasm_execution_error, "access violation");
+         } catch(eosio::vm::exception& e) {
+            FC_THROW_EXCEPTION(wasm_execution_error, "eos-vm system failure");
+         }
+      }
+
+      void fast_shutdown() override {
+         _prof.clear();
+      }
+
+      profile_data* start(apply_context& context) {
+         name account = context.get_receiver();
+         if(!context.control.is_profiling(account)) return nullptr;
+         if(auto it = _prof.find(account); it != _prof.end()) {
+            return it->second.get();
+         } else {
+            auto code_sequence = context.control.db().get<account_metadata_object, by_name>(account).code_sequence;
+            std::string basename = account.to_string() + "." + std::to_string(code_sequence);
+            auto prof = std::make_unique<profile_data>(basename + ".profile", *_instantiated_module);
+            auto [pos,_] = _prof.insert(std::pair{ account, std::move(prof)});
+            std::ofstream outfile(basename + ".wasm");
+            outfile.write(_original_code.data(), _original_code.size());
+            return pos->second.get();
+         }
+         return nullptr;
+      }
+
+   private:
+
+      std::unique_ptr<backend_t> _instantiated_module;
+      boost::container::flat_map<name, std::unique_ptr<profile_data>> _prof;
+      std::vector<char> _original_code;
+};
+
 template<typename Impl>
 eos_vm_runtime<Impl>::eos_vm_runtime() {}
 
@@ -194,6 +260,32 @@ std::unique_ptr<wasm_instantiated_module_interface> eos_vm_runtime<Impl>::instan
 
 template class eos_vm_runtime<eosio::vm::interpreter>;
 template class eos_vm_runtime<eosio::vm::jit>;
+
+eos_vm_profile_runtime::eos_vm_profile_runtime() {}
+
+void eos_vm_profile_runtime::immediately_exit_currently_running_module() {
+   throw wasm_exit{};
+}
+
+bool eos_vm_profile_runtime::inject_module(IR::Module& module) {
+   return false;
+}
+
+std::unique_ptr<wasm_instantiated_module_interface> eos_vm_profile_runtime::instantiate_module(const char* code_bytes, size_t code_size, std::vector<uint8_t>,
+                                                                                               const digest_type&, const uint8_t&, const uint8_t&) {
+
+   using backend_t = eosio::vm::backend<eos_vm_host_functions_t, eosio::vm::jit_profile, webassembly::eos_vm_runtime::apply_options, vm::profile_instr_map>;
+   try {
+      wasm_code_ptr code((uint8_t*)code_bytes, code_size);
+      apply_options options = { .max_pages = 65536,
+                                .max_call_depth = 0 };
+      std::unique_ptr<backend_t> bkend = std::make_unique<backend_t>(code, code_size, nullptr, options);
+      eos_vm_host_functions_t::resolve(bkend->get_module());
+      return std::make_unique<eos_vm_profiling_module>(std::move(bkend), code_bytes, code_size);
+   } catch(eosio::vm::exception& e) {
+      FC_THROW_EXCEPTION(wasm_execution_error, "Error building eos-vm interp: ${e}", ("e", e.what()));
+   }
+}
 
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -241,6 +241,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
 #endif
          })->default_value(eosio::chain::config::default_wasm_runtime, default_wasm_runtime_str), wasm_runtime_opt.c_str()
          )
+         ("profile-account", boost::program_options::value<vector<string>>()->composing(),
+          "The name of an account whose code will be profiled")
          ("abi-serializer-max-time-ms", bpo::value<uint32_t>()->default_value(config::default_abi_serializer_max_time_us / 1000),
           "Override default maximum ABI serialization time allowed in ms")
          ("chain-state-db-size-mb", bpo::value<uint64_t>()->default_value(config::default_state_size / (1024  * 1024)), "Maximum size (in MiB) of the chain state database")
@@ -725,6 +727,8 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 
       if( options.count( "wasm-runtime" ))
          my->wasm_runtime = options.at( "wasm-runtime" ).as<vm_type>();
+
+      LOAD_VALUE_SET( options, "profile-account", my->chain_config->profile_accounts );
 
       if(options.count("abi-serializer-max-time-ms"))
          my->abi_serializer_max_time_us = fc::microseconds(options.at("abi-serializer-max-time-ms").as<uint32_t>() * 1000);

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -1,0 +1,77 @@
+#include <eosio/chain/controller.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/permission_object.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+
+#include "fork_test_utilities.hpp"
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+
+BOOST_AUTO_TEST_SUITE(chain_tests)
+
+BOOST_AUTO_TEST_CASE( replace_producer_keys ) try {
+   validating_tester tester;
+
+   const auto head_ptr = tester.control->head_block_state();
+   BOOST_REQUIRE(head_ptr);
+
+   const auto new_key = get_public_key(name("newkey"), config::active_name.to_string());
+
+   // make sure new keys is not used
+   for(const auto& prod : head_ptr->active_schedule.producers) {
+      for(const auto& key : prod.authority.get<block_signing_authority_v0>().keys){
+         BOOST_REQUIRE(key.key != new_key);
+      }
+   }
+
+   const auto old_version = head_ptr->pending_schedule.schedule.version;
+   BOOST_REQUIRE_NO_THROW(tester.control->replace_producer_keys(new_key));
+   const auto new_version = head_ptr->pending_schedule.schedule.version;
+   // make sure version not been changed
+   BOOST_REQUIRE(old_version == new_version);
+
+   const auto& gpo = tester.control->db().get<global_property_object>();
+   BOOST_REQUIRE(!gpo.proposed_schedule_block_num);
+   BOOST_REQUIRE(gpo.proposed_schedule.version == 0);
+   BOOST_REQUIRE(gpo.proposed_schedule.producers.empty());
+
+   const uint32_t expected_threshold = 1;
+   const weight_type expected_key_weight = 1;
+   for(const auto& prod : head_ptr->active_schedule.producers) {
+      BOOST_REQUIRE_EQUAL(prod.authority.get<block_signing_authority_v0>().threshold, expected_threshold);
+      for(const auto& key : prod.authority.get<block_signing_authority_v0>().keys){
+         BOOST_REQUIRE_EQUAL(key.key, new_key);
+         BOOST_REQUIRE_EQUAL(key.weight, expected_key_weight);
+       }
+   }
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_CASE( replace_account_keys ) try {
+   validating_tester tester;
+   const name usr = config::system_account_name;
+   const name active_permission = config::active_name;
+   const auto& rlm = tester.control->get_resource_limits_manager();
+   const auto* perm = tester.control->db().find<permission_object, by_owner>(boost::make_tuple(usr, active_permission));
+   BOOST_REQUIRE(perm != NULL);
+
+   const int64_t old_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
+   const auto old_usr_auth = perm->auth;
+   const auto new_key = get_public_key(name("newkey"), "active");
+   const authority expected_authority(new_key);
+   BOOST_REQUIRE(old_usr_auth != expected_authority);
+   const auto old_ram_usg = rlm.get_account_ram_usage(usr);
+
+   BOOST_REQUIRE_NO_THROW(tester.control->replace_account_keys(usr, active_permission, new_key));
+   const int64_t new_size = (int64_t)(chain::config::billable_size_v<permission_object> + perm->auth.get_billable_size());
+   const auto new_ram_usg = rlm.get_account_ram_usage(usr);
+   BOOST_REQUIRE_EQUAL(old_ram_usg + (new_size - old_size), new_ram_usg);
+   const auto new_usr_auth = perm->auth;
+   BOOST_REQUIRE(new_usr_auth == expected_authority);
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
These changes allow clsdk's cltester and debug_plugin to build.

Changes
* Backport 2.1 replace_producer_keys and replace_account_keys
* Port substitute_apply from https://github.com/eoscommunity/eos/pull/1
* Make a transaction_checktime_timer constructor public
* Added ENABLE_OC cmake option (defaults to on)
