### PR TITLE
Implement new consensus algorithm.

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -407,10 +407,10 @@ struct controller_impl {
 
       auto fork_head = (read_mode == db_read_mode::IRREVERSIBLE) ? fork_db.pending_head() : fork_db.head();
 
-      if( fork_head->dpos_irreversible_blocknum <= lib_num )
+      if( fork_head->last_irreversible_block_num() <= lib_num )
          return;
 
-      const auto branch = fork_db.fetch_branch( fork_head->id, fork_head->dpos_irreversible_blocknum );
+      const auto branch = fork_db.fetch_branch( fork_head->id, fork_head->last_irreversible_block_num() );
       try {
          const auto& rbi = reversible_blocks.get_index<reversible_block_index,by_num>();
 
@@ -1655,7 +1655,7 @@ struct controller_impl {
          const auto& gpo = db.get<global_property_object>();
 
          if( gpo.proposed_schedule_block_num.valid() && // if there is a proposed schedule that was proposed in a block ...
-             ( *gpo.proposed_schedule_block_num <= pbhs.dpos_irreversible_blocknum ) && // ... that has now become irreversible ...
+             ( *gpo.proposed_schedule_block_num <= pbhs.last_irreversible_block_num() ) && // ... that has now become irreversible ...
              pbhs.prev_pending_schedule.schedule.producers.size() == 0 // ... and there was room for a new pending schedule prior to any possible promotion
          )
          {
@@ -1663,7 +1663,7 @@ struct controller_impl {
             if( !replay_head_time ) {
                ilog( "promoting proposed schedule (set in block ${proposed_num}) to pending; current block: ${n} lib: ${lib} schedule: ${schedule} ",
                      ("proposed_num", *gpo.proposed_schedule_block_num)("n", pbhs.block_num)
-                     ("lib", pbhs.dpos_irreversible_blocknum)
+                     ("lib", pbhs.last_irreversible_block_num())
                      ("schedule", producer_authority_schedule::from_shared(gpo.proposed_schedule) ) );
             }
 

--- a/libraries/chain/fork_database.cpp
+++ b/libraries/chain/fork_database.cpp
@@ -7,6 +7,7 @@
 #include <boost/multi_index/mem_fun.hpp>
 #include <boost/multi_index/global_fun.hpp>
 #include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/key.hpp>
 #include <fc/io/fstream.hpp>
 #include <fstream>
 
@@ -40,14 +41,12 @@ namespace eosio { namespace chain {
          ordered_unique< tag<by_lib_block_num>,
             composite_key< block_state,
                global_fun<const block_state&,            bool,          &block_state_is_valid>,
-               member<detail::block_header_state_common, uint32_t,      &detail::block_header_state_common::dpos_irreversible_blocknum>,
-               member<detail::block_header_state_common, uint32_t,      &detail::block_header_state_common::block_num>,
+               key<&block_header_state::order>,
                member<block_header_state,                block_id_type, &block_header_state::id>
             >,
             composite_key_compare<
                std::greater<bool>,
-               std::greater<uint32_t>,
-               std::greater<uint32_t>,
+               std::greater<>,
                sha256_less
             >
          >
@@ -55,8 +54,7 @@ namespace eosio { namespace chain {
    > fork_multi_index_type;
 
    bool first_preferred( const block_header_state& lhs, const block_header_state& rhs ) {
-      return std::tie( lhs.dpos_irreversible_blocknum, lhs.block_num )
-               > std::tie( rhs.dpos_irreversible_blocknum, rhs.block_num );
+      return lhs.order() > rhs.order();
    }
 
    struct fork_database_impl {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -380,7 +380,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
             if( chain.get_read_mode() != db_read_mode::IRREVERSIBLE && hbs->id != id && hbs->block != nullptr ) { // not applied to head
                ilog("Block not applied to head ${id}... #${n} @ ${t} signed by ${p} [trxs: ${count}, dpos: ${dpos}, conf: ${confs}, latency: ${latency} ms]",
                     ("p",hbs->block->producer)("id",hbs->id.str().substr(8,16))("n",hbs->block_num)("t",hbs->block->timestamp)
-                    ("count",hbs->block->transactions.size())("dpos", hbs->dpos_irreversible_blocknum)
+                    ("count",hbs->block->transactions.size())("dpos", hbs->last_irreversible_block_num())
                     ("confs", hbs->block->confirmed)("latency", (fc::time_point::now() - hbs->block->timestamp).count()/1000 ) );
             }
          }
@@ -1599,7 +1599,7 @@ producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {
          }
 
          // can not confirm irreversible blocks
-         blocks_to_confirm = (uint16_t)(std::min<uint32_t>(blocks_to_confirm, (uint32_t)(hbs->block_num - hbs->dpos_irreversible_blocknum)));
+         blocks_to_confirm = (uint16_t)(std::min<uint32_t>(blocks_to_confirm, (uint32_t)(hbs->block_num - hbs->last_irreversible_block_num())));
       }
 
       abort_block();

--- a/unittests/bft.cpp
+++ b/unittests/bft.cpp
@@ -1,0 +1,142 @@
+#include <eosio/chain/block_header_state.hpp>
+#include <utility>
+#include <algorithm>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(bft)
+
+void dump_state(const eosio::chain::detail::confirmation_group_v1& g)
+{
+   std::cout << "proposed_irreversible_blocknum: " << g.proposed_irreversible_blocknum << std::endl;
+   std::cout << "irreversible_blocknum: " << g.irreversible_blocknum << std::endl;
+   std::cout << "confirm1:\n";
+   for(auto [prod, range] : g.producer_to_last_confirmed)
+   {
+      std::cout << "  " << prod.to_string() << ": [" << range.first << "," << range.second << ")\n";
+   }
+   std::cout << "confirm2:\n";
+   for(auto [prod, range] : g.producer_to_second_confirmations)
+   {
+      std::cout << "  " << prod.to_string() << ": [" << range.first << "," << range.second << ")\n";
+   }
+}
+
+BOOST_AUTO_TEST_CASE(single_producer)
+{
+   eosio::chain::detail::confirmation_group_v1 g0;
+   g0.set_producers({N(a1)});
+   uint32_t head = 0;
+   for(uint32_t n : { 10, 1, 1, 1, 1, 4, 6, 1 })
+   {
+      g0.confirm1(N(a1), {head, head + n});
+      head += n;
+      BOOST_TEST(g0.proposed_irreversible_blocknum == head - 1);
+      BOOST_TEST(g0.irreversible_blocknum == head - 1);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(single_producer_skip)
+{
+   eosio::chain::detail::confirmation_group_v1 g0;
+   g0.set_producers({N(a1)});
+   uint32_t head = 0;
+   for(uint32_t n : { 10, 1, 1, 2, 2, 4, 6, 1 })
+   {
+      g0.confirm1(N(a1), {head + 1, head + n});
+      head += n;
+      if(n > 1)
+      {
+         BOOST_TEST(g0.proposed_irreversible_blocknum == head - 1);
+         BOOST_TEST(g0.irreversible_blocknum == head - 1);
+      }
+   }
+}
+
+BOOST_AUTO_TEST_CASE(multi_producer_all)
+{
+   eosio::chain::detail::confirmation_group_v1 g0;
+   g0.set_producers({N(p1), N(p2), N(p3), N(p4)});
+   g0.confirm1(N(p1), {0, 5});
+   g0.confirm1(N(p2), {0, 6});
+   g0.confirm1(N(p3), {0, 7});
+   g0.confirm1(N(p4), {0, 8});
+   BOOST_TEST(g0.proposed_irreversible_blocknum == 5);
+   BOOST_TEST(g0.irreversible_blocknum == 0);
+   eosio::chain::name producers[] = { N(p4), N(p1), N(p2), N(p3) };
+   for(int i = 9; i < 20; ++i)
+   {
+      g0.confirm1(producers[i%4], {i - 4, i});
+      BOOST_TEST(g0.proposed_irreversible_blocknum == i - 3);
+      BOOST_TEST(g0.irreversible_blocknum == i - 5);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(multi_producer_min_quorum)
+{
+   eosio::chain::detail::confirmation_group_v1 g0;
+   g0.set_producers({N(p1), N(p2), N(p3), N(p4)});
+   g0.confirm1(N(p1), {0, 5});
+   g0.confirm1(N(p2), {0, 6});
+   g0.confirm1(N(p3), {0, 7});
+   g0.confirm1(N(p1), {5, 8});
+   BOOST_TEST(g0.proposed_irreversible_blocknum == 5);
+   BOOST_TEST(g0.irreversible_blocknum == 0);
+   eosio::chain::name producers[] = { N(p2), N(p3), N(p1) };
+   for(int i = 9; i < 20; ++i)
+   {
+      g0.confirm1(producers[i%3], {i - 3, i});
+      BOOST_TEST(g0.proposed_irreversible_blocknum == i - 3);
+      BOOST_TEST(g0.irreversible_blocknum == i - 5);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(multi_producer_below_min)
+{
+   eosio::chain::detail::confirmation_group_v1 g0;
+   g0.set_producers({N(p1), N(p2), N(p3), N(p4)});
+   g0.confirm1(N(p1), {0, 5});
+   g0.confirm1(N(p2), {0, 6});
+   eosio::chain::name producers[] = { N(p2), N(p1) };
+   for(int i = 7; i < 20; ++i)
+   {
+      g0.confirm1(producers[i%2], {i - 2, i});
+      BOOST_TEST(g0.proposed_irreversible_blocknum == 0);
+      BOOST_TEST(g0.irreversible_blocknum == 0);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(multi_producer_interference)
+{
+   eosio::chain::detail::confirmation_group_v1 g0;
+   std::vector producers = { N(p11), N(p12), N(p13), N(p14), N(p15), N(p21), N(p22) };
+   g0.set_producers(producers);
+
+   auto is_good_producer = [](auto n) { return n != N(p12) && n != N(p14); };
+   auto good_confirm = [](eosio::chain::detail::confirmation_group_v1& g0, eosio::chain::name prod, uint32_t head_blocknum)
+   {
+      auto iter = g0.producer_to_last_confirmed.find(prod);
+      g0.confirm1(prod, {iter->second.second, head_blocknum});
+   };
+
+   std::size_t current_producer_index = 4;
+   uint32_t head_blocknum = 9;
+   for(int i = 0; i < 20; ++i)
+   {
+      auto prod = producers[current_producer_index];
+      if(is_good_producer(prod))
+      {
+         good_confirm(g0, prod, head_blocknum);
+      }
+      else
+      {
+         ++head_blocknum;
+         g0.confirm1(prod, {head_blocknum - 1, head_blocknum});
+      }
+      ++head_blocknum;
+      current_producer_index = (current_producer_index + 1) % 7;
+   }
+   BOOST_TEST(g0.irreversible_blocknum == 18);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/consensus_tests.cpp
+++ b/unittests/consensus_tests.cpp
@@ -1,0 +1,437 @@
+#include <eosio/testing/tester.hpp>
+
+#include <boost/test/unit_test.hpp>
+
+#ifdef NON_VALIDATING_TEST
+#define TESTER tester
+#else
+#define TESTER validating_tester
+#endif
+
+using namespace eosio::testing;
+using namespace eosio::chain;
+using mvo = fc::mutable_variant_object;
+
+BOOST_AUTO_TEST_SUITE(consensus_tests)
+
+BOOST_FIXTURE_TEST_CASE( single_producer, TESTER ) try {
+   for ( int i = 0; i < 5; ++i ) {
+      produce_block();
+      auto state = control->head_block_state();
+      BOOST_TEST( state->last_irreversible_block_num() == state->block_num - 1);
+   }
+} FC_LOG_AND_RETHROW()
+
+struct consensus_tester : TESTER
+{
+   // \post the head block has the given block number
+   // \post the producer schedule is set to producers
+   // \post the pending block is the first block to be created by the new producer schedule
+   // \post LIB is the block before the head block
+   void setup( std::initializer_list<account_name> producers, uint32_t block_num )
+   {
+      create_accounts( producers );
+      while ( control->head_block_num() < block_num - 3 ) {
+         produce_block();
+      }
+      set_producers( producers );
+      produce_and_check( block_num - 2, block_num - 3, N(eosio) );
+      BOOST_TEST( control->active_producers().version == 0 );
+      produce_and_check( block_num - 1, block_num - 2, N(eosio) );
+      BOOST_TEST( control->active_producers().version == 1 );
+      produce_and_check( block_num - 0, block_num - 1, N(eosio) );
+   }
+   void check( uint32_t block_num, uint32_t last_irreversible_block_num, account_name prod = account_name() ) {
+      auto state = control->head_block_state();
+      BOOST_TEST( state->block_num == block_num );
+      BOOST_TEST_CONTEXT( "block_num = " << block_num ) {
+         BOOST_TEST( state->last_irreversible_block_num() == last_irreversible_block_num );
+         if ( prod != account_name() ) {
+            BOOST_TEST( state->header.producer == prod );
+         }
+      }
+   };
+   // Produces a block and verifies its block_num, LIB, and producer.
+   // If the producer is not specified, it must be the same as the previous block
+   void produce_and_check( uint32_t block_num, uint32_t last_irreversible_block_num, account_name prod = account_name() ) {
+      if ( prod == account_name() )
+      {
+         prod = control->head_block_producer();
+      }
+      produce_block();
+      check( block_num, last_irreversible_block_num, prod );
+   };
+   struct block_info {
+      uint32_t block_num;
+      uint32_t lib;
+      account_name producer;
+      int32_t confirmed = -1;
+   };
+   void produce_and_check( std::initializer_list<block_info> expected )
+   {
+      for ( auto [ block_num, irreversible, prod, _ ] : expected )
+      {
+         produce_and_check( block_num, irreversible, prod );
+      }
+   }
+   block_timestamp_type get_next_slot( account_name prod )
+   {
+      auto state = control->head_block_state();
+      block_timestamp_type result = state->header.timestamp;
+      ++result.slot;
+      while( state->get_scheduled_producer( result ).producer_name != prod )
+      {
+         ++result.slot;
+      }
+      return result;
+   }
+   // Skips to the next slot scheduled for a specified producer.
+   // If confirmed is not specified, uses the normal default confirmations.
+   // If prod is not specified, a block will be produced normally, and
+   // the block produced must have the same producer as the previous block.
+   void produce_and_check_with_producer( uint32_t block_num, uint32_t last_irreversible_block_num, account_name prod, int32_t confirmed = -1 ) {
+      if ( confirmed >= 0 )
+      {
+         control->abort_block();
+         control->start_block( get_next_slot( prod ), confirmed );
+      }
+      if ( prod != account_name() )
+      {
+         produce_block( get_next_slot( prod ).to_time_point() - control->head_block_time() );
+      }
+      else
+      {
+         prod = control->head_block_producer();
+         produce_block();
+      }
+      check( block_num, last_irreversible_block_num, prod );
+   };
+   void produce_and_check_with_producer( std::initializer_list<block_info> expected )
+   {
+      for ( auto [ block_num, irreversible, prod, confirmed ] : expected )
+      {
+         produce_and_check_with_producer( block_num, irreversible, prod, confirmed );
+      }
+   }
+};
+
+BOOST_FIXTURE_TEST_CASE( two_producers, consensus_tester ) try {
+   setup( {N(alice),N(bob)}, 15 );
+   produce_and_check({
+      { 16, 14, N(bob) },
+      { 17, 14 },
+      { 18, 14 },
+      { 19, 14 },
+      { 20, 14 },
+      { 21, 14 },
+      { 22, 14 },
+      { 23, 14 },
+      { 24, 14, N(bob) },
+      { 25, 15, N(alice) },
+      { 26, 15 },
+      { 27, 15 },
+      { 28, 15 },
+      { 29, 15 },
+      { 30, 15 },
+      { 31, 15 },
+      { 32, 15 },
+      { 33, 15 },
+      { 34, 15 },
+      { 35, 15 },
+      { 36, 15, N(alice) },
+      { 37, 24, N(bob) },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( two_producers_neither_confirms , consensus_tester ) try {
+   setup( {N(alice),N(bob)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob), 0 },
+      { 17, 15, N(alice), 0 },
+      { 18, 15, N(bob), 0 },
+      { 19, 15, N(alice), 0 },
+      { 20, 15, N(bob), 0 },
+      { 21, 15, N(alice), 0 }
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( two_producers_one_confirms , consensus_tester ) try {
+   setup( {N(alice),N(bob)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob), 0 },
+      { 17, 15, N(alice), 1 },
+      { 18, 15, N(bob), 0 },
+      { 19, 16, N(alice), 1 },
+      { 20, 16, N(bob), 0 },
+      { 21, 18, N(alice), 1 }
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( three_producers , consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol)}, 15 );
+   produce_and_check({
+      { 16, 14, N(bob) },
+      { 17, 14 },
+      { 18, 14 },
+      { 19, 14 },
+      { 20, 14 },
+      { 21, 14 },
+      { 22, 14 },
+      { 23, 14 },
+      { 24, 14, N(bob) },
+      { 25, 14, N(carol) },
+      { 26, 14 },
+      { 27, 14 },
+      { 28, 14 },
+      { 29, 14 },
+      { 30, 14 },
+      { 31, 14 },
+      { 32, 14 },
+      { 33, 14 },
+      { 34, 14 },
+      { 35, 14 },
+      { 36, 14, N(carol) },
+      { 37, 15, N(alice) },
+      { 38, 15 },
+      { 39, 15 },
+      { 40, 15 },
+      { 41, 15 },
+      { 42, 15 },
+      { 43, 15 },
+      { 44, 15 },
+      { 45, 15 },
+      { 46, 15 },
+      { 47, 15 },
+      { 48, 15, N(alice) },
+      { 49, 15, N(bob) },
+      { 50, 15 },
+      { 51, 15 },
+      { 52, 15 },
+      { 53, 15 },
+      { 54, 15 },
+      { 55, 15 },
+      { 56, 15 },
+      { 57, 15 },
+      { 58, 15 },
+      { 59, 15 },
+      { 60, 15, N(bob) },
+      { 61, 24, N(carol) },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( three_producers_two_active , consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob) },
+      { 17, 14, N(alice) },
+      { 18, 14, N(bob) },
+      { 19, 14, N(alice) },
+      { 20, 14, N(bob) },
+      { 21, 14, N(alice) },
+      { 22, 14, N(bob) },
+      { 23, 14, N(alice) },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( three_producers_short_confirm , consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob), 1 },
+      { 17, 14, N(carol), 1 },
+      { 18, 15, N(alice), 1 },
+      { 19, 15, N(bob), 1 },
+      { 20, 15, N(carol), 1 },
+      { 21, 15, N(alice), 1 },
+      { 22, 15, N(bob), 1 },
+      { 23, 15, N(carol), 1 },
+      { 24, 15, N(alice), 1 },
+      { 25, 15, N(bob), 1 },
+      { 26, 15, N(carol), 1 },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( three_producers_one_short_confirm , consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob) },
+      { 17, 14, N(carol), 0 },
+      { 18, 15, N(alice) },
+      { 19, 15, N(bob) },
+      { 20, 15, N(carol), 0 },
+      { 21, 15, N(alice) },
+      { 22, 17, N(bob) },
+      { 23, 17, N(carol), 0 },
+      { 24, 17, N(alice) },
+      { 25, 20, N(bob) },
+      { 26, 20, N(carol), 0 },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( confirmation_tracking_over_limit, consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob) },
+      { 17, 14, N(carol), 1 },
+   });
+   uint32_t forgotten_at = config::maximum_tracked_dpos_confirmations + 16;
+   for(uint32_t i = 18; i < forgotten_at; ++i)
+   {
+      produce_and_check_with_producer( i, 14 , N(carol) );
+   }
+   produce_and_check_with_producer({
+      { forgotten_at, 15, N(alice), config::maximum_tracked_dpos_confirmations + 1 },
+      { forgotten_at + 1, 15, N(bob), 0 },
+      { forgotten_at + 2, 15, N(carol), 0 },
+      { forgotten_at + 3, 15, N(alice), 0 },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( confirmation_tracking_at_limit, consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob) },
+      { 17, 14, N(carol), 1 },
+   });
+   uint32_t forgotten_at = config::maximum_tracked_dpos_confirmations + 15;
+   for(uint32_t i = 18; i < forgotten_at; ++i)
+   {
+      produce_and_check_with_producer( i, 14 , N(carol) );
+   }
+   produce_and_check_with_producer({
+      { forgotten_at, 15, N(alice), config::maximum_tracked_dpos_confirmations },
+      { forgotten_at + 1, 15, N(bob), 0 },
+      { forgotten_at + 2, 15, N(carol), 0 },
+      { forgotten_at + 3, 16, N(alice), 0 },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( four_producers, consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol),N(dave)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob) },
+      { 17, 14, N(carol) },
+      { 18, 15, N(dave) },
+      { 19, 15, N(alice) },
+      { 20, 15, N(bob) },
+      { 21, 16, N(carol) },
+      { 22, 17, N(dave) },
+      { 23, 18, N(alice) },
+      { 24, 19, N(bob) },
+      { 25, 20, N(carol) },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( stop_confirming, consensus_tester ) try {
+   setup( {N(alice),N(bob),N(carol),N(dave)}, 15 );
+   produce_and_check_with_producer({
+      { 16, 14, N(bob) },
+      { 17, 14, N(carol) },
+      { 18, 15, N(dave) },
+      { 19, 15, N(alice), 0 },
+      { 20, 15, N(bob), 0 },
+      { 21, 16, N(carol), 0 },
+      { 22, 16, N(dave), 0 },
+      { 23, 16, N(alice), 0 },
+      { 24, 16, N(bob), 0 },
+      { 25, 16, N(carol), 0 },
+      { 26, 16, N(dave), 0 },
+      { 27, 16, N(alice), 0 },
+      { 28, 16, N(bob), 0 },
+   });
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE( confirmations_across_new_producer_schedule, consensus_tester ) try {
+   create_accounts( {N(carol),N(dave),N(emily),N(frank)} );
+   setup( {N(alice),N(bob)}, 15 );
+   produce_and_check({
+      { 16, 14, N(bob) },
+      { 17, 14 },
+      { 18, 14 },
+      { 19, 14 },
+      { 20, 14 },
+      { 21, 14 },
+      { 22, 14 },
+      { 23, 14 },
+      { 24, 14 },
+      { 25, 15, N(alice) },
+      { 26, 15 },
+      { 27, 15 },
+   });
+   set_producers( {N(carol),N(dave),N(emily),N(frank)} );
+   produce_and_check({
+      { 28, 15 },
+      { 29, 15 },
+      { 30, 15 },
+      { 31, 15 },
+      { 32, 15 },
+      { 33, 15 },
+      { 34, 15 },
+      { 35, 15 },
+      { 36, 15 },
+      { 37, 24, N(bob) },
+      { 38, 24 },
+      { 39, 24 },
+      { 40, 24 },
+      { 41, 24 },
+      { 42, 24 },
+      { 43, 24 },
+      { 44, 24 },
+      { 45, 24 },
+      { 46, 24 },
+      { 47, 24 },
+      { 48, 24 },
+      { 49, 36, N(alice) }, // schedule 2 becomes pending here
+      { 50, 36 },
+      { 51, 36 },
+      { 52, 36 },
+      { 53, 36 },
+      { 54, 36 },
+      { 55, 36 },
+      { 56, 36 },
+      { 57, 36 },
+      { 58, 36 },
+      { 59, 36 },
+      { 60, 36 },
+      { 61, 48, N(bob) },
+      { 62, 48 },
+      { 63, 48 },
+      { 64, 48 },
+      { 65, 48 },
+      { 66, 48 },
+      { 67, 48 },
+      { 68, 48 },
+      { 69, 48 },
+      { 70, 48 },
+      { 71, 48 },
+      { 72, 48 },
+      { 73, 60, N(alice) },
+      { 74, 60, N(emily) },
+      { 75, 60 },
+      { 76, 60 },
+      { 77, 60 },
+      { 78, 60 },
+      { 79, 60 },
+      { 80, 60 },
+      { 81, 60 },
+      { 82, 60 },
+      { 83, 60 },
+      { 84, 60 },
+      { 85, 60, N(frank) },
+      { 86, 60 },
+      { 87, 60 },
+      { 88, 60 },
+      { 89, 60 },
+      { 90, 60 },
+      { 91, 60 },
+      { 92, 60 },
+      { 93, 60 },
+      { 94, 60 },
+      { 95, 60 },
+      { 96, 60 },
+      { 97, 73, N(carol) },
+      { 98, 73 },
+   });
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/database_tests.cpp
+++ b/unittests/database_tests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
 
          // Check the last irreversible block number is set correctly, with one producer, irreversibility should only just 1 block before
          const auto expected_last_irreversible_block_number = test.control->head_block_num() - 1;
-         BOOST_TEST(test.control->head_block_state()->dpos_irreversible_blocknum == expected_last_irreversible_block_number);
+         BOOST_TEST(test.control->head_block_state()->last_irreversible_block_num() == expected_last_irreversible_block_number);
          // Ensure that future block doesn't exist
          const auto nonexisting_future_block_num = test.control->head_block_num() + 1;
          BOOST_TEST(test.control->fetch_block_by_number(nonexisting_future_block_num) == nullptr);
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_SUITE(database_tests)
 
          const auto next_expected_last_irreversible_block_number = test.control->head_block_num() - 1;
          // Check the last irreversible block number is updated correctly
-         BOOST_TEST(test.control->head_block_state()->dpos_irreversible_blocknum == next_expected_last_irreversible_block_number);
+         BOOST_TEST(test.control->head_block_state()->last_irreversible_block_num() == next_expected_last_irreversible_block_number);
          // Previous nonexisting future block should exist by now
          BOOST_CHECK_NO_THROW(test.control->fetch_block_by_number(nonexisting_future_block_num));
          // Check the latest head block match

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -118,9 +118,9 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
    }
 
    // make sure we can still produce a blocks until irreversibility moves
-   auto lib = bios.control->head_block_state()->dpos_irreversible_blocknum;
+   auto lib = bios.control->head_block_state()->last_irreversible_block_num();
    size_t tries = 0;
-   while (bios.control->head_block_state()->dpos_irreversible_blocknum == lib && ++tries < 10000) {
+   while (bios.control->head_block_state()->last_irreversible_block_num() == lib && ++tries < 10000) {
       bios.produce_block();
    }
 


### PR DESCRIPTION
- The new algorithm is similar to the existing algorithm, but fixes the bug that allows two forks simultaneously to become irreversible.
- The new algorithm is compatible with out-of-band confirmations, which allows faster irreversibility (not yet implemented).
- The use of the new algorithm is controlled by a variant in block_header_state, but there is not yet a protocol feature to enable it.
- Add tests verifying the behavior of the current consensus algorithm in several corner cases.
- Snapshots and SHiP are broken due to changes in binary format