### PR TITLE
Replace N macro with operator ""_n

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -73,7 +73,7 @@ void apply_context::exec_one()
 
          if( ( receiver_account->code_hash != digest_type() ) &&
                (  !( act->account == config::system_account_name
-                     && act->name == N( setcode )
+                     && act->name == "setcode"_n
                      && receiver == config::system_account_name )
                   || control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
                )

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2422,7 +2422,7 @@ struct controller_impl {
    {
       action on_block_act;
       on_block_act.account = config::system_account_name;
-      on_block_act.name = N(onblock);
+      on_block_act.name = "onblock"_n;
       on_block_act.authorization = vector<permission_level>{{config::system_account_name, config::active_name}};
       on_block_act.data = fc::raw::pack(self.head_block_header());
 

--- a/libraries/chain/include/eosio/chain/config.hpp
+++ b/libraries/chain/include/eosio/chain/config.hpp
@@ -20,21 +20,21 @@ const static auto default_state_size            = 1*1024*1024*1024ll;
 const static auto default_state_guard_size      =    128*1024*1024ll;
 
 
-const static name system_account_name    { N(eosio) };
-const static name null_account_name      { N(eosio.null) };
-const static name producers_account_name { N(eosio.prods) };
+const static name system_account_name    { "eosio"_n };
+const static name null_account_name      { "eosio.null"_n };
+const static name producers_account_name { "eosio.prods"_n };
 
 // Active permission of producers account requires greater than 2/3 of the producers to authorize
-const static name majority_producers_permission_name { N(prod.major) }; // greater than 1/2 of producers needed to authorize
-const static name minority_producers_permission_name { N(prod.minor) }; // greater than 1/3 of producers needed to authorize0
+const static name majority_producers_permission_name { "prod.major"_n }; // greater than 1/2 of producers needed to authorize
+const static name minority_producers_permission_name { "prod.minor"_n }; // greater than 1/3 of producers needed to authorize0
 
-const static name eosio_auth_scope       { N(eosio.auth) };
-const static name eosio_all_scope        { N(eosio.all) };
+const static name eosio_auth_scope       { "eosio.auth"_n };
+const static name eosio_all_scope        { "eosio.all"_n };
 
-const static name active_name     { N(active) };
-const static name owner_name      { N(owner) };
-const static name eosio_any_name  { N(eosio.any) };
-const static name eosio_code_name { N(eosio.code) };
+const static name active_name     { "active"_n };
+const static name owner_name      { "owner"_n };
+const static name eosio_any_name  { "eosio.any"_n };
+const static name eosio_code_name { "eosio.code"_n };
 
 const static int      block_interval_ms = 500;
 const static int      block_interval_us = block_interval_ms*1000;

--- a/libraries/chain/include/eosio/chain/contract_types.hpp
+++ b/libraries/chain/include/eosio/chain/contract_types.hpp
@@ -18,7 +18,7 @@ struct newaccount {
    }
 
    static action_name get_name() {
-      return N(newaccount);
+      return "newaccount"_n;
    }
 };
 
@@ -33,7 +33,7 @@ struct setcode {
    }
 
    static action_name get_name() {
-      return N(setcode);
+      return "setcode"_n;
    }
 };
 
@@ -46,7 +46,7 @@ struct setabi {
    }
 
    static action_name get_name() {
-      return N(setabi);
+      return "setabi"_n;
    }
 };
 
@@ -62,7 +62,7 @@ struct updateauth {
    }
 
    static action_name get_name() {
-      return N(updateauth);
+      return "updateauth"_n;
    }
 };
 
@@ -80,7 +80,7 @@ struct deleteauth {
    }
 
    static action_name get_name() {
-      return N(deleteauth);
+      return "deleteauth"_n;
    }
 };
 
@@ -100,7 +100,7 @@ struct linkauth {
    }
 
    static action_name get_name() {
-      return N(linkauth);
+      return "linkauth"_n;
    }
 };
 
@@ -119,7 +119,7 @@ struct unlinkauth {
    }
 
    static action_name get_name() {
-      return N(unlinkauth);
+      return "unlinkauth"_n;
    }
 };
 
@@ -132,7 +132,7 @@ struct canceldelay {
    }
 
    static action_name get_name() {
-      return N(canceldelay);
+      return "canceldelay"_n;
    }
 };
 
@@ -148,7 +148,7 @@ struct onerror {
    }
 
    static action_name get_name() {
-      return N(onerror);
+      return "onerror"_n;
    }
 };
 

--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -1,8 +1,6 @@
 #pragma once
 #include <string>
 #include <fc/reflect/reflect.hpp>
-#include <fc/exception/exception.hpp>
-#include <eosio/chain/exceptions.hpp>
 #include <iosfwd>
 
 namespace eosio::chain {
@@ -15,41 +13,29 @@ namespace fc {
 } // fc
 
 namespace eosio::chain {
-   constexpr uint64_t char_to_symbol( char c ) {
+   inline constexpr uint64_t char_to_symbol( char c ) {
       if( c >= 'a' && c <= 'z' )
          return (c - 'a') + 6;
       if( c >= '1' && c <= '5' )
          return (c - '1') + 1;
-      else if( c == '.')
-         return 0;
-      else
-         FC_THROW_EXCEPTION(name_type_exception, "Name contains invalid character: (${c}) ", ("c", std::string(1, c)));
-
-      //unreachable
       return 0;
    }
 
-   // true if std::string can be converted to name
-   bool is_string_valid_name(std::string_view str);
-
-   constexpr uint64_t string_to_uint64_t( std::string_view str ) {
-      EOS_ASSERT(str.size() <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", std::string(str)));
-
+   inline constexpr uint64_t string_to_uint64_t( std::string_view str ) {
       uint64_t n = 0;
-      int i = (int) str.size();
-      if (i >= 13) {
-         // Only the first 12 characters can be full-range ([.1-5a-z]).
-         i = 12;
+      int i = 0;
+      for ( ; i < str.size() && i < 12; ++i) {
+         // NOTE: char_to_symbol() returns char type, and without this explicit
+         // expansion to uint64 type, the compilation fails at the point of usage
+         // of string_to_name(), where the usage requires constant (compile time) expression.
+         n |= (char_to_symbol(str[i]) & 0x1f) << (64 - 5 * (i + 1));
+      }
 
-         // The 13th character must be in the range [.1-5a-j] because it needs to be encoded
-         // using only four bits (64_bits - 5_bits_per_char * 12_chars).
-         n = char_to_symbol(str[12]);
-         EOS_ASSERT(n <= 0x0Full, name_type_exception, "invalid 13th character: (${c})", ("c", std::string(1, str[12])));
-      }
-      // Encode full-range characters.
-      while (--i >= 0) {
-         n |= char_to_symbol(str[i]) << (64 - 5 * (i + 1));
-      }
+      // The for-loop encoded up to 60 high bits into uint64 'name' variable,
+      // if (strlen(str) > 12) then encode str[12] into the low (remaining)
+      // 4 bits of 'name'
+      if (i < str.size() && i == 12)
+         n |= char_to_symbol(str[12]) & 0x0F;
       return n;
    }
 
@@ -95,7 +81,7 @@ namespace eosio::chain {
    // to its 5-bit slot starting with the highest slot for the first char.
    // The 13th char, if str is long enough, is encoded into 4-bit chunk
    // and placed in the lowest 4 bits. 64 = 12 * 5 + 4
-   constexpr name string_to_name( std::string_view str )
+   inline constexpr name string_to_name( std::string_view str )
    {
       return name( string_to_uint64_t( str ) );
    }

--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <string>
 #include <fc/reflect/reflect.hpp>
+#include <fc/exception/exception.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include <iosfwd>
 
 namespace eosio::chain {
@@ -13,29 +15,41 @@ namespace fc {
 } // fc
 
 namespace eosio::chain {
-   inline constexpr uint64_t char_to_symbol( char c ) {
+   constexpr uint64_t char_to_symbol( char c ) {
       if( c >= 'a' && c <= 'z' )
          return (c - 'a') + 6;
       if( c >= '1' && c <= '5' )
          return (c - '1') + 1;
+      else if( c == '.')
+         return 0;
+      else
+         FC_THROW_EXCEPTION(name_type_exception, "Name contains invalid character: (${c}) ", ("c", std::string(1, c)));
+
+      //unreachable
       return 0;
    }
 
-   inline constexpr uint64_t string_to_uint64_t( std::string_view str ) {
-      uint64_t n = 0;
-      int i = 0;
-      for ( ; i < str.size() && i < 12; ++i) {
-         // NOTE: char_to_symbol() returns char type, and without this explicit
-         // expansion to uint64 type, the compilation fails at the point of usage
-         // of string_to_name(), where the usage requires constant (compile time) expression.
-         n |= (char_to_symbol(str[i]) & 0x1f) << (64 - 5 * (i + 1));
-      }
+   // true if std::string can be converted to name
+   bool is_string_valid_name(std::string_view str);
 
-      // The for-loop encoded up to 60 high bits into uint64 'name' variable,
-      // if (strlen(str) > 12) then encode str[12] into the low (remaining)
-      // 4 bits of 'name'
-      if (i < str.size() && i == 12)
-         n |= char_to_symbol(str[12]) & 0x0F;
+   constexpr uint64_t string_to_uint64_t( std::string_view str ) {
+      EOS_ASSERT(str.size() <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", std::string(str)));
+
+      uint64_t n = 0;
+      int i = (int) str.size();
+      if (i >= 13) {
+         // Only the first 12 characters can be full-range ([.1-5a-z]).
+         i = 12;
+
+         // The 13th character must be in the range [.1-5a-j] because it needs to be encoded
+         // using only four bits (64_bits - 5_bits_per_char * 12_chars).
+         n = char_to_symbol(str[12]);
+         EOS_ASSERT(n <= 0x0Full, name_type_exception, "invalid 13th character: (${c})", ("c", std::string(1, str[12])));
+      }
+      // Encode full-range characters.
+      while (--i >= 0) {
+         n |= char_to_symbol(str[i]) << (64 - 5 * (i + 1));
+      }
       return n;
    }
 
@@ -81,7 +95,7 @@ namespace eosio::chain {
    // to its 5-bit slot starting with the highest slot for the first char.
    // The 13th char, if str is long enough, is encoded into 4-bit chunk
    // and placed in the lowest 4 bits. 64 = 12 * 5 + 4
-   inline constexpr name string_to_name( std::string_view str )
+   constexpr name string_to_name( std::string_view str )
    {
       return name( string_to_uint64_t( str ) );
    }
@@ -100,8 +114,6 @@ namespace eosio::chain {
 # pragma clang diagnostic pop
 #endif
    } // namespace literals
-
-#define N(X) eosio::chain::string_to_name(#X)
 
 } // eosio::chain
 

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -72,7 +72,7 @@ namespace eosio { namespace chain {
       if (tt.action_traces.empty())
          return false;
       const auto& act = tt.action_traces[0].act;
-      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+      if (act.account != eosio::chain::config::system_account_name || act.name != "onblock"_n ||
           act.authorization.size() != 1)
          return false;
       const auto& auth = act.authorization[0];

--- a/libraries/chain/name.cpp
+++ b/libraries/chain/name.cpp
@@ -1,18 +1,11 @@
 #include <eosio/chain/name.hpp>
 #include <fc/variant.hpp>
 #include <boost/algorithm/string.hpp>
-#include <fc/exception/exception.hpp>
-#include <eosio/chain/exceptions.hpp>
 
 namespace eosio::chain {
 
    void name::set( std::string_view str ) {
-      const auto len = str.size();
-      EOS_ASSERT(len <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", std::string(str)));
       value = string_to_uint64_t(str);
-      EOS_ASSERT(to_string() == str, name_type_exception,
-                 "Name not properly normalized (name: ${name}, normalized: ${normalized}) ",
-                 ("name", std::string(str))("normalized", to_string()));
    }
 
    // keep in sync with name::to_string() in contract definition for name
@@ -30,6 +23,32 @@ namespace eosio::chain {
 
       boost::algorithm::trim_right_if( str, []( char c ){ return c == '.'; } );
       return str;
+   }
+
+   bool is_string_valid_name(std::string_view str)
+   {
+      size_t slen = str.size();
+      if( slen > 13)
+         return false;
+
+      size_t len = (slen <= 12) ? slen : 12;
+      for( size_t i = 0; i < len; ++i ) {
+         char c = str[i];
+         if ((c >= 'a' && c <= 'z') || (c >= '1' && c <= '5') || (c == '.'))
+            continue;
+         else
+            return false;
+      }
+
+      if( slen == 13) {
+         char c = str[12];
+         if ((c >= 'a' && c <= 'j') || (c >= '1' && c <= '5') || (c == '.'))
+            return true;
+         else
+            return false;
+      }
+
+      return true;
    }
 
 } // eosio::chain

--- a/libraries/chain/name.cpp
+++ b/libraries/chain/name.cpp
@@ -1,11 +1,18 @@
 #include <eosio/chain/name.hpp>
 #include <fc/variant.hpp>
 #include <boost/algorithm/string.hpp>
+#include <fc/exception/exception.hpp>
+#include <eosio/chain/exceptions.hpp>
 
 namespace eosio::chain {
 
    void name::set( std::string_view str ) {
+      const auto len = str.size();
+      EOS_ASSERT(len <= 13, name_type_exception, "Name is longer than 13 characters (${name}) ", ("name", std::string(str)));
       value = string_to_uint64_t(str);
+      EOS_ASSERT(to_string() == str, name_type_exception,
+                 "Name not properly normalized (name: ${name}, normalized: ${normalized}) ",
+                 ("name", std::string(str))("normalized", to_string()));
    }
 
    // keep in sync with name::to_string() in contract definition for name
@@ -23,32 +30,6 @@ namespace eosio::chain {
 
       boost::algorithm::trim_right_if( str, []( char c ){ return c == '.'; } );
       return str;
-   }
-
-   bool is_string_valid_name(std::string_view str)
-   {
-      size_t slen = str.size();
-      if( slen > 13)
-         return false;
-
-      size_t len = (slen <= 12) ? slen : 12;
-      for( size_t i = 0; i < len; ++i ) {
-         char c = str[i];
-         if ((c >= 'a' && c <= 'z') || (c >= '1' && c <= '5') || (c == '.'))
-            continue;
-         else
-            return false;
-      }
-
-      if( slen == 13) {
-         char c = str[12];
-         if ((c >= 'a' && c <= 'j') || (c >= '1' && c <= '5') || (c == '.'))
-            return true;
-         else
-            return false;
-      }
-
-      return true;
    }
 
 } // eosio::chain

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -28,8 +28,14 @@ namespace eosio {
  *    payload
  */
 
-inline uint64_t       ship_magic(uint32_t version) { return N(ship).to_uint64_t() | version; }
-inline bool           is_ship(uint64_t magic) { return (magic & 0xffff'ffff'0000'0000) == N(ship).to_uint64_t(); }
+inline uint64_t       ship_magic(uint32_t version) {
+   using namespace eosio::chain::literals;
+   return "ship"_n.to_uint64_t() | version;
+}
+inline bool           is_ship(uint64_t magic) {
+   using namespace eosio::chain::literals;
+   return (magic & 0xffff'ffff'0000'0000) == "ship"_n.to_uint64_t();
+}
 inline uint32_t       get_ship_version(uint64_t magic) { return magic; }
 inline bool           is_ship_supported_version(uint64_t magic) { return get_ship_version(magic) == 0; }
 static const uint32_t ship_current_version = 0;

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -966,7 +966,7 @@ namespace eosio { namespace testing {
                                        const symbol&       asset_symbol,
                                        const account_name& account ) const {
       const auto& db  = control->db();
-      const auto* tbl = db.template find<table_id_object, by_code_scope_table>(boost::make_tuple(code, account, N(accounts)));
+      const auto* tbl = db.template find<table_id_object, by_code_scope_table>(boost::make_tuple(code, account, "accounts"_n));
       share_type result = 0;
 
       // the balance is implied to be 0 if either the table or row does not exist
@@ -1098,7 +1098,7 @@ namespace eosio { namespace testing {
          schedule_variant.emplace_back(e.get_abi_variant());
       }
 
-      return push_action( config::system_account_name, N(setprods), config::system_account_name,
+      return push_action( config::system_account_name, "setprods"_n, config::system_account_name,
                           fc::mutable_variant_object()("schedule", schedule_variant));
 
    }
@@ -1115,7 +1115,7 @@ namespace eosio { namespace testing {
          });
       }
 
-      return push_action( config::system_account_name, N(setprods), config::system_account_name,
+      return push_action( config::system_account_name, "setprods"_n, config::system_account_name,
                           fc::mutable_variant_object()("schedule", legacy_keys));
 
    }
@@ -1136,7 +1136,7 @@ namespace eosio { namespace testing {
 
    void base_tester::preactivate_protocol_features(const vector<digest_type> feature_digests) {
       for( const auto& feature_digest: feature_digests ) {
-         push_action( config::system_account_name, N(activate), config::system_account_name,
+         push_action( config::system_account_name, "activate"_n, config::system_account_name,
                       fc::mutable_variant_object()("feature_digest", feature_digest) );
       }
    }

--- a/plugins/chain_plugin/account_query_db.cpp
+++ b/plugins/chain_plugin/account_query_db.cpp
@@ -16,6 +16,7 @@
 #include <shared_mutex>
 
 using namespace eosio;
+using namespace eosio::chain::literals;
 using namespace boost::multi_index;
 using namespace boost::bimaps;
 
@@ -68,7 +69,7 @@ namespace {
       if (p->action_traces.empty())
          return false;
       const auto& act = p->action_traces[0].act;
-      if (act.account != eosio::chain::config::system_account_name || act.name != N(onblock) ||
+      if (act.account != eosio::chain::config::system_account_name || act.name != "onblock"_n ||
           act.authorization.size() != 1)
          return false;
       const auto& auth = act.authorization[0];
@@ -327,9 +328,9 @@ namespace eosio::chain_apis {
                   auto itr = deleted.emplace(chain::permission_level{data.account, data.permission}).first;
                   updated.erase(*itr);
                } else if (at.act.name == chain::newaccount::get_name()) {
-                   auto data = at.act.data_as<chain::newaccount>();
-                   updated.emplace(chain::permission_level{data.name, N(owner)});
-                   updated.emplace(chain::permission_level{data.name, N(active)});
+                  auto data = at.act.data_as<chain::newaccount>();
+                  updated.emplace(chain::permission_level{data.name, "owner"_n});
+                  updated.emplace(chain::permission_level{data.name, "active"_n});
                }
             }
          };

--- a/plugins/chain_plugin/test/test_account_query_db.cpp
+++ b/plugins/chain_plugin/test/test_account_query_db.cpp
@@ -50,7 +50,7 @@ BOOST_FIXTURE_TEST_CASE(newaccount_test, TESTER) { try {
 
    produce_blocks(10);
 
-   account_name tester_account = N(tester);
+   account_name tester_account = "tester"_n;
    const auto trace_ptr =  create_account(tester_account);
    aq_db.cache_transaction_trace(trace_ptr);
    produce_block();
@@ -75,14 +75,14 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, TESTER) { try {
 
     produce_blocks(10);
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
    const string role = "first";
    produce_block();
    create_account(tester_account);
 
    const auto trace_ptr = push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
          ("account", tester_account)
-         ("permission", N(role))
+         ("permission", "role"_n)
          ("parent", "active")
          ("auth",  authority(get_public_key(tester_account, role), 5))
    );
@@ -93,7 +93,7 @@ BOOST_FIXTURE_TEST_CASE(updateauth_test, TESTER) { try {
    pars.keys.emplace_back(get_public_key(tester_account, role));
    const auto results = aq_db.get_accounts_by_authorizers(pars);
 
-   BOOST_TEST_REQUIRE(find_account_auth(results, tester_account, N(role)) == true);
+   BOOST_TEST_REQUIRE(find_account_auth(results, tester_account, "role"_n) == true);
 
 } FC_LOG_AND_RETHROW() }
 
@@ -115,13 +115,13 @@ BOOST_AUTO_TEST_CASE(future_fork_test) { try {
    }
 
    // produce a block on node A with a new account and permission
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
    const string role = "first";
    node_a.create_account(tester_account);
 
    const auto trace_ptr = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
          ("account", tester_account)
-         ("permission", N(role))
+         ("permission", "role"_n)
          ("parent", "active")
          ("auth",  authority(node_a.get_public_key(tester_account, role), 5))
    );
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(future_fork_test) { try {
    pars.keys.emplace_back(node_a.get_public_key(tester_account, role));
 
    const auto pre_results = aq_db.get_accounts_by_authorizers(pars);
-   BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, N(role)) == true);
+   BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, "role"_n) == true);
 
    // have node B take over from head-1 and produce "future" blocks to overtake
    node_a.push_block(node_b.produce_block(fc::milliseconds(config::block_interval_ms * 100)));
@@ -162,22 +162,22 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       }
 
       // produce a block on node A with a new account and permission
-      const auto& tester_account = N(tester);
-      const auto& tester_account2 = N(tester2);
+      const auto& tester_account = "tester"_n;
+      const auto& tester_account2 = "tester2"_n;
       const string role = "first";
       node_a.create_account(tester_account);
       node_a.create_account(tester_account2);
 
       const auto trace_ptr = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
             ("account", tester_account)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_a.get_public_key(tester_account, role), 5)), 1
       );
       aq_db.cache_transaction_trace(trace_ptr);
       const auto trace_ptr2 = node_a.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
             ("account", tester_account2)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_a.get_public_key(tester_account2, role), 5)), 2
       );
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
       pars.keys.emplace_back(node_a.get_public_key(tester_account, role));
 
       const auto pre_results = aq_db.get_accounts_by_authorizers(pars);
-      BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, N(role)) == true);
+      BOOST_TEST_REQUIRE(find_account_auth(pre_results, tester_account, "role"_n) == true);
 
       // have node B take over from head-1 and also update permissions
       node_b.create_account(tester_account);
@@ -196,14 +196,14 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
 
       const auto trace_ptr3 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
             ("account", tester_account)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account, role), 6)), 1
       );
       aq_db.cache_transaction_trace(trace_ptr3);
       const auto trace_ptr4 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
             ("account", tester_account2)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account2, role), 6)), 2
       );
@@ -214,14 +214,14 @@ BOOST_AUTO_TEST_CASE(fork_test) { try {
 
       const auto trace_ptr5 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
             ("account", tester_account)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account, role), 5)), 3
       );
       aq_db.cache_transaction_trace(trace_ptr5);
       const auto trace_ptr6 = node_b.push_action(config::system_account_name, updateauth::get_name(), tester_account2, fc::mutable_variant_object()
             ("account", tester_account2)
-            ("permission", N(role))
+            ("permission", "role"_n)
             ("parent", "active")
             ("auth",  authority(node_b.get_public_key(tester_account2, role), 5)), 4
       );

--- a/plugins/history_plugin/history_plugin.cpp
+++ b/plugins/history_plugin/history_plugin.cpp
@@ -226,15 +226,15 @@ namespace eosio {
          void on_system_action( const action_trace& at ) {
             auto& chain = chain_plug->chain();
             chainbase::database& db = const_cast<chainbase::database&>( chain.db() ); // Override read-only access to state DB (highly unrecommended practice!)
-            if( at.act.name == N(newaccount) )
+            if( at.act.name == "newaccount"_n )
             {
                const auto create = at.act.data_as<chain::newaccount>();
-               add(db, create.owner.keys, create.name, N(owner));
-               add(db, create.owner.accounts, create.name, N(owner));
-               add(db, create.active.keys, create.name, N(active));
-               add(db, create.active.accounts, create.name, N(active));
+               add(db, create.owner.keys, create.name, "owner"_n);
+               add(db, create.owner.accounts, create.name, "owner"_n);
+               add(db, create.active.keys, create.name, "active"_n);
+               add(db, create.active.accounts, create.name, "active"_n);
             }
-            else if( at.act.name == N(updateauth) )
+            else if( at.act.name == "updateauth"_n )
             {
                const auto update = at.act.data_as<chain::updateauth>();
                remove<public_key_history_multi_index, by_account_permission>(db, update.account, update.permission);
@@ -242,7 +242,7 @@ namespace eosio {
                add(db, update.auth.keys, update.account, update.permission);
                add(db, update.auth.accounts, update.account, update.permission);
             }
-            else if( at.act.name == N(deleteauth) )
+            else if( at.act.name == "deleteauth"_n )
             {
                const auto del = at.act.data_as<chain::deleteauth>();
                remove<public_key_history_multi_index, by_account_permission>(db, del.account, del.permission);

--- a/plugins/producer_plugin/test/test_subjective_billing.cpp
+++ b/plugins/producer_plugin/test/test_subjective_billing.cpp
@@ -22,9 +22,9 @@ BOOST_AUTO_TEST_CASE( subjective_bill_test ) {
    transaction_id_type id4 = sha256::hash( "4" );
    transaction_id_type id5 = sha256::hash( "5" );
    transaction_id_type id6 = sha256::hash( "6" );
-   account_name a = N("a");
-   account_name b = N("b");
-   account_name c = N("c");
+   account_name a = "a"_n;
+   account_name b = "b"_n;
+   account_name c = "c"_n;
 
    const auto now = time_point::now();
    const auto halftime = now + fc::milliseconds(subjective_billing::expired_accumulator_average_window * subjective_billing::subjective_time_interval_ms / 2);

--- a/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
+++ b/plugins/txn_test_gen_plugin/txn_test_gen_plugin.cpp
@@ -206,7 +206,7 @@ struct txn_test_gen_plugin_impl {
             {
                action act;
                act.account = newaccountT;
-               act.name = N(create);
+               act.name = "create"_n;
                act.authorization = vector<permission_level>{{newaccountT,config::active_name}};
                act.data = eosio_token_serializer.variant_to_binary("create",
                                                                    fc::json::from_string(fc::format_string("{\"issuer\":\"${issuer}\",\"maximum_supply\":\"1000000000.0000 CUR\"}}",
@@ -217,7 +217,7 @@ struct txn_test_gen_plugin_impl {
             {
                action act;
                act.account = newaccountT;
-               act.name = N(issue);
+               act.name = "issue"_n;
                act.authorization = vector<permission_level>{{newaccountT,config::active_name}};
                act.data = eosio_token_serializer.variant_to_binary("issue",
                                                                    fc::json::from_string(fc::format_string("{\"to\":\"${to}\",\"quantity\":\"60000.0000 CUR\",\"memo\":\"\"}",
@@ -228,7 +228,7 @@ struct txn_test_gen_plugin_impl {
             {
                action act;
                act.account = newaccountT;
-               act.name = N(transfer);
+               act.name = "transfer"_n;
                act.authorization = vector<permission_level>{{newaccountT,config::active_name}};
                act.data = eosio_token_serializer.variant_to_binary("transfer",
                                                                    fc::json::from_string(fc::format_string("{\"from\":\"${from}\",\"to\":\"${to}\",\"quantity\":\"20000.0000 CUR\",\"memo\":\"\"}",
@@ -239,7 +239,7 @@ struct txn_test_gen_plugin_impl {
             {
                action act;
                act.account = newaccountT;
-               act.name = N(transfer);
+               act.name = "transfer"_n;
                act.authorization = vector<permission_level>{{newaccountT,config::active_name}};
                act.data = eosio_token_serializer.variant_to_binary("transfer",
                                                                    fc::json::from_string(fc::format_string("{\"from\":\"${from}\",\"to\":\"${to}\",\"quantity\":\"20000.0000 CUR\",\"memo\":\"\"}",
@@ -281,7 +281,7 @@ struct txn_test_gen_plugin_impl {
       abi_serializer eosio_token_serializer{fc::json::from_string(contracts::eosio_token_abi().data()).as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time )};
       //create the actions here
       act_a_to_b.account = newaccountT;
-      act_a_to_b.name = N(transfer);
+      act_a_to_b.name = "transfer"_n;
       act_a_to_b.authorization = vector<permission_level>{{newaccountA,config::active_name}};
       act_a_to_b.data = eosio_token_serializer.variant_to_binary("transfer",
                                                                   fc::json::from_string(fc::format_string("{\"from\":\"${from}\",\"to\":\"${to}\",\"quantity\":\"1.0000 CUR\",\"memo\":\"${l}\"}",
@@ -289,7 +289,7 @@ struct txn_test_gen_plugin_impl {
                                                                   abi_serializer::create_yield_function( abi_serializer_max_time ));
 
       act_b_to_a.account = newaccountT;
-      act_b_to_a.name = N(transfer);
+      act_b_to_a.name = "transfer"_n;
       act_b_to_a.authorization = vector<permission_level>{{newaccountB,config::active_name}};
       act_b_to_a.data = eosio_token_serializer.variant_to_binary("transfer",
                                                                   fc::json::from_string(fc::format_string("{\"from\":\"${from}\",\"to\":\"${to}\",\"quantity\":\"1.0000 CUR\",\"memo\":\"${l}\"}",

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -613,7 +613,7 @@ chain::action create_buyram(const name& creator, const name& newaccount, const a
          ("receiver", newaccount.to_string())
          ("quant", quantity.to_string());
    return create_action(get_account_permissions(tx_permission, {creator,config::active_name}),
-                        config::system_account_name, N(buyram), act_payload);
+                        config::system_account_name, "buyram"_n, act_payload);
 }
 
 chain::action create_buyrambytes(const name& creator, const name& newaccount, uint32_t numbytes) {
@@ -622,7 +622,7 @@ chain::action create_buyrambytes(const name& creator, const name& newaccount, ui
          ("receiver", newaccount.to_string())
          ("bytes", numbytes);
    return create_action(get_account_permissions(tx_permission, {creator,config::active_name}),
-                        config::system_account_name, N(buyrambytes), act_payload);
+                        config::system_account_name, "buyrambytes"_n, act_payload);
 }
 
 chain::action create_delegate(const name& from, const name& receiver, const asset& net, const asset& cpu, bool transfer) {
@@ -633,7 +633,7 @@ chain::action create_delegate(const name& from, const name& receiver, const asse
          ("stake_cpu_quantity", cpu.to_string())
          ("transfer", transfer);
    return create_action(get_account_permissions(tx_permission, {from,config::active_name}),
-                        config::system_account_name, N(delegatebw), act_payload);
+                        config::system_account_name, "delegatebw"_n, act_payload);
 }
 
 fc::variant regproducer_variant(const account_name& producer, const public_key_type& key, const string& url, uint16_t location) {
@@ -652,7 +652,7 @@ chain::action create_open(const string& contract, const name& owner, symbol sym,
       ("ram_payer", ram_payer);
     return action {
       get_account_permissions(tx_permission, {ram_payer, config::active_name}),
-      name(contract), N(open), variant_to_bin( name(contract), N(open), open_ )
+      name(contract), "open"_n, variant_to_bin( name(contract), "open"_n, open_ )
    };
 }
 
@@ -666,7 +666,7 @@ chain::action create_transfer(const string& contract, const name& sender, const 
 
    return action {
       get_account_permissions(tx_permission, {sender,config::active_name}),
-      name(contract), N(transfer), variant_to_bin( name(contract), N(transfer), transfer )
+      name(contract), "transfer"_n, variant_to_bin( name(contract), "transfer"_n, transfer )
    };
 }
 
@@ -764,7 +764,7 @@ asset to_asset( account_name code, const string& s ) {
 }
 
 inline asset to_asset( const string& s ) {
-   return to_asset( N(eosio.token), s );
+   return to_asset( "eosio.token"_n, s );
 }
 
 struct set_account_permission_subcommand {
@@ -1043,7 +1043,7 @@ struct register_producer_subcommand {
 
          auto regprod_var = regproducer_variant(name(producer_str), producer_key, url, loc );
          auto accountPermissions = get_account_permissions(tx_permission, {name(producer_str), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(regproducer), regprod_var)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "regproducer"_n, regprod_var)});
       });
    }
 };
@@ -1148,7 +1148,7 @@ struct unregister_producer_subcommand {
                   ("producer", producer_str);
 
          auto accountPermissions = get_account_permissions(tx_permission, {name(producer_str), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(unregprod), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "unregprod"_n, act_payload)});
       });
    }
 };
@@ -1169,7 +1169,7 @@ struct vote_producer_proxy_subcommand {
                   ("proxy", proxy_str)
                   ("producers", std::vector<account_name>{});
          auto accountPermissions = get_account_permissions(tx_permission, {name(voter_str), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(voteproducer), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "voteproducer"_n, act_payload)});
       });
    }
 };
@@ -1193,7 +1193,7 @@ struct vote_producers_subcommand {
                   ("proxy", "")
                   ("producers", producer_names);
          auto accountPermissions = get_account_permissions(tx_permission, {name(voter_str), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(voteproducer), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "voteproducer"_n, act_payload)});
       });
    }
 };
@@ -1246,7 +1246,7 @@ struct approve_producer_subcommand {
                ("proxy", "")
                ("producers", prods);
             auto accountPermissions = get_account_permissions(tx_permission, {name(voter), config::active_name});
-            send_actions({create_action(accountPermissions, config::system_account_name, N(voteproducer), act_payload)});
+            send_actions({create_action(accountPermissions, config::system_account_name, "voteproducer"_n, act_payload)});
       });
    }
 };
@@ -1298,7 +1298,7 @@ struct unapprove_producer_subcommand {
                ("proxy", "")
                ("producers", prods);
             auto accountPermissions = get_account_permissions(tx_permission, {name(voter), config::active_name});
-            send_actions({create_action(accountPermissions, config::system_account_name, N(voteproducer), act_payload)});
+            send_actions({create_action(accountPermissions, config::system_account_name, "voteproducer"_n, act_payload)});
       });
    }
 };
@@ -1471,7 +1471,7 @@ struct delegate_bandwidth_subcommand {
                   ("stake_cpu_quantity", to_asset(stake_cpu_amount))
                   ("transfer", transfer);
          auto accountPermissions = get_account_permissions(tx_permission, {name(from_str), config::active_name});
-         std::vector<chain::action> acts{create_action(accountPermissions, config::system_account_name, N(delegatebw), act_payload)};
+         std::vector<chain::action> acts{create_action(accountPermissions, config::system_account_name, "delegatebw"_n, act_payload)};
          EOSC_ASSERT( !(buy_ram_amount.size()) || !buy_ram_bytes, "ERROR: --buyram and --buy-ram-bytes cannot be set at the same time" );
          if (buy_ram_amount.size()) {
             acts.push_back( create_buyram(name(from_str), name(receiver_str), to_asset(buy_ram_amount)) );
@@ -1505,7 +1505,7 @@ struct undelegate_bandwidth_subcommand {
                   ("unstake_net_quantity", to_asset(unstake_net_amount))
                   ("unstake_cpu_quantity", to_asset(unstake_cpu_amount));
          auto accountPermissions = get_account_permissions(tx_permission, {name(from_str), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(undelegatebw), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "undelegatebw"_n, act_payload)});
       });
    }
 };
@@ -1526,7 +1526,7 @@ struct bidname_subcommand {
                   ("newname", newname_str)
                   ("bid", to_asset(bid_amount));
          auto accountPermissions = get_account_permissions(tx_permission, {name(bidder_str), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(bidname), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "bidname"_n, act_payload)});
       });
    }
 };
@@ -1651,7 +1651,7 @@ struct sellram_subcommand {
                ("account", receiver_str)
                ("bytes", amount);
             auto accountPermissions = get_account_permissions(tx_permission, {name(receiver_str), config::active_name});
-            send_actions({create_action(accountPermissions, config::system_account_name, N(sellram), act_payload)});
+            send_actions({create_action(accountPermissions, config::system_account_name, "sellram"_n, act_payload)});
          });
    }
 };
@@ -1668,7 +1668,7 @@ struct claimrewards_subcommand {
          fc::variant act_payload = fc::mutable_variant_object()
                   ("owner", owner);
          auto accountPermissions = get_account_permissions(tx_permission, {name(owner), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(claimrewards), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "claimrewards"_n, act_payload)});
       });
    }
 };
@@ -1686,7 +1686,7 @@ struct regproxy_subcommand {
                   ("proxy", proxy)
                   ("isproxy", true);
          auto accountPermissions = get_account_permissions(tx_permission, {name(proxy), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(regproxy), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "regproxy"_n, act_payload)});
       });
    }
 };
@@ -1704,7 +1704,7 @@ struct unregproxy_subcommand {
                   ("proxy", proxy)
                   ("isproxy", false);
          auto accountPermissions = get_account_permissions(tx_permission, {name(proxy), config::active_name});
-         send_actions({create_action(accountPermissions, config::system_account_name, N(regproxy), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "regproxy"_n, act_payload)});
       });
    }
 };
@@ -1727,7 +1727,7 @@ struct canceldelay_subcommand {
                   ("canceling_auth", canceling_auth)
                   ("trx_id", trx_id);
          auto accountPermissions = get_account_permissions(tx_permission, canceling_auth);
-         send_actions({create_action(accountPermissions, config::system_account_name, N(canceldelay), act_payload)});
+         send_actions({create_action(accountPermissions, config::system_account_name, "canceldelay"_n, act_payload)});
       });
    }
 };
@@ -1735,7 +1735,7 @@ struct canceldelay_subcommand {
 struct deposit_subcommand {
    string owner_str;
    string amount_str;
-   const name act_name{ N(deposit) };
+   const name act_name{ "deposit"_n };
 
    deposit_subcommand(CLI::App* actionRoot) {
       auto deposit = actionRoot->add_subcommand("deposit", localized("Deposit into owner's REX fund by transfering from owner's liquid token balance"));
@@ -1755,7 +1755,7 @@ struct deposit_subcommand {
 struct withdraw_subcommand {
    string owner_str;
    string amount_str;
-   const name act_name{ N(withdraw) };
+   const name act_name{ "withdraw"_n };
 
    withdraw_subcommand(CLI::App* actionRoot) {
       auto withdraw = actionRoot->add_subcommand("withdraw", localized("Withdraw from owner's REX fund by transfering to owner's liquid token balance"));
@@ -1775,7 +1775,7 @@ struct withdraw_subcommand {
 struct buyrex_subcommand {
    string from_str;
    string amount_str;
-   const name act_name{ N(buyrex) };
+   const name act_name{ "buyrex"_n };
 
    buyrex_subcommand(CLI::App* actionRoot) {
       auto buyrex = actionRoot->add_subcommand("buyrex", localized("Buy REX using tokens in owner's REX fund"));
@@ -1795,8 +1795,8 @@ struct buyrex_subcommand {
 struct lendrex_subcommand {
    string from_str;
    string amount_str;
-   const name act_name1{ N(deposit) };
-   const name act_name2{ N(buyrex) };
+   const name act_name1{ "deposit"_n };
+   const name act_name2{ "buyrex"_n };
 
    lendrex_subcommand(CLI::App* actionRoot) {
       auto lendrex = actionRoot->add_subcommand("lendrex", localized("Deposit tokens to REX fund and use the tokens to buy REX"));
@@ -1822,7 +1822,7 @@ struct unstaketorex_subcommand {
    string receiver_str;
    string from_net_str;
    string from_cpu_str;
-   const name act_name{ N(unstaketorex) };
+   const name act_name{ "unstaketorex"_n };
 
    unstaketorex_subcommand(CLI::App* actionRoot) {
       auto unstaketorex = actionRoot->add_subcommand("unstaketorex", localized("Buy REX using staked tokens"));
@@ -1846,7 +1846,7 @@ struct unstaketorex_subcommand {
 struct sellrex_subcommand {
    string from_str;
    string rex_str;
-   const name act_name{ N(sellrex) };
+   const name act_name{ "sellrex"_n };
 
    sellrex_subcommand(CLI::App* actionRoot) {
       auto sellrex = actionRoot->add_subcommand("sellrex", localized("Sell REX tokens"));
@@ -1865,7 +1865,7 @@ struct sellrex_subcommand {
 
 struct cancelrexorder_subcommand {
    string owner_str;
-   const name act_name{ N(cnclrexorder) };
+   const name act_name{ "cnclrexorder"_n };
 
    cancelrexorder_subcommand(CLI::App* actionRoot) {
       auto cancelrexorder = actionRoot->add_subcommand("cancelrexorder", localized("Cancel queued REX sell order if one exists"));
@@ -1884,7 +1884,7 @@ struct rentcpu_subcommand {
    string receiver_str;
    string loan_payment_str;
    string loan_fund_str;
-   const name act_name{ N(rentcpu) };
+   const name act_name{ "rentcpu"_n };
 
    rentcpu_subcommand(CLI::App* actionRoot) {
       auto rentcpu = actionRoot->add_subcommand("rentcpu", localized("Rent CPU bandwidth for 30 days"));
@@ -1910,7 +1910,7 @@ struct rentnet_subcommand {
    string receiver_str;
    string loan_payment_str;
    string loan_fund_str;
-   const name act_name{ N(rentnet) };
+   const name act_name{ "rentnet"_n };
 
    rentnet_subcommand(CLI::App* actionRoot) {
       auto rentnet = actionRoot->add_subcommand("rentnet", localized("Rent Network bandwidth for 30 days"));
@@ -1935,7 +1935,7 @@ struct fundcpuloan_subcommand {
    string from_str;
    string loan_num_str;
    string payment_str;
-   const name act_name{ N(fundcpuloan) };
+   const name act_name{ "fundcpuloan"_n };
 
    fundcpuloan_subcommand(CLI::App* actionRoot) {
       auto fundcpuloan = actionRoot->add_subcommand("fundcpuloan", localized("Deposit into a CPU loan fund"));
@@ -1958,7 +1958,7 @@ struct fundnetloan_subcommand {
    string from_str;
    string loan_num_str;
    string payment_str;
-   const name act_name{ N(fundnetloan) };
+   const name act_name{ "fundnetloan"_n };
 
    fundnetloan_subcommand(CLI::App* actionRoot) {
       auto fundnetloan = actionRoot->add_subcommand("fundnetloan", localized("Deposit into a Network loan fund"));
@@ -1981,7 +1981,7 @@ struct defcpuloan_subcommand {
    string from_str;
    string loan_num_str;
    string amount_str;
-   const name act_name{ N(defcpuloan) };
+   const name act_name{ "defcpuloan"_n };
 
    defcpuloan_subcommand(CLI::App* actionRoot) {
       auto defcpuloan = actionRoot->add_subcommand("defundcpuloan", localized("Withdraw from a CPU loan fund"));
@@ -2004,7 +2004,7 @@ struct defnetloan_subcommand {
    string from_str;
    string loan_num_str;
    string amount_str;
-   const name act_name{ N(defnetloan) };
+   const name act_name{ "defnetloan"_n };
 
    defnetloan_subcommand(CLI::App* actionRoot) {
       auto defnetloan = actionRoot->add_subcommand("defundnetloan", localized("Withdraw from a Network loan fund"));
@@ -2026,7 +2026,7 @@ struct defnetloan_subcommand {
 struct mvtosavings_subcommand {
    string owner_str;
    string rex_str;
-   const name act_name{ N(mvtosavings) };
+   const name act_name{ "mvtosavings"_n };
 
    mvtosavings_subcommand(CLI::App* actionRoot) {
       auto mvtosavings = actionRoot->add_subcommand("mvtosavings", localized("Move REX tokens to savings bucket"));
@@ -2046,7 +2046,7 @@ struct mvtosavings_subcommand {
 struct mvfrsavings_subcommand {
    string owner_str;
    string rex_str;
-   const name act_name{ N(mvfrsavings) };
+   const name act_name{ "mvfrsavings"_n };
 
    mvfrsavings_subcommand(CLI::App* actionRoot) {
       auto mvfrsavings = actionRoot->add_subcommand("mvfromsavings", localized("Move REX tokens out of savings bucket"));
@@ -2065,7 +2065,7 @@ struct mvfrsavings_subcommand {
 
 struct updaterex_subcommand {
    string owner_str;
-   const name act_name{ N(updaterex) };
+   const name act_name{ "updaterex"_n };
 
    updaterex_subcommand(CLI::App* actionRoot) {
       auto updaterex = actionRoot->add_subcommand("updaterex", localized("Update REX owner vote stake and vote weight"));
@@ -2081,7 +2081,7 @@ struct updaterex_subcommand {
 
 struct consolidate_subcommand {
    string owner_str;
-   const name act_name{ N(consolidate) };
+   const name act_name{ "consolidate"_n };
 
    consolidate_subcommand(CLI::App* actionRoot) {
       auto consolidate = actionRoot->add_subcommand("consolidate", localized("Consolidate REX maturity buckets into one that matures in 4 days"));
@@ -2098,7 +2098,7 @@ struct consolidate_subcommand {
 struct rexexec_subcommand {
    string user_str;
    string max_str;
-   const name act_name{ N(rexexec) };
+   const name act_name{ "rexexec"_n };
 
    rexexec_subcommand(CLI::App* actionRoot) {
       auto rexexec = actionRoot->add_subcommand("rexexec", localized("Perform REX maintenance by processing expired loans and unfilled sell orders"));
@@ -2117,7 +2117,7 @@ struct rexexec_subcommand {
 
 struct closerex_subcommand {
    string owner_str;
-   const name act_name{ N(closerex) };
+   const name act_name{ "closerex"_n };
 
    closerex_subcommand(CLI::App* actionRoot) {
       auto closerex = actionRoot->add_subcommand("closerex", localized("Delete unused REX-related user table entries"));
@@ -3547,7 +3547,7 @@ int main( int argc, char** argv ) {
          ("requested", requested_perm_var)
          ("trx", trx_var);
 
-      send_actions({chain::action{accountPermissions, N(eosio.msig), N(propose), variant_to_bin( N(eosio.msig), N(propose), args ) }});
+      send_actions({chain::action{accountPermissions, "eosio.msig"_n, "propose"_n, variant_to_bin( "eosio.msig"_n, "propose"_n, args ) }});
    });
 
    //multisig propose transaction
@@ -3580,7 +3580,7 @@ int main( int argc, char** argv ) {
          ("requested", requested_perm_var)
          ("trx", trx_var);
 
-      send_actions({chain::action{accountPermissions, N(eosio.msig), N(propose), variant_to_bin( N(eosio.msig), N(propose), args ) }});
+      send_actions({chain::action{accountPermissions, "eosio.msig"_n, "propose"_n, variant_to_bin( "eosio.msig"_n, "propose"_n, args ) }});
    });
 
 
@@ -3797,7 +3797,7 @@ int main( int argc, char** argv ) {
       }
 
       auto accountPermissions = get_account_permissions(tx_permission, {name(proposer), config::active_name});
-      send_actions({chain::action{accountPermissions, N(eosio.msig), name(action), variant_to_bin( N(eosio.msig), name(action), args ) }});
+      send_actions({chain::action{accountPermissions, "eosio.msig"_n, name(action), variant_to_bin( "eosio.msig"_n, name(action), args ) }});
    };
 
    // multisig approve
@@ -3827,7 +3827,7 @@ int main( int argc, char** argv ) {
          ("account", invalidator);
 
       auto accountPermissions = get_account_permissions(tx_permission, {name(invalidator), config::active_name});
-      send_actions({chain::action{accountPermissions, N(eosio.msig), N(invalidate), variant_to_bin( N(eosio.msig), N(invalidate), args ) }});
+      send_actions({chain::action{accountPermissions, "eosio.msig"_n, "invalidate"_n, variant_to_bin( "eosio.msig"_n, "invalidate"_n, args ) }});
    });
 
    // multisig cancel
@@ -3854,7 +3854,7 @@ int main( int argc, char** argv ) {
          ("proposal_name", proposal_name)
          ("canceler", canceler);
 
-      send_actions({chain::action{accountPermissions, N(eosio.msig), N(cancel), variant_to_bin( N(eosio.msig), N(cancel), args ) }});
+      send_actions({chain::action{accountPermissions, "eosio.msig"_n, "cancel"_n, variant_to_bin( "eosio.msig"_n, "cancel"_n, args ) }});
       }
    );
 
@@ -3883,7 +3883,7 @@ int main( int argc, char** argv ) {
          ("proposal_name", proposal_name)
          ("executer", executer);
 
-      send_actions({chain::action{accountPermissions, N(eosio.msig), N(exec), variant_to_bin( N(eosio.msig), N(exec), args ) }});
+      send_actions({chain::action{accountPermissions, "eosio.msig"_n, "exec"_n, variant_to_bin( "eosio.msig"_n, "exec"_n, args ) }});
       }
    );
 
@@ -3913,7 +3913,7 @@ int main( int argc, char** argv ) {
          ("executer", executer )
          ("trx", trx_var);
 
-      send_actions({chain::action{accountPermissions, name(wrap_con), N(exec), variant_to_bin( name(wrap_con), N(exec), args ) }});
+      send_actions({chain::action{accountPermissions, name(wrap_con), "exec"_n, variant_to_bin( name(wrap_con), "exec"_n, args ) }});
    });
 
    // system subcommand

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -37,12 +37,12 @@ BOOST_AUTO_TEST_SUITE(chain_plugin_tests)
 BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(asserter)} );
+   create_accounts( {"asserter"_n} );
    produce_block();
 
    // setup contract and abi
-   set_code( N(asserter), contracts::asserter_wasm() );
-   set_abi( N(asserter), contracts::asserter_abi().data() );
+   set_code( "asserter"_n, contracts::asserter_wasm() );
+   set_abi( "asserter"_n, contracts::asserter_abi().data() );
    produce_blocks(1);
 
    auto resolver = [&,this]( const account_name& name ) -> optional<abi_serializer> {
@@ -57,7 +57,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    };
 
    // abi should be resolved
-   BOOST_REQUIRE_EQUAL(true, resolver(N(asserter)).valid());
+   BOOST_REQUIRE_EQUAL(true, resolver("asserter"_n).valid());
 
    // make an action using the valid contract & abi
    variant pretty_trx = mutable_variant_object()
@@ -79,7 +79,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    signed_transaction trx;
    abi_serializer::from_variant(pretty_trx, trx, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
    set_transaction_headers(trx);
-   trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
+   trx.sign( get_private_key( "asserter"_n, "active" ), control->get_chain_id() );
    push_transaction( trx );
    produce_blocks(1);
 
@@ -103,11 +103,11 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    auto pos = abi2.find("int8");
    BOOST_TEST(pos != std::string::npos);
    abi2.replace(pos, 4, "xxxx");
-   set_abi(N(asserter), abi2.c_str());
+   set_abi("asserter"_n, abi2.c_str());
    produce_blocks(1);
 
    // resolving the invalid abi result in exception
-   BOOST_CHECK_THROW(resolver(N(asserter)), invalid_type_inside_abi);
+   BOOST_CHECK_THROW(resolver("asserter"_n), invalid_type_inside_abi);
 
    // get the same block as string, results in decode failed(invalid abi) but not exception
    std::string block_str2 = json::to_pretty_string(plugin.get_block(param));

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -36,11 +36,11 @@ BOOST_AUTO_TEST_SUITE(get_table_tests)
 
 transaction_trace_ptr
 issue_tokens( TESTER& t, account_name issuer, account_name to, const asset& amount,
-              std::string memo = "", account_name token_contract = N(eosio.token) )
+              std::string memo = "", account_name token_contract = "eosio.token"_n )
 {
    signed_transaction trx;
 
-   trx.actions.emplace_back( t.get_action( token_contract, N(issue),
+   trx.actions.emplace_back( t.get_action( token_contract, "issue"_n,
                                            vector<permission_level>{{issuer, config::active_name}},
                                            mutable_variant_object()
                                              ("to", issuer.to_string())
@@ -48,7 +48,7 @@ issue_tokens( TESTER& t, account_name issuer, account_name to, const asset& amou
                                              ("memo", memo)
    ) );
 
-   trx.actions.emplace_back( t.get_action( token_contract, N(transfer),
+   trx.actions.emplace_back( t.get_action( token_contract, "transfer"_n,
                                            vector<permission_level>{{issuer, config::active_name}},
                                            mutable_variant_object()
                                              ("from", issuer.to_string())
@@ -65,22 +65,22 @@ issue_tokens( TESTER& t, account_name issuer, account_name to, const asset& amou
 BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-      N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+   create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
+      "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n });
 
-   std::vector<account_name> accs{N(inita), N(initb), N(initc), N(initd)};
+   std::vector<account_name> accs{"inita"_n, "initb"_n, "initc"_n, "initd"_n};
    create_accounts(accs);
    produce_block();
 
-   set_code( N(eosio.token), contracts::eosio_token_wasm() );
-   set_abi( N(eosio.token), contracts::eosio_token_abi().data() );
+   set_code( "eosio.token"_n, contracts::eosio_token_wasm() );
+   set_abi( "eosio.token"_n, contracts::eosio_token_abi().data() );
    produce_blocks(1);
 
    // create currency
    auto act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action("eosio.token"_n, "create"_n, "eosio.token"_n, act );
 
    // issue
    for (account_name a: accs) {
@@ -90,21 +90,21 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
 
    // iterate over scope
    eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
-   eosio::chain_apis::read_only::get_table_by_scope_params param{N(eosio.token), N(accounts), "inita", "", 10};
+   eosio::chain_apis::read_only::get_table_by_scope_params param{"eosio.token"_n, "accounts"_n, "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param);
 
    BOOST_REQUIRE_EQUAL(4u, result.rows.size());
    BOOST_REQUIRE_EQUAL("", result.more);
    if (result.rows.size() >= 4) {
-      BOOST_REQUIRE_EQUAL(name(N(eosio.token)), result.rows[0].code);
-      BOOST_REQUIRE_EQUAL(name(N(inita)), result.rows[0].scope);
-      BOOST_REQUIRE_EQUAL(name(N(accounts)), result.rows[0].table);
-      BOOST_REQUIRE_EQUAL(name(N(eosio)), result.rows[0].payer);
+      BOOST_REQUIRE_EQUAL(name("eosio.token"_n), result.rows[0].code);
+      BOOST_REQUIRE_EQUAL(name("inita"_n), result.rows[0].scope);
+      BOOST_REQUIRE_EQUAL(name("accounts"_n), result.rows[0].table);
+      BOOST_REQUIRE_EQUAL(name("eosio"_n), result.rows[0].payer);
       BOOST_REQUIRE_EQUAL(1u, result.rows[0].count);
 
-      BOOST_REQUIRE_EQUAL(name(N(initb)), result.rows[1].scope);
-      BOOST_REQUIRE_EQUAL(name(N(initc)), result.rows[2].scope);
-      BOOST_REQUIRE_EQUAL(name(N(initd)), result.rows[3].scope);
+      BOOST_REQUIRE_EQUAL(name("initb"_n), result.rows[1].scope);
+      BOOST_REQUIRE_EQUAL(name("initc"_n), result.rows[2].scope);
+      BOOST_REQUIRE_EQUAL(name("initd"_n), result.rows[3].scope);
    }
 
    param.lower_bound = "initb";
@@ -113,8 +113,8 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL(2u, result.rows.size());
    BOOST_REQUIRE_EQUAL("", result.more);
    if (result.rows.size() >= 2) {
-      BOOST_REQUIRE_EQUAL(name(N(initb)), result.rows[0].scope);
-      BOOST_REQUIRE_EQUAL(name(N(initc)), result.rows[1].scope);
+      BOOST_REQUIRE_EQUAL(name("initb"_n), result.rows[0].scope);
+      BOOST_REQUIRE_EQUAL(name("initc"_n), result.rows[1].scope);
    }
 
    param.limit = 1;
@@ -127,7 +127,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    BOOST_REQUIRE_EQUAL(1u, result.rows.size());
    BOOST_REQUIRE_EQUAL("initc", result.more);
 
-   param.table = N(invalid);
+   param.table = "invalid"_n;
    result = plugin.read_only::get_table_by_scope(param);
    BOOST_REQUIRE_EQUAL(0u, result.rows.size());
    BOOST_REQUIRE_EQUAL("", result.more);
@@ -137,22 +137,22 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-      N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+   create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
+      "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n });
 
-   std::vector<account_name> accs{N(inita), N(initb)};
+   std::vector<account_name> accs{"inita"_n, "initb"_n};
    create_accounts(accs);
    produce_block();
 
-   set_code( N(eosio.token), contracts::eosio_token_wasm() );
-   set_abi( N(eosio.token), contracts::eosio_token_abi().data() );
+   set_code( "eosio.token"_n, contracts::eosio_token_wasm() );
+   set_abi( "eosio.token"_n, contracts::eosio_token_abi().data() );
    produce_blocks(1);
 
    // create currency
    auto act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action("eosio.token"_n, "create"_n, "eosio.token"_n, act );
 
    // issue
    for (account_name a: accs) {
@@ -164,7 +164,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 AAA"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action("eosio.token"_n, "create"_n, "eosio.token"_n, act );
    // issue
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("9999.0000 AAA") );
@@ -175,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 CCC"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action("eosio.token"_n, "create"_n, "eosio.token"_n, act );
    // issue
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("7777.0000 CCC") );
@@ -186,7 +186,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 BBB"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action("eosio.token"_n, "create"_n, "eosio.token"_n, act );
    // issue
    for (account_name a: accs) {
       issue_tokens( *this, config::system_account_name, a, eosio::chain::asset::from_string("8888.0000 BBB") );
@@ -196,9 +196,9 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    // get table: normal case
    eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
-   p.code = N(eosio.token);
+   p.code = "eosio.token"_n;
    p.scope = "inita";
-   p.table = N(accounts);
+   p.table = "accounts"_n;
    p.json = true;
    p.index_position = "primary";
    eosio::chain_apis::read_only::get_table_rows_result result = plugin.read_only::get_table_rows(p);
@@ -316,22 +316,22 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-      N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+   create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
+      "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n });
 
-   std::vector<account_name> accs{N(inita), N(initb), N(initc), N(initd)};
+   std::vector<account_name> accs{"inita"_n, "initb"_n, "initc"_n, "initd"_n};
    create_accounts(accs);
    produce_block();
 
-   set_code( N(eosio.token), contracts::eosio_token_wasm() );
-   set_abi( N(eosio.token), contracts::eosio_token_abi().data() );
+   set_code( "eosio.token"_n, contracts::eosio_token_wasm() );
+   set_abi( "eosio.token"_n, contracts::eosio_token_abi().data() );
    produce_blocks(1);
 
    // create currency
    auto act = mutable_variant_object()
          ("issuer",       "eosio")
          ("maximum_supply", eosio::chain::asset::from_string("1000000000.0000 SYS"));
-   push_action(N(eosio.token), N(create), N(eosio.token), act );
+   push_action("eosio.token"_n, "create"_n, "eosio.token"_n, act );
 
    // issue
    for (account_name a: accs) {
@@ -342,32 +342,32 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    set_code( config::system_account_name, contracts::eosio_system_wasm() );
    set_abi( config::system_account_name, contracts::eosio_system_abi().data() );
 
-   base_tester::push_action(config::system_account_name, N(init),
+   base_tester::push_action(config::system_account_name, "init"_n,
                             config::system_account_name,  mutable_variant_object()
                             ("version", 0)
                             ("core", "4,SYS"));
 
    // bidname
    auto bidname = [this]( const account_name& bidder, const account_name& newname, const asset& bid ) {
-      return push_action( N(eosio), N(bidname), bidder, fc::mutable_variant_object()
+      return push_action( "eosio"_n, "bidname"_n, bidder, fc::mutable_variant_object()
                           ("bidder",  bidder)
                           ("newname", newname)
                           ("bid", bid)
                           );
    };
 
-   bidname(N(inita), N(com), eosio::chain::asset::from_string("10.0000 SYS"));
-   bidname(N(initb), N(org), eosio::chain::asset::from_string("11.0000 SYS"));
-   bidname(N(initc), N(io), eosio::chain::asset::from_string("12.0000 SYS"));
-   bidname(N(initd), N(html), eosio::chain::asset::from_string("14.0000 SYS"));
+   bidname("inita"_n, "com"_n, eosio::chain::asset::from_string("10.0000 SYS"));
+   bidname("initb"_n, "org"_n, eosio::chain::asset::from_string("11.0000 SYS"));
+   bidname("initc"_n, "io"_n, eosio::chain::asset::from_string("12.0000 SYS"));
+   bidname("initd"_n, "html"_n, eosio::chain::asset::from_string("14.0000 SYS"));
    produce_blocks(1);
 
    // get table: normal case
    eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
    eosio::chain_apis::read_only::get_table_rows_params p;
-   p.code = N(eosio);
+   p.code = "eosio"_n;
    p.scope = "eosio";
-   p.table = N(namebids);
+   p.table = "namebids"_n;
    p.json = true;
    p.index_position = "secondary"; // ordered by high_bid
    p.key_type = "i64";
@@ -450,20 +450,20 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
 
 
 BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
-   create_account(N(test));
+   create_account("test"_n);
 
    // setup contract and abi
-   set_code( N(test), contracts::get_table_test_wasm() );
-   set_abi( N(test), contracts::get_table_test_abi().data() );
+   set_code( "test"_n, contracts::get_table_test_wasm() );
+   set_abi( "test"_n, contracts::get_table_test_abi().data() );
    produce_block();
 
    // Init some data
-   push_action(N(test), N(addnumobj), N(test), mutable_variant_object()("input", 2));
-   push_action(N(test), N(addnumobj), N(test), mutable_variant_object()("input", 5));
-   push_action(N(test), N(addnumobj), N(test), mutable_variant_object()("input", 7));
-   push_action(N(test), N(addhashobj), N(test), mutable_variant_object()("hashinput", "firstinput"));
-   push_action(N(test), N(addhashobj), N(test), mutable_variant_object()("hashinput", "secondinput"));
-   push_action(N(test), N(addhashobj), N(test), mutable_variant_object()("hashinput", "thirdinput"));
+   push_action("test"_n, "addnumobj"_n, "test"_n, mutable_variant_object()("input", 2));
+   push_action("test"_n, "addnumobj"_n, "test"_n, mutable_variant_object()("input", 5));
+   push_action("test"_n, "addnumobj"_n, "test"_n, mutable_variant_object()("input", 7));
+   push_action("test"_n, "addhashobj"_n, "test"_n, mutable_variant_object()("hashinput", "firstinput"));
+   push_action("test"_n, "addhashobj"_n, "test"_n, mutable_variant_object()("hashinput", "secondinput"));
+   push_action("test"_n, "addhashobj"_n, "test"_n, mutable_variant_object()("hashinput", "thirdinput"));
    produce_block();
 
    // The result of the init will populate
@@ -518,12 +518,12 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
    chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
    chain_apis::read_only::get_table_rows_params params{
       .json=true,
-      .code=N(test),
+      .code="test"_n,
       .scope="test",
       .limit=1
    };
 
-   params.table = N(numobjs);
+   params.table = "numobjs"_n;
 
    // i64 primary key type
    params.key_type = "i64";
@@ -606,7 +606,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
    float128_t more2_secldouble_res_value =  more2_res_5.rows[0].get_object()["secldouble"].as<float128_t>();
    BOOST_TEST(more2_secldouble_res_value == more2_secldouble_expected_value);
 
-   params.table = N(hashobjs);
+   params.table = "hashobjs"_n;
 
    // sha256 secondary key type
    params.key_type = "sha256";

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -1401,8 +1401,8 @@ struct action1 {
    uint64_t blah1;
    uint32_t blah2;
    uint8_t blah3;
-   static account_name get_account() { return N(acount1); }
-   static account_name get_name() { return N(action1); }
+   static account_name get_account() { return "acount1"_n; }
+   static account_name get_name() { return "action1"_n; }
 
    template<typename Stream>
    friend Stream& operator<<( Stream& ds, const action1& act ) {
@@ -1423,8 +1423,8 @@ struct action2 {
    uint32_t blah1;
    uint64_t blah2;
    uint8_t blah3;
-   static account_name get_account() { return N(acount2); }
-   static account_name get_name() { return N(action2); }
+   static account_name get_account() { return "acount2"_n; }
+   static account_name get_name() { return "action2"_n; }
 
    template<typename Stream>
    friend Stream& operator<<( Stream& ds, const action2& act ) {
@@ -1473,9 +1473,9 @@ BOOST_AUTO_TEST_CASE(packed_transaction)
    txn.ref_block_num = 1;
    txn.ref_block_prefix = 2;
    txn.expiration.from_iso_string("2021-12-20T15:30");
-   name a = N(alice);
+   name a = "alice"_n;
    txn.context_free_actions.emplace_back(
-         vector<permission_level>{{N(testapi1), config::active_name}},
+         vector<permission_level>{{"testapi1"_n, config::active_name}},
          newaccount{
                .creator  = config::system_account_name,
                .name     = a,
@@ -1483,13 +1483,13 @@ BOOST_AUTO_TEST_CASE(packed_transaction)
                .active   = authority( get_public_key( a, "active" ) )
          });
    txn.context_free_actions.emplace_back(
-         vector<permission_level>{{N(testapi2), config::active_name}},
+         vector<permission_level>{{"testapi2"_n, config::active_name}},
          action1{ 15, 23, (uint8_t)3});
    txn.actions.emplace_back(
-         vector<permission_level>{{N(testapi3), config::active_name}},
+         vector<permission_level>{{"testapi3"_n, config::active_name}},
          action2{ 42, 67, (uint8_t)1});
    txn.actions.emplace_back(
-         vector<permission_level>{{N(testapi4), config::active_name}},
+         vector<permission_level>{{"testapi4"_n, config::active_name}},
          action2{ 61, 23, (uint8_t)2});
    txn.max_net_usage_words = 15;
    txn.max_cpu_usage_ms = 43;

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -56,12 +56,14 @@ static constexpr unsigned long long WASM_TEST_ACTION(const char* cls, const char
   return static_cast<unsigned long long>(DJBH(cls)) << 32 | static_cast<unsigned long long>(DJBH(method));
 }
 
+using namespace eosio::chain::literals;
+
 struct dummy_action {
    static eosio::chain::name get_name() {
-      return N(dummyaction);
+      return "dummyaction"_n;
    }
    static eosio::chain::name get_account() {
-      return N(testapi);
+      return "testapi"_n;
    }
 
   char a; //1
@@ -75,10 +77,10 @@ struct u128_action {
 
 struct cf_action {
    static eosio::chain::name get_name() {
-      return N(cfaction);
+      return "cfaction"_n;
    }
    static eosio::chain::name get_account() {
-      return N(testapi);
+      return "testapi"_n;
    }
 
    uint32_t       payload = 100;
@@ -91,13 +93,13 @@ struct dtt_action {
       return WASM_TEST_ACTION("test_transaction", "send_deferred_tx_with_dtt_action");
    }
    static uint64_t get_account() {
-      return N(testapi).to_uint64_t();
+      return "testapi"_n.to_uint64_t();
    }
 
-   uint64_t       payer = N(testapi).to_uint64_t();
-   uint64_t       deferred_account = N(testapi).to_uint64_t();
+   uint64_t       payer = "testapi"_n.to_uint64_t();
+   uint64_t       deferred_account = "testapi"_n.to_uint64_t();
    uint64_t       deferred_action = WASM_TEST_ACTION("test_transaction", "deferred_print");
-   uint64_t       permission_name = N(active).to_uint64_t();
+   uint64_t       permission_name = "active"_n.to_uint64_t();
    uint32_t       delay_sec = 2;
 };
 
@@ -130,7 +132,7 @@ namespace bio = boost::iostreams;
 template<uint64_t NAME>
 struct test_api_action {
 	static account_name get_account() {
-		return N(testapi);
+		return "testapi"_n;
 	}
 
 	static action_name get_name() {
@@ -193,7 +195,7 @@ string U128Str(unsigned __int128 i)
 }
 
 template <typename T>
-transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>& scope = {N(testapi)}) {
+transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>& scope = {"testapi"_n}) {
    signed_transaction trx;
 
 
@@ -216,7 +218,7 @@ transaction_trace_ptr CallAction(TESTER& test, T ac, const vector<account_name>&
 }
 
 template <typename T, typename Tester>
-std::pair<transaction_trace_ptr, signed_block_ptr> _CallFunction(Tester& test, T ac, const vector<char>& data, const vector<account_name>& scope = {N(testapi)}, bool no_throw = false) {
+std::pair<transaction_trace_ptr, signed_block_ptr> _CallFunction(Tester& test, T ac, const vector<char>& data, const vector<account_name>& scope = {"testapi"_n}, bool no_throw = false) {
    {
       signed_transaction trx;
 
@@ -227,7 +229,7 @@ std::pair<transaction_trace_ptr, signed_block_ptr> _CallFunction(Tester& test, T
 
       action act(pl, ac);
       act.data = data;
-      act.authorization = {{N(testapi), config::active_name}};
+      act.authorization = {{"testapi"_n, config::active_name}};
       trx.actions.push_back(act);
 
       test.set_transaction_headers(trx, test.DEFAULT_EXPIRATION_DELTA);
@@ -246,7 +248,7 @@ std::pair<transaction_trace_ptr, signed_block_ptr> _CallFunction(Tester& test, T
 }
 
 template <typename T, typename Tester>
-transaction_trace_ptr CallFunction(Tester& test, T ac, const vector<char>& data, const vector<account_name>& scope = {N(testapi)}, bool no_throw = false) {
+transaction_trace_ptr CallFunction(Tester& test, T ac, const vector<char>& data, const vector<account_name>& scope = {"testapi"_n}, bool no_throw = false) {
    {
       return _CallFunction(test, ac, data, scope, no_throw).first;
    }
@@ -256,7 +258,7 @@ transaction_trace_ptr CallFunction(Tester& test, T ac, const vector<char>& data,
 #define CALL_TEST_FUNCTION_WITH_BLOCK(_TESTER, CLS, MTH, DATA) _CallFunction(_TESTER, test_api_action<TEST_METHOD(CLS, MTH)>{}, DATA)
 #define CALL_TEST_FUNCTION_SYSTEM(_TESTER, CLS, MTH, DATA) CallFunction(_TESTER, test_chain_action<TEST_METHOD(CLS, MTH)>{}, DATA, {config::system_account_name} )
 #define CALL_TEST_FUNCTION_SCOPE(_TESTER, CLS, MTH, DATA, ACCOUNT) CallFunction(_TESTER, test_api_action<TEST_METHOD(CLS, MTH)>{}, DATA, ACCOUNT)
-#define CALL_TEST_FUNCTION_NO_THROW(_TESTER, CLS, MTH, DATA) CallFunction(_TESTER, test_api_action<TEST_METHOD(CLS, MTH)>{}, DATA, {N(testapi)}, true)
+#define CALL_TEST_FUNCTION_NO_THROW(_TESTER, CLS, MTH, DATA) CallFunction(_TESTER, test_api_action<TEST_METHOD(CLS, MTH)>{}, DATA, {"testapi"_n}, true)
 #define CALL_TEST_FUNCTION_AND_CHECK_EXCEPTION(_TESTER, CLS, MTH, DATA, EXC, EXC_MESSAGE) \
 BOOST_CHECK_EXCEPTION( \
    CALL_TEST_FUNCTION( _TESTER, CLS, MTH, DATA), \
@@ -315,13 +317,13 @@ uint32_t last_fnc_err = 0;
 
 BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
    produce_blocks(2);
-   create_account( N(test) );
-   set_code( N(test), contracts::payloadless_wasm() );
+   create_account( "test"_n );
+   set_code( "test"_n, contracts::payloadless_wasm() );
    produce_blocks(1);
 
    auto call_doit_and_check = [&]( account_name contract, account_name signer, auto&& checker ) {
       signed_transaction trx;
-      trx.actions.emplace_back( vector<permission_level>{{signer, config::active_name}}, contract, N(doit), bytes{} );
+      trx.actions.emplace_back( vector<permission_level>{{signer, config::active_name}}, contract, "doit"_n, bytes{} );
       this->set_transaction_headers( trx, this->DEFAULT_EXPIRATION_DELTA );
       trx.sign( this->get_private_key(signer, "active"), control->get_chain_id() );
       auto res = this->push_transaction(trx);
@@ -330,7 +332,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
 
    auto call_provereset_and_check = [&]( account_name contract, account_name signer, auto&& checker ) {
       signed_transaction trx;
-      trx.actions.emplace_back( vector<permission_level>{{signer, config::active_name}}, contract, N(provereset), bytes{} );
+      trx.actions.emplace_back( vector<permission_level>{{signer, config::active_name}}, contract, "provereset"_n, bytes{} );
       this->set_transaction_headers( trx, this->DEFAULT_EXPIRATION_DELTA );
       trx.sign( this->get_private_key(signer, "active"), control->get_chain_id() );
       auto res = this->push_transaction(trx);
@@ -349,7 +351,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
 
    uint64_t base_test_recv_seq_num = 0;
    uint64_t base_test_auth_seq_num = 0;
-   call_doit_and_check( N(test), N(test), [&]( const transaction_trace_ptr& res ) {
+   call_doit_and_check( "test"_n, "test"_n, [&]( const transaction_trace_ptr& res ) {
       BOOST_CHECK_EQUAL( res->receipt->status, transaction_receipt::executed );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->global_sequence, base_global_sequence_num + 1 );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->code_sequence.value, 1 );
@@ -365,10 +367,10 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
       --base_test_auth_seq_num;
    } );
 
-   set_code( N(test), contracts::asserter_wasm() );
+   set_code( "test"_n, contracts::asserter_wasm() );
    set_code( config::system_account_name, contracts::payloadless_wasm() );
 
-   call_provereset_and_check( N(test), N(test), [&]( const transaction_trace_ptr& res ) {
+   call_provereset_and_check( "test"_n, "test"_n, [&]( const transaction_trace_ptr& res ) {
       BOOST_CHECK_EQUAL( res->receipt->status, transaction_receipt::executed );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->global_sequence, base_global_sequence_num + 4 );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->recv_sequence, base_test_recv_seq_num + 2 );
@@ -384,7 +386,7 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
    // Adding a block also retires an onblock action which increments both the global sequence number
    // and the recv and auth sequences numbers for the system account.
 
-   call_doit_and_check( config::system_account_name, N(test), [&]( const transaction_trace_ptr& res ) {
+   call_doit_and_check( config::system_account_name, "test"_n, [&]( const transaction_trace_ptr& res ) {
       BOOST_CHECK_EQUAL( res->receipt->status, transaction_receipt::executed );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->global_sequence, base_global_sequence_num + 6 );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->recv_sequence, base_system_recv_seq_num + 4 );
@@ -398,11 +400,11 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
 
    set_code( config::system_account_name, contracts::eosio_bios_wasm() );
 
-   set_code( N(test), contracts::eosio_bios_wasm() );
-   set_abi( N(test), contracts::eosio_bios_abi().data() );
-	set_code( N(test), contracts::payloadless_wasm() );
+   set_code( "test"_n, contracts::eosio_bios_wasm() );
+   set_abi( "test"_n, contracts::eosio_bios_abi().data() );
+	set_code( "test"_n, contracts::payloadless_wasm() );
 
-   call_doit_and_check( N(test), N(test), [&]( const transaction_trace_ptr& res ) {
+   call_doit_and_check( "test"_n, "test"_n, [&]( const transaction_trace_ptr& res ) {
       BOOST_CHECK_EQUAL( res->receipt->status, transaction_receipt::executed);
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->global_sequence, base_global_sequence_num + 11 );
       BOOST_CHECK_EQUAL( res->action_traces[0].receipt->recv_sequence, base_test_recv_seq_num + 3 );
@@ -421,13 +423,13 @@ BOOST_FIXTURE_TEST_CASE(action_receipt_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
 	produce_blocks(2);
-	create_account( N(testapi) );
-	create_account( N(acc1) );
-	create_account( N(acc2) );
-	create_account( N(acc3) );
-	create_account( N(acc4) );
+	create_account( "testapi"_n );
+	create_account( "acc1"_n );
+	create_account( "acc2"_n );
+	create_account( "acc3"_n );
+	create_account( "acc4"_n );
 	produce_blocks(10);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 	produce_blocks(1);
 
    // test assert_true
@@ -466,18 +468,18 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       );
 
    // test require_notice
-   auto scope = std::vector<account_name>{N(testapi)};
+   auto scope = std::vector<account_name>{"testapi"_n};
    auto test_require_notice = [this](auto& test, std::vector<char>& data, std::vector<account_name>& scope){
       signed_transaction trx;
       auto tm = test_api_action<TEST_METHOD("test_action", "require_notice")>{};
 
-      action act(std::vector<permission_level>{{N(testapi), config::active_name}}, tm);
+      action act(std::vector<permission_level>{{"testapi"_n, config::active_name}}, tm);
       vector<char>& dest = *(vector<char> *)(&act.data);
       std::copy(data.begin(), data.end(), std::back_inserter(dest));
       trx.actions.push_back(act);
 
       test.set_transaction_headers(trx);
-      trx.sign(test.get_private_key(N(inita), "active"), control->get_chain_id());
+      trx.sign(test.get_private_key("inita"_n, "active"), control->get_chain_id());
       auto res = test.push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    };
@@ -496,7 +498,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       );
 
    // test require_auth
-   auto a3only = std::vector<permission_level>{{N(acc3), config::active_name}};
+   auto a3only = std::vector<permission_level>{{"acc3"_n, config::active_name}};
    BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "require_auth", fc::raw::pack(a3only)), missing_auth_exception,
          [](const missing_auth_exception& e) {
             return expect_assert_message(e, "missing authority of");
@@ -504,7 +506,7 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       );
 
    // test require_auth
-   auto a4only = std::vector<permission_level>{{N(acc4), config::active_name}};
+   auto a4only = std::vector<permission_level>{{"acc4"_n, config::active_name}};
    BOOST_CHECK_EXCEPTION(CALL_TEST_FUNCTION( *this, "test_action", "require_auth", fc::raw::pack(a4only)), missing_auth_exception,
          [](const missing_auth_exception& e) {
             return expect_assert_message(e, "missing authority of");
@@ -512,8 +514,8 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       );
 
    // test require_auth
-   auto a3a4 = std::vector<permission_level>{{N(acc3), config::active_name}, {N(acc4), config::active_name}};
-   auto a3a4_scope = std::vector<account_name>{N(acc3), N(acc4)};
+   auto a3a4 = std::vector<permission_level>{{"acc3"_n, config::active_name}, {"acc4"_n, config::active_name}};
+   auto a3a4_scope = std::vector<account_name>{"acc3"_n, "acc4"_n};
    {
       signed_transaction trx;
       auto tm = test_api_action<TEST_METHOD("test_action", "require_auth")>{};
@@ -526,13 +528,13 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
       auto dat = fc::raw::pack(a3a4);
       vector<char>& dest = *(vector<char> *)(&act.data);
       std::copy(dat.begin(), dat.end(), std::back_inserter(dest));
-      act.authorization = {{N(testapi), config::active_name}, {N(acc3), config::active_name}, {N(acc4), config::active_name}};
+      act.authorization = {{"testapi"_n, config::active_name}, {"acc3"_n, config::active_name}, {"acc4"_n, config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
-      trx.sign(get_private_key(N(acc3), "active"), control->get_chain_id());
-      trx.sign(get_private_key(N(acc4), "active"), control->get_chain_id());
+      trx.sign(get_private_key("testapi"_n, "active"), control->get_chain_id());
+      trx.sign(get_private_key("acc3"_n, "active"), control->get_chain_id());
+      trx.sign(get_private_key("acc4"_n, "active"), control->get_chain_id());
       auto res = push_transaction(trx);
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
    }
@@ -547,10 +549,10 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
                           eosio_assert_message_exception, eosio_assert_message_is("tmp == current_time()")     );
 
    // test test_current_receiver
-   CALL_TEST_FUNCTION( *this, "test_action", "test_current_receiver", fc::raw::pack(N(testapi)));
+   CALL_TEST_FUNCTION( *this, "test_action", "test_current_receiver", fc::raw::pack("testapi"_n));
 
    // test send_action_sender
-   CALL_TEST_FUNCTION( *this, "test_transaction", "send_action_sender", fc::raw::pack(N(testapi)));
+   CALL_TEST_FUNCTION( *this, "test_transaction", "send_action_sender", fc::raw::pack("testapi"_n));
 
    produce_block();
 
@@ -574,22 +576,22 @@ BOOST_FIXTURE_TEST_CASE(action_tests, TESTER) { try {
 // test require_recipient loop (doesn't cause infinite loop)
 BOOST_FIXTURE_TEST_CASE(require_notice_tests, TESTER) { try {
       produce_blocks(2);
-      create_account( N(testapi) );
-      create_account( N(acc5) );
+      create_account( "testapi"_n );
+      create_account( "acc5"_n );
       produce_blocks(1);
-      set_code( N(testapi), contracts::test_api_wasm() );
-      set_code( N(acc5), contracts::test_api_wasm() );
+      set_code( "testapi"_n, contracts::test_api_wasm() );
+      set_code( "acc5"_n, contracts::test_api_wasm() );
       produce_blocks(1);
 
       // test require_notice
       signed_transaction trx;
       auto tm = test_api_action<TEST_METHOD( "test_action", "require_notice_tests" )>{};
 
-      action act( std::vector<permission_level>{{N( testapi ), config::active_name}}, tm );
+      action act( std::vector<permission_level>{{"testapi"_n, config::active_name}}, tm );
       trx.actions.push_back( act );
 
       set_transaction_headers( trx );
-      trx.sign( get_private_key( N( testapi ), "active" ), control->get_chain_id() );
+      trx.sign( get_private_key( "testapi"_n, "active" ), control->get_chain_id() );
       auto res = push_transaction( trx );
       BOOST_CHECK_EQUAL( res->receipt->status, transaction_receipt::executed );
 
@@ -605,24 +607,24 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
    chain.preactivate_protocol_features( {*d} );
 
    chain.produce_blocks(2);
-   chain.create_account( N(testapi) );
-   chain.create_account( N(testapi2) );
+   chain.create_account( "testapi"_n );
+   chain.create_account( "testapi2"_n );
    chain.produce_blocks(10);
-   chain.set_code( N(testapi), contracts::test_api_wasm() );
+   chain.set_code( "testapi"_n, contracts::test_api_wasm() );
    chain.produce_blocks(1);
-   chain.set_code( N(testapi2), contracts::test_api_wasm() );
+   chain.set_code( "testapi2"_n, contracts::test_api_wasm() );
    chain.produce_blocks(1);
 
    BOOST_CHECK_EXCEPTION( CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify",
-                                              fc::raw::pack( ((unsigned __int128)N(testapi2).to_uint64_t() << 64) | N(testapi).to_uint64_t() ) ),
+                                              fc::raw::pack( ((unsigned __int128)"testapi2"_n.to_uint64_t() << 64) | "testapi"_n.to_uint64_t() ) ),
                           subjective_block_production_exception,
                           fc_exception_message_is("Cannot charge RAM to other accounts during notify.")
    );
 
 
-   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)N(testapi2).to_uint64_t() << 64) | 0 ) );
+   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)"testapi2"_n.to_uint64_t() << 64) | 0 ) );
 
-   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)N(testapi2).to_uint64_t() << 64) | N(testapi2).to_uint64_t() ) );
+   CALL_TEST_FUNCTION( chain, "test_action", "test_ram_billing_in_notify", fc::raw::pack( ((unsigned __int128)"testapi2"_n.to_uint64_t() << 64) | "testapi2"_n.to_uint64_t() ) );
 
    BOOST_REQUIRE_EQUAL( chain.validate(), true );
 } FC_LOG_AND_RETHROW() }
@@ -632,10 +634,10 @@ BOOST_AUTO_TEST_CASE(ram_billing_in_notify_tests) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
       produce_blocks(2);
-      create_account( N(testapi) );
-      create_account( N(dummy) );
+      create_account( "testapi"_n );
+      create_account( "dummy"_n );
       produce_blocks(10);
-      set_code( N(testapi), contracts::test_api_wasm() );
+      set_code( "testapi"_n, contracts::test_api_wasm() );
       produce_blocks(1);
       cf_action cfa;
       signed_transaction trx;
@@ -663,12 +665,12 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
 
       // add a normal action along with cfa
       dummy_action da = { DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C };
-      auto pl = vector<permission_level>{{N(testapi), config::active_name}};
+      auto pl = vector<permission_level>{{"testapi"_n, config::active_name}};
       action act1(pl, da);
       trx.actions.push_back(act1);
       set_transaction_headers(trx);
       // run normal passing case
-      auto sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
+      auto sigs = trx.sign(get_private_key("testapi"_n, "active"), control->get_chain_id());
       auto res = push_transaction(trx);
 
       BOOST_CHECK_EQUAL(res->receipt->status, transaction_receipt::executed);
@@ -682,7 +684,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
       trx.actions.push_back(act2);
       set_transaction_headers(trx);
       // run (dummy_action.b = 200) case looking for invalid use of context_free api
-      sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
+      sigs = trx.sign(get_private_key("testapi"_n, "active"), control->get_chain_id());
       BOOST_CHECK_EXCEPTION(push_transaction(trx), unaccessible_api,
                             [](const fc::exception& e) {
                                return expect_assert_message(e, "this API may only be called from context_free apply");
@@ -707,7 +709,7 @@ BOOST_FIXTURE_TEST_CASE(cf_action_tests, TESTER) { try {
             trx.context_free_actions.emplace_back(cfa_act);
             trx.signatures.clear();
             set_transaction_headers(trx);
-            sigs = trx.sign(get_private_key(N(testapi), "active"), control->get_chain_id());
+            sigs = trx.sign(get_private_key("testapi"_n, "active"), control->get_chain_id());
             BOOST_CHECK_EXCEPTION(push_transaction(trx), unaccessible_api,
                  [](const fc::exception& e) {
                     return expect_assert_message(e, "only context free api's can be used in this context" );
@@ -758,11 +760,11 @@ BOOST_FIXTURE_TEST_CASE(cfa_tx_signature, TESTER)  try {
 
 BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, TESTER)  try {
 
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
 	produce_blocks(1);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 
-   account_name a = N(testapi2);
+   account_name a = "testapi2"_n;
    account_name creator = config::system_account_name;
 
    signed_transaction trx;
@@ -788,11 +790,11 @@ BOOST_FIXTURE_TEST_CASE(cfa_stateful_api, TESTER)  try {
 
 BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, TESTER)  try {
 
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
 	produce_blocks(1);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 
-   account_name a = N(testapi2);
+   account_name a = "testapi2"_n;
    account_name creator = config::system_account_name;
 
    signed_transaction trx;
@@ -817,18 +819,18 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_failed, TESTER)  try {
    produce_blocks(10);
 
    // CFA failed, testapi2 not created
-   create_account( N(testapi2) );
+   create_account( "testapi2"_n );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
 
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
 	produce_blocks(1);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 
-   account_name a = N(testapi2);
+   account_name a = "testapi2"_n;
    account_name creator = config::system_account_name;
 
    signed_transaction trx;
@@ -853,7 +855,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
    produce_blocks(10);
 
    // CFA success, testapi2 created
-   BOOST_CHECK_EXCEPTION(create_account( N(testapi2) ), fc::exception,
+   BOOST_CHECK_EXCEPTION(create_account( "testapi2"_n ), fc::exception,
       [&](const fc::exception &e) {
          return expect_assert_message(e, "Cannot create account named testapi2, as that name is already taken");
       });
@@ -865,9 +867,9 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(checktime_pass_tests, TESTER) { try {
 	produce_blocks(2);
-	create_account( N(testapi) );
+	create_account( "testapi"_n );
 	produce_blocks(10);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 	produce_blocks(1);
 
    // test checktime_pass
@@ -880,13 +882,13 @@ template<class T>
 void call_test(TESTER& test, T ac, uint32_t billed_cpu_time_us , uint32_t max_cpu_usage_ms = 200, std::vector<char> payload = {} ) {
    signed_transaction trx;
 
-   auto pl = vector<permission_level>{{N(testapi), config::active_name}};
+   auto pl = vector<permission_level>{{"testapi"_n, config::active_name}};
    action act(pl, ac);
    act.data = payload;
 
    trx.actions.push_back(act);
    test.set_transaction_headers(trx);
-   auto sigs = trx.sign(test.get_private_key(N(testapi), "active"), test.control->get_chain_id());
+   auto sigs = trx.sign(test.get_private_key("testapi"_n, "active"), test.control->get_chain_id());
    flat_set<public_key_type> keys;
    trx.get_signature_keys(test.control->get_chain_id(), fc::time_point::maximum(), keys);
    auto res = test.push_transaction( trx, fc::time_point::now() + fc::milliseconds(max_cpu_usage_ms), billed_cpu_time_us );
@@ -899,14 +901,14 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
    t.produce_blocks(2);
 
    ilog( "create account" );
-   t.create_account( N(testapi) );
+   t.create_account( "testapi"_n );
    ilog( "set code" );
-   t.set_code( N(testapi), contracts::test_api_wasm() );
+   t.set_code( "testapi"_n, contracts::test_api_wasm() );
    ilog( "produce block" );
    t.produce_blocks(1);
 
    int64_t x; int64_t net; int64_t cpu;
-   t.control->get_resource_limits_manager().get_account_limits( N(testapi), x, net, cpu );
+   t.control->get_resource_limits_manager().get_account_limits( "testapi"_n, x, net, cpu );
    wdump((net)(cpu));
 
 #warning TODO call the contract before testing to cache it, and validate that it was cached
@@ -923,7 +925,7 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
    std::string dummy_string = "nonce";
    uint32_t increment = config::default_max_transaction_cpu_usage / 3;
    for( auto i = 0; time_left_in_block_us > 2*increment; ++i ) {
-      t.push_dummy( N(testapi), dummy_string + std::to_string(i), increment );
+      t.push_dummy( "testapi"_n, dummy_string + std::to_string(i), increment );
       time_left_in_block_us -= increment;
    }
    BOOST_CHECK_EXCEPTION( call_test( t, test_api_action<TEST_METHOD("test_checktime", "checktime_failure")>{},
@@ -936,7 +938,7 @@ BOOST_AUTO_TEST_CASE(checktime_fail_tests) { try {
 
 BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, TESTER) { try {
 	produce_blocks(2);
-	create_account( N(testapi) );
+	create_account( "testapi"_n );
 	produce_blocks(10);
 
         std::stringstream ss;
@@ -977,7 +979,7 @@ BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, TESTER) { try {
 )CONTRACT";
         }
         ss<< "))";
-	set_code( N(testapi), ss.str().c_str() );
+	set_code( "testapi"_n, ss.str().c_str() );
 	produce_blocks(1);
 
         //initialize cache
@@ -995,9 +997,9 @@ BOOST_FIXTURE_TEST_CASE(checktime_intrinsic, TESTER) { try {
 
 BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, TESTER) { try {
 	produce_blocks(2);
-	create_account( N(testapi) );
+	create_account( "testapi"_n );
 	produce_blocks(10);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 	produce_blocks(1);
 
         //hit deadline exception, but cache the contract
@@ -1048,9 +1050,9 @@ BOOST_FIXTURE_TEST_CASE(checktime_hashing_fail, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(transaction_tests, TESTER) { try {
    produce_blocks(2);
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
    produce_blocks(100);
-   set_code( N(testapi), contracts::test_api_wasm() );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
    // test for zero auth
@@ -1129,7 +1131,7 @@ BOOST_FIXTURE_TEST_CASE(transaction_tests, TESTER) { try {
       BOOST_CHECK( !test_trace->failed_dtrx_trace );
       BOOST_CHECK_EQUAL(0, block_ids.count( trace->id ) ); // onerror id, not in block
       BOOST_CHECK_EQUAL(1, block_ids.count( trace->failed_dtrx_trace->id ) ); // deferred id since trace moved to failed_dtrx_trace
-      BOOST_CHECK( trace->action_traces.at(0).act.name == N(onerror) );
+      BOOST_CHECK( trace->action_traces.at(0).act.name == "onerror"_n );
 
       c.disconnect();
       c2.disconnect();
@@ -1173,12 +1175,12 @@ BOOST_AUTO_TEST_CASE(inline_action_subjective_limit) { try {
       block = chain.produce_block();
       chain2.push_block(block);
    }
-   chain.create_account( N(testapi) );
+   chain.create_account( "testapi"_n );
    for (int n=0; n < 2; ++n) {
       block = chain.produce_block();
       chain2.push_block(block);
    }
-   chain.set_code( N(testapi), contracts::test_api_wasm() );
+   chain.set_code( "testapi"_n, contracts::test_api_wasm() );
    block = chain.produce_block();
    chain2.push_block(block);
 
@@ -1196,12 +1198,12 @@ BOOST_AUTO_TEST_CASE(inline_action_objective_limit) { try {
    const uint32_t _4k = 4 * 1024;
    tester chain(setup_policy::full, db_read_mode::SPECULATIVE, {_4k}, {_4k - 1});
    chain.produce_blocks(2);
-   chain.create_account( N(testapi) );
+   chain.create_account( "testapi"_n );
    chain.produce_blocks(100);
-   chain.set_code( N(testapi), contracts::test_api_wasm() );
+   chain.set_code( "testapi"_n, contracts::test_api_wasm() );
    chain.produce_block();
 
-   chain.push_action(config::system_account_name, N(setpriv), config::system_account_name,  mutable_variant_object()
+   chain.push_action(config::system_account_name, "setpriv"_n, config::system_account_name,  mutable_variant_object()
          ("account", "testapi")
          ("is_priv", 1));
    chain.produce_block();
@@ -1218,9 +1220,9 @@ BOOST_AUTO_TEST_CASE(deferred_inline_action_subjective_limit_failure) { try {
    const uint32_t _4k = 4 * 1024;
    tester chain(setup_policy::full, db_read_mode::SPECULATIVE, {_4k + 100}, {_4k});
    chain.produce_blocks(2);
-   chain.create_accounts( {N(testapi), N(testapi2), N(alice)} );
-   chain.set_code( N(testapi), contracts::test_api_wasm() );
-   chain.set_code( N(testapi2), contracts::test_api_wasm() );
+   chain.create_accounts( {"testapi"_n, "testapi2"_n, "alice"_n} );
+   chain.set_code( "testapi"_n, contracts::test_api_wasm() );
+   chain.set_code( "testapi2"_n, contracts::test_api_wasm() );
    chain.produce_block();
 
    transaction_trace_ptr trace;
@@ -1255,9 +1257,9 @@ BOOST_AUTO_TEST_CASE(deferred_inline_action_subjective_limit) { try {
       block = chain.produce_block();
       chain2.push_block(block);
    }
-   chain.create_accounts( {N(testapi), N(testapi2), N(alice)} );
-   chain.set_code( N(testapi), contracts::test_api_wasm() );
-   chain.set_code( N(testapi2), contracts::test_api_wasm() );
+   chain.create_accounts( {"testapi"_n, "testapi2"_n, "alice"_n} );
+   chain.set_code( "testapi"_n, contracts::test_api_wasm() );
+   chain.set_code( "testapi2"_n, contracts::test_api_wasm() );
    block = chain.produce_block();
    chain2.push_block(block);
 
@@ -1289,9 +1291,9 @@ BOOST_AUTO_TEST_CASE(deferred_inline_action_subjective_limit) { try {
 
 BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
    produce_blocks(2);
-   create_accounts( {N(testapi), N(testapi2), N(alice)} );
-   set_code( N(testapi), contracts::test_api_wasm() );
-   set_code( N(testapi2), contracts::test_api_wasm() );
+   create_accounts( {"testapi"_n, "testapi2"_n, "alice"_n} );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
+   set_code( "testapi2"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
    //schedule
@@ -1417,19 +1419,19 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       // Trigger a tx which in turn sends a deferred tx with payer != receiver
       // Payer is alice in this case, this tx should fail since we don't have the authorization of alice
       dtt_action dtt_act1;
-      dtt_act1.payer = N(alice).to_uint64_t();
+      dtt_act1.payer = "alice"_n.to_uint64_t();
       BOOST_CHECK_THROW(CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_tx_with_dtt_action", fc::raw::pack(dtt_act1)), action_validate_exception);
 
       // Send a tx which in turn sends a deferred tx with the deferred tx's receiver != this tx receiver
       // This will include the authorization of the receiver, and impose any related delay associated with the authority
       // We set the authorization delay to be 10 sec here, and since the deferred tx delay is set to be 5 sec, so this tx should fail
       dtt_action dtt_act2;
-      dtt_act2.deferred_account = N(testapi2).to_uint64_t();
-      dtt_act2.permission_name = N(additional).to_uint64_t();
+      dtt_act2.deferred_account = "testapi2"_n.to_uint64_t();
+      dtt_act2.permission_name = "additional"_n.to_uint64_t();
       dtt_act2.delay_sec = 5;
 
       auto auth = authority(get_public_key(name("testapi"), name(dtt_act2.permission_name).to_string()), 10);
-      auth.accounts.push_back( permission_level_weight{{N(testapi), config::eosio_code_name}, 1} );
+      auth.accounts.push_back( permission_level_weight{{"testapi"_n, config::eosio_code_name}, 1} );
 
       push_action(config::system_account_name, updateauth::get_name(), name("testapi"), fc::mutable_variant_object()
               ("account", "testapi")
@@ -1452,8 +1454,8 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       // But not anymore. With the RESTRICT_ACTION_TO_SELF protocol feature activated, it should now objectively
       // fail because testapi@additional permission is not unilaterally satisfied by testapi@eosio.code.
       dtt_action dtt_act3;
-      dtt_act3.deferred_account = N(testapi).to_uint64_t();
-      dtt_act3.permission_name = N(additional).to_uint64_t();
+      dtt_act3.deferred_account = "testapi"_n.to_uint64_t();
+      dtt_act3.permission_name = "additional"_n.to_uint64_t();
       push_action(config::system_account_name, linkauth::get_name(), name("testapi"), fc::mutable_variant_object()
             ("account", "testapi")
             ("code", name(dtt_act3.deferred_account))
@@ -1468,7 +1470,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_transaction_tests, TESTER) { try {
       // If we make testapi account to be priviledged account:
       // - the deferred transaction will work no matter who is the payer
       // - the deferred transaction will not care about the delay of the authorization
-      push_action(config::system_account_name, N(setpriv), config::system_account_name,  mutable_variant_object()
+      push_action(config::system_account_name, "setpriv"_n, config::system_account_name,  mutable_variant_object()
                                                           ("account", "testapi")
                                                           ("is_priv", 1));
       CALL_TEST_FUNCTION(*this, "test_transaction", "send_deferred_tx_with_dtt_action", fc::raw::pack(dtt_act1));
@@ -1508,7 +1510,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 
    BOOST_REQUIRE_EQUAL(0, index.size());
 
-   chain.push_action( contract_account, N(delayedcall), test_account, fc::mutable_variant_object()
+   chain.push_action( contract_account, "delayedcall"_n, test_account, fc::mutable_variant_object()
       ("payer",     test_account)
       ("sender_id", 0)
       ("contract",  contract_account)
@@ -1522,7 +1524,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 
    signed_transaction trx;
    trx.actions.emplace_back(
-      chain.get_action( contract_account, N(delayedcall),
+      chain.get_action( contract_account, "delayedcall"_n,
                   vector<permission_level>{{test_account, config::active_name}},
                   fc::mutable_variant_object()
                      ("payer",     test_account)
@@ -1534,7 +1536,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
       )
    );
    trx.actions.emplace_back(
-      chain.get_action( contract_account, N(delayedcall),
+      chain.get_action( contract_account, "delayedcall"_n,
                   vector<permission_level>{{test_account, config::active_name}},
                   fc::mutable_variant_object()
                      ("payer",     test_account)
@@ -1546,7 +1548,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
       )
    );
    trx.actions.emplace_back(
-      chain.get_action( contract_account, N(fail),
+      chain.get_action( contract_account, "fail"_n,
                   vector<permission_level>{},
                   fc::mutable_variant_object()
       )
@@ -1564,7 +1566,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 
    chain.produce_blocks(2);
 
-   chain.push_action( contract_account, N(delayedcall), test_account, fc::mutable_variant_object()
+   chain.push_action( contract_account, "delayedcall"_n, test_account, fc::mutable_variant_object()
       ("payer",     test_account)
       ("sender_id", 1)
       ("contract",  contract_account)
@@ -1573,7 +1575,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
       ("replace_existing", false)
    );
 
-   chain.push_action( contract_account, N(delayedcall), test_account, fc::mutable_variant_object()
+   chain.push_action( contract_account, "delayedcall"_n, test_account, fc::mutable_variant_object()
       ("payer",     test_account)
       ("sender_id", 2)
       ("contract",  contract_account)
@@ -1586,7 +1588,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
    print_deferred();
 
    BOOST_REQUIRE_THROW(
-      chain.push_action( contract_account, N(delayedcall), test_account, fc::mutable_variant_object()
+      chain.push_action( contract_account, "delayedcall"_n, test_account, fc::mutable_variant_object()
          ("payer",     test_account)
          ("sender_id", 2)
          ("contract",  contract_account)
@@ -1602,7 +1604,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
 
    signed_transaction trx2;
    trx2.actions.emplace_back(
-      chain.get_action( contract_account, N(delayedcall),
+      chain.get_action( contract_account, "delayedcall"_n,
                   vector<permission_level>{{test_account, config::active_name}},
                   fc::mutable_variant_object()
                      ("payer",     test_account)
@@ -1614,7 +1616,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
       )
    );
    trx2.actions.emplace_back(
-      chain.get_action( contract_account, N(delayedcall),
+      chain.get_action( contract_account, "delayedcall"_n,
                   vector<permission_level>{{test_account, config::active_name}},
                   fc::mutable_variant_object()
                      ("payer",     test_account)
@@ -1626,7 +1628,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
       )
    );
    trx2.actions.emplace_back(
-      chain.get_action( contract_account, N(delayedcall),
+      chain.get_action( contract_account, "delayedcall"_n,
                   vector<permission_level>{{test_account, config::active_name}},
                   fc::mutable_variant_object()
                      ("payer",     test_account)
@@ -1638,7 +1640,7 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
       )
    );
    trx2.actions.emplace_back(
-      chain.get_action( contract_account, N(fail),
+      chain.get_action( contract_account, "fail"_n,
                   vector<permission_level>{},
                   fc::mutable_variant_object()
       )
@@ -1657,52 +1659,41 @@ BOOST_AUTO_TEST_CASE(more_deferred_transaction_tests) { try {
    BOOST_REQUIRE_EQUAL( chain.validate(), true );
 } FC_LOG_AND_RETHROW() }
 
-template <uint64_t NAME>
-struct setprod_act {
-   static account_name get_account() {
-      return N(config::system_account_name);
-   }
-
-   static action_name get_name() {
-      return action_name(NAME);
-   }
-};
-
 /*************************************************************************************
  * chain_tests test case
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(chain_tests, TESTER) { try {
    produce_blocks(2);
 
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
 
-   vector<account_name> producers = { N(inita),
-                                      N(initb),
-                                      N(initc),
-                                      N(initd),
-                                      N(inite),
-                                      N(initf),
-                                      N(initg),
-                                      N(inith),
-                                      N(initi),
-                                      N(initj),
-                                      N(initk),
-                                      N(initl),
-                                      N(initm),
-                                      N(initn),
-                                      N(inito),
-                                      N(initp),
-                                      N(initq),
-                                      N(initr),
-                                      N(inits),
-                                      N(initt),
-                                      N(initu)
+   vector<account_name> producers = { "inita"_n,
+                                      "initb"_n,
+                                      "initc"_n,
+                                      "initd"_n,
+                                      "inite"_n,
+                                      "initf"_n,
+                                      "initg"_n,
+                                      "inith"_n,
+                                      "initi"_n,
+                                      "initj"_n,
+                                      "initk"_n,
+                                      "initl"_n,
+                                      "initm"_n,
+                                      "initn"_n,
+                                      "inito"_n,
+                                      "initp"_n,
+                                      "initq"_n,
+                                      "initr"_n,
+                                      "inits"_n,
+                                      "initt"_n,
+                                      "initu"_n
    };
 
    create_accounts( producers );
    set_producers (producers );
 
-   set_code( N(testapi), contracts::test_api_wasm() );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(100);
 
    vector<account_name> prods( control->active_producers().producers.size() );
@@ -1720,32 +1711,32 @@ BOOST_FIXTURE_TEST_CASE(chain_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
    produce_blocks(2);
-   create_account( N(testapi) );
-   create_account( N(testapi2) );
+   create_account( "testapi"_n );
+   create_account( "testapi2"_n );
    produce_blocks(10);
-   set_code( N(testapi), contracts::test_api_db_wasm() );
-   set_abi(  N(testapi), contracts::test_api_db_abi().data() );
-   set_code( N(testapi2), contracts::test_api_db_wasm() );
-   set_abi(  N(testapi2), contracts::test_api_db_abi().data() );
+   set_code( "testapi"_n, contracts::test_api_db_wasm() );
+   set_abi(  "testapi"_n, contracts::test_api_db_abi().data() );
+   set_code( "testapi2"_n, contracts::test_api_db_wasm() );
+   set_abi(  "testapi2"_n, contracts::test_api_db_abi().data() );
    produce_blocks(1);
 
-   push_action( N(testapi), N(pg),  N(testapi), mutable_variant_object() ); // primary_i64_general
-   push_action( N(testapi), N(pl),  N(testapi), mutable_variant_object() ); // primary_i64_lowerbound
-   push_action( N(testapi), N(pu),  N(testapi), mutable_variant_object() ); // primary_i64_upperbound
-   push_action( N(testapi), N(s1g), N(testapi), mutable_variant_object() ); // idx64_general
-   push_action( N(testapi), N(s1l), N(testapi), mutable_variant_object() ); // idx64_lowerbound
-   push_action( N(testapi), N(s1u), N(testapi), mutable_variant_object() ); // idx64_upperbound
+   push_action( "testapi"_n, "pg"_n,  "testapi"_n, mutable_variant_object() ); // primary_i64_general
+   push_action( "testapi"_n, "pl"_n,  "testapi"_n, mutable_variant_object() ); // primary_i64_lowerbound
+   push_action( "testapi"_n, "pu"_n,  "testapi"_n, mutable_variant_object() ); // primary_i64_upperbound
+   push_action( "testapi"_n, "s1g"_n, "testapi"_n, mutable_variant_object() ); // idx64_general
+   push_action( "testapi"_n, "s1l"_n, "testapi"_n, mutable_variant_object() ); // idx64_lowerbound
+   push_action( "testapi"_n, "s1u"_n, "testapi"_n, mutable_variant_object() ); // idx64_upperbound
 
    // Store value in primary table
-   push_action( N(testapi), N(tia), N(testapi), mutable_variant_object() // test_invalid_access
+   push_action( "testapi"_n, "tia"_n, "testapi"_n, mutable_variant_object() // test_invalid_access
       ("code", "testapi")
       ("val", 10)
       ("index", 0)
       ("store", true)
    );
 
-   // Attempt to change the value stored in the primary table under the code of N(testapi)
-   BOOST_CHECK_EXCEPTION( push_action( N(testapi2), N(tia), N(testapi2), mutable_variant_object()
+   // Attempt to change the value stored in the primary table under the code of "testapi"_n
+   BOOST_CHECK_EXCEPTION( push_action( "testapi2"_n, "tia"_n, "testapi2"_n, mutable_variant_object()
                               ("code", "testapi")
                               ("val", "20")
                               ("index", 0)
@@ -1755,7 +1746,7 @@ BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
    );
 
    // Verify that the value has not changed.
-   push_action( N(testapi), N(tia), N(testapi), mutable_variant_object()
+   push_action( "testapi"_n, "tia"_n, "testapi"_n, mutable_variant_object()
       ("code", "testapi")
       ("val", 10)
       ("index", 0)
@@ -1763,15 +1754,15 @@ BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
    );
 
    // Store value in secondary table
-   push_action( N(testapi), N(tia), N(testapi), mutable_variant_object() // test_invalid_access
+   push_action( "testapi"_n, "tia"_n, "testapi"_n, mutable_variant_object() // test_invalid_access
       ("code", "testapi")
       ("val", 10)
       ("index", 1)
       ("store", true)
    );
 
-   // Attempt to change the value stored in the secondary table under the code of N(testapi)
-   BOOST_CHECK_EXCEPTION( push_action( N(testapi2), N(tia), N(testapi2), mutable_variant_object()
+   // Attempt to change the value stored in the secondary table under the code of "testapi"_n
+   BOOST_CHECK_EXCEPTION( push_action( "testapi2"_n, "tia"_n, "testapi2"_n, mutable_variant_object()
                               ("code", "testapi")
                               ("val", "20")
                               ("index", 1)
@@ -1781,7 +1772,7 @@ BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
    );
 
    // Verify that the value has not changed.
-   push_action( N(testapi), N(tia), N(testapi), mutable_variant_object()
+   push_action( "testapi"_n, "tia"_n, "testapi"_n, mutable_variant_object()
       ("code", "testapi")
       ("val", 10)
       ("index", 1)
@@ -1789,37 +1780,37 @@ BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
    );
 
    // idx_double_nan_create_fail
-   BOOST_CHECK_EXCEPTION(  push_action( N(testapi), N(sdnancreate), N(testapi), mutable_variant_object() ),
+   BOOST_CHECK_EXCEPTION(  push_action( "testapi"_n, "sdnancreate"_n, "testapi"_n, mutable_variant_object() ),
                            transaction_exception,
                            fc_exception_message_is("NaN is not an allowed value for a secondary key")
    );
 
    // idx_double_nan_modify_fail
-   BOOST_CHECK_EXCEPTION(  push_action( N(testapi), N(sdnanmodify), N(testapi), mutable_variant_object() ),
+   BOOST_CHECK_EXCEPTION(  push_action( "testapi"_n, "sdnanmodify"_n, "testapi"_n, mutable_variant_object() ),
                            transaction_exception,
                            fc_exception_message_is("NaN is not an allowed value for a secondary key")
    );
 
    // idx_double_nan_lookup_fail
-   BOOST_CHECK_EXCEPTION(  push_action( N(testapi), N(sdnanlookup), N(testapi), mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  push_action( "testapi"_n, "sdnanlookup"_n, "testapi"_n, mutable_variant_object()
                               ("lookup_type", 0) // 0 for find
                            ), transaction_exception,
                            fc_exception_message_is("NaN is not an allowed value for a secondary key")
    );
 
-   BOOST_CHECK_EXCEPTION(  push_action( N(testapi), N(sdnanlookup), N(testapi), mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  push_action( "testapi"_n, "sdnanlookup"_n, "testapi"_n, mutable_variant_object()
                               ("lookup_type", 1) // 1 for lower bound
                            ), transaction_exception,
                            fc_exception_message_is("NaN is not an allowed value for a secondary key")
    );
 
-   BOOST_CHECK_EXCEPTION(  push_action( N(testapi), N(sdnanlookup), N(testapi), mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  push_action( "testapi"_n, "sdnanlookup"_n, "testapi"_n, mutable_variant_object()
                               ("lookup_type", 2) // 2 for upper bound
                            ), transaction_exception,
                            fc_exception_message_is("NaN is not an allowed value for a secondary key")
    );
 
-   push_action( N(testapi), N(sk32align), N(testapi), mutable_variant_object() ); // misaligned_secondary_key256_tests
+   push_action( "testapi"_n, "sk32align"_n, "testapi"_n, mutable_variant_object() ); // misaligned_secondary_key256_tests
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }
@@ -1829,53 +1820,53 @@ BOOST_FIXTURE_TEST_CASE(db_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(multi_index_tests, TESTER) { try {
    produce_blocks(1);
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
    produce_blocks(1);
-   set_code( N(testapi), contracts::test_api_multi_index_wasm() );
-   set_abi( N(testapi), contracts::test_api_multi_index_abi().data() );
+   set_code( "testapi"_n, contracts::test_api_multi_index_wasm() );
+   set_abi( "testapi"_n, contracts::test_api_multi_index_abi().data() );
    produce_blocks(1);
 
    auto check_failure = [this]( action_name a, const char* expected_error_msg ) {
-      BOOST_CHECK_EXCEPTION(  push_action( N(testapi), a, N(testapi), {} ),
+      BOOST_CHECK_EXCEPTION(  push_action( "testapi"_n, a, "testapi"_n, {} ),
                               eosio_assert_message_exception,
                               eosio_assert_message_is( expected_error_msg )
       );
    };
 
-   push_action( N(testapi), N(s1g),  N(testapi), {} );        // idx64_general
-   push_action( N(testapi), N(s1store),  N(testapi), {} );    // idx64_store_only
-   push_action( N(testapi), N(s1check),  N(testapi), {} );    // idx64_check_without_storing
-   push_action( N(testapi), N(s2g),  N(testapi), {} );        // idx128_general
-   push_action( N(testapi), N(s2store),  N(testapi), {} );    // idx128_store_only
-   push_action( N(testapi), N(s2check),  N(testapi), {} );    // idx128_check_without_storing
-   push_action( N(testapi), N(s2autoinc),  N(testapi), {} );  // idx128_autoincrement_test
-   push_action( N(testapi), N(s2autoinc1),  N(testapi), {} ); // idx128_autoincrement_test_part1
-   push_action( N(testapi), N(s2autoinc2),  N(testapi), {} ); // idx128_autoincrement_test_part2
-   push_action( N(testapi), N(s3g),  N(testapi), {} );        // idx256_general
-   push_action( N(testapi), N(sdg),  N(testapi), {} );        // idx_double_general
-   push_action( N(testapi), N(sldg),  N(testapi), {} );       // idx_long_double_general
+   push_action( "testapi"_n, "s1g"_n,  "testapi"_n, {} );        // idx64_general
+   push_action( "testapi"_n, "s1store"_n,  "testapi"_n, {} );    // idx64_store_only
+   push_action( "testapi"_n, "s1check"_n,  "testapi"_n, {} );    // idx64_check_without_storing
+   push_action( "testapi"_n, "s2g"_n,  "testapi"_n, {} );        // idx128_general
+   push_action( "testapi"_n, "s2store"_n,  "testapi"_n, {} );    // idx128_store_only
+   push_action( "testapi"_n, "s2check"_n,  "testapi"_n, {} );    // idx128_check_without_storing
+   push_action( "testapi"_n, "s2autoinc"_n,  "testapi"_n, {} );  // idx128_autoincrement_test
+   push_action( "testapi"_n, "s2autoinc1"_n,  "testapi"_n, {} ); // idx128_autoincrement_test_part1
+   push_action( "testapi"_n, "s2autoinc2"_n,  "testapi"_n, {} ); // idx128_autoincrement_test_part2
+   push_action( "testapi"_n, "s3g"_n,  "testapi"_n, {} );        // idx256_general
+   push_action( "testapi"_n, "sdg"_n,  "testapi"_n, {} );        // idx_double_general
+   push_action( "testapi"_n, "sldg"_n,  "testapi"_n, {} );       // idx_long_double_general
 
-   check_failure( N(s1pkend), "cannot increment end iterator" ); // idx64_pk_iterator_exceed_end
-   check_failure( N(s1skend), "cannot increment end iterator" ); // idx64_sk_iterator_exceed_end
-   check_failure( N(s1pkbegin), "cannot decrement iterator at beginning of table" ); // idx64_pk_iterator_exceed_begin
-   check_failure( N(s1skbegin), "cannot decrement iterator at beginning of index" ); // idx64_sk_iterator_exceed_begin
-   check_failure( N(s1pkref), "object passed to iterator_to is not in multi_index" ); // idx64_pass_pk_ref_to_other_table
-   check_failure( N(s1skref), "object passed to iterator_to is not in multi_index" ); // idx64_pass_sk_ref_to_other_table
-   check_failure( N(s1pkitrto), "object passed to iterator_to is not in multi_index" ); // idx64_pass_pk_end_itr_to_iterator_to
-   check_failure( N(s1pkmodify), "cannot pass end iterator to modify" ); // idx64_pass_pk_end_itr_to_modify
-   check_failure( N(s1pkerase), "cannot pass end iterator to erase" ); // idx64_pass_pk_end_itr_to_erase
-   check_failure( N(s1skitrto), "object passed to iterator_to is not in multi_index" ); // idx64_pass_sk_end_itr_to_iterator_to
-   check_failure( N(s1skmodify), "cannot pass end iterator to modify" ); // idx64_pass_sk_end_itr_to_modify
-   check_failure( N(s1skerase), "cannot pass end iterator to erase" ); // idx64_pass_sk_end_itr_to_erase
-   check_failure( N(s1modpk), "updater cannot change primary key when modifying an object" ); // idx64_modify_primary_key
-   check_failure( N(s1exhaustpk), "next primary key in table is at autoincrement limit" ); // idx64_run_out_of_avl_pk
-   check_failure( N(s1findfail1), "unable to find key" ); // idx64_require_find_fail
-   check_failure( N(s1findfail2), "unable to find primary key in require_find" );// idx64_require_find_fail_with_msg
-   check_failure( N(s1findfail3), "unable to find secondary key" ); // idx64_require_find_sk_fail
-   check_failure( N(s1findfail4), "unable to find sec key" ); // idx64_require_find_sk_fail_with_msg
+   check_failure( "s1pkend"_n, "cannot increment end iterator" ); // idx64_pk_iterator_exceed_end
+   check_failure( "s1skend"_n, "cannot increment end iterator" ); // idx64_sk_iterator_exceed_end
+   check_failure( "s1pkbegin"_n, "cannot decrement iterator at beginning of table" ); // idx64_pk_iterator_exceed_begin
+   check_failure( "s1skbegin"_n, "cannot decrement iterator at beginning of index" ); // idx64_sk_iterator_exceed_begin
+   check_failure( "s1pkref"_n, "object passed to iterator_to is not in multi_index" ); // idx64_pass_pk_ref_to_other_table
+   check_failure( "s1skref"_n, "object passed to iterator_to is not in multi_index" ); // idx64_pass_sk_ref_to_other_table
+   check_failure( "s1pkitrto"_n, "object passed to iterator_to is not in multi_index" ); // idx64_pass_pk_end_itr_to_iterator_to
+   check_failure( "s1pkmodify"_n, "cannot pass end iterator to modify" ); // idx64_pass_pk_end_itr_to_modify
+   check_failure( "s1pkerase"_n, "cannot pass end iterator to erase" ); // idx64_pass_pk_end_itr_to_erase
+   check_failure( "s1skitrto"_n, "object passed to iterator_to is not in multi_index" ); // idx64_pass_sk_end_itr_to_iterator_to
+   check_failure( "s1skmodify"_n, "cannot pass end iterator to modify" ); // idx64_pass_sk_end_itr_to_modify
+   check_failure( "s1skerase"_n, "cannot pass end iterator to erase" ); // idx64_pass_sk_end_itr_to_erase
+   check_failure( "s1modpk"_n, "updater cannot change primary key when modifying an object" ); // idx64_modify_primary_key
+   check_failure( "s1exhaustpk"_n, "next primary key in table is at autoincrement limit" ); // idx64_run_out_of_avl_pk
+   check_failure( "s1findfail1"_n, "unable to find key" ); // idx64_require_find_fail
+   check_failure( "s1findfail2"_n, "unable to find primary key in require_find" );// idx64_require_find_fail_with_msg
+   check_failure( "s1findfail3"_n, "unable to find secondary key" ); // idx64_require_find_sk_fail
+   check_failure( "s1findfail4"_n, "unable to find sec key" ); // idx64_require_find_sk_fail_with_msg
 
-   push_action( N(testapi), N(s1skcache),  N(testapi), {} ); // idx64_sk_cache_pk_lookup
-   push_action( N(testapi), N(s1pkcache),  N(testapi), {} ); // idx64_pk_cache_sk_lookup
+   push_action( "testapi"_n, "s1skcache"_n,  "testapi"_n, {} ); // idx64_sk_cache_pk_lookup
+   push_action( "testapi"_n, "s1pkcache"_n,  "testapi"_n, {} ); // idx64_pk_cache_sk_lookup
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW() }
@@ -1885,17 +1876,17 @@ BOOST_FIXTURE_TEST_CASE(multi_index_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
    produce_block();
-   create_account(N(testapi) );
+   create_account("testapi"_n );
    produce_block();
-   set_code(N(testapi), contracts::test_api_wasm() );
+   set_code("testapi"_n, contracts::test_api_wasm() );
    produce_block();
    {
       signed_transaction trx;
 
-      auto pl = vector<permission_level>{{N(testapi), config::active_name}};
+      auto pl = vector<permission_level>{{"testapi"_n, config::active_name}};
 
       action act(pl, test_api_action<TEST_METHOD("test_crypto", "test_recover_key")>{});
-      const auto priv_key = get_private_key(N(testapi), "active" );
+      const auto priv_key = get_private_key("testapi"_n, "active" );
       const auto pub_key = priv_key.get_public_key();
       auto hash = trx.sig_digest( control->get_chain_id() );
       auto sig = priv_key.sign(hash);
@@ -1921,12 +1912,12 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
    {
       signed_transaction trx;
 
-      auto pl = vector<permission_level>{{N(testapi), config::active_name}};
+      auto pl = vector<permission_level>{{"testapi"_n, config::active_name}};
 
       action act(pl, test_api_action<TEST_METHOD("test_crypto", "test_recover_key_partial")>{});
 
       // construct a mock WebAuthN pubkey and signature, as it is the only type that would be variable-sized
-      const auto priv_key = get_private_key<mock::webauthn_private_key>(N(testapi), "active" );
+      const auto priv_key = get_private_key<mock::webauthn_private_key>("testapi"_n, "active" );
       const auto pub_key = priv_key.get_public_key();
       auto hash  = trx.sig_digest( control->get_chain_id() );
       auto sig = priv_key.sign(hash);
@@ -1982,10 +1973,10 @@ BOOST_FIXTURE_TEST_CASE(crypto_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(print_tests, TESTER) { try {
 	produce_blocks(2);
-	create_account(N(testapi) );
+	create_account("testapi"_n );
 	produce_blocks(1000);
 
-	set_code(N(testapi), contracts::test_api_wasm() );
+	set_code("testapi"_n, contracts::test_api_wasm() );
 	produce_blocks(1000);
 	string captured = "";
 
@@ -2108,10 +2099,10 @@ BOOST_FIXTURE_TEST_CASE(print_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(types_tests, TESTER) { try {
 	produce_blocks(1000);
-	create_account( N(testapi) );
+	create_account( "testapi"_n );
 
 	produce_blocks(1000);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 	produce_blocks(1000);
 
 	CALL_TEST_FUNCTION( *this, "test_types", "types_size", {});
@@ -2126,15 +2117,15 @@ BOOST_FIXTURE_TEST_CASE(types_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
    produce_blocks(1);
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
 
    produce_blocks(1);
-   set_code( N(testapi), contracts::test_api_wasm() );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
    auto get_result_int64 = [&]() -> int64_t {
       const auto& db = control->db();
-      const auto* t_id = db.find<table_id_object, by_code_scope_table>(boost::make_tuple(N(testapi), N(testapi), N(testapi)));
+      const auto* t_id = db.find<table_id_object, by_code_scope_table>(boost::make_tuple("testapi"_n, "testapi"_n, "testapi"_n));
 
       FC_ASSERT(t_id != 0, "Table id not found");
 
@@ -2149,10 +2140,10 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "check_authorization",
       fc::raw::pack( check_auth {
-         .account    = N(testapi),
-         .permission = N(active),
+         .account    = "testapi"_n,
+         .permission = "active"_n,
          .pubkeys    = {
-            get_public_key(N(testapi), "active")
+            get_public_key("testapi"_n, "active")
          }
       })
    );
@@ -2160,8 +2151,8 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "check_authorization",
       fc::raw::pack( check_auth {
-         .account    = N(testapi),
-         .permission = N(active),
+         .account    = "testapi"_n,
+         .permission = "active"_n,
          .pubkeys    = {
             public_key_type(string("EOS7GfRtyDWWgxV88a5TRaYY59XmHptyfjsFmHHfioGNJtPjpSmGX"))
          }
@@ -2171,10 +2162,10 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "check_authorization",
       fc::raw::pack( check_auth {
-         .account    = N(testapi),
-         .permission = N(active),
+         .account    = "testapi"_n,
+         .permission = "active"_n,
          .pubkeys    = {
-            get_public_key(N(testapi), "active"),
+            get_public_key("testapi"_n, "active"),
             public_key_type(string("EOS7GfRtyDWWgxV88a5TRaYY59XmHptyfjsFmHHfioGNJtPjpSmGX"))
          }
       })
@@ -2183,10 +2174,10 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "check_authorization",
       fc::raw::pack( check_auth {
-         .account    = N(noname),
-         .permission = N(active),
+         .account    = "noname"_n,
+         .permission = "active"_n,
          .pubkeys    = {
-            get_public_key(N(testapi), "active")
+            get_public_key("testapi"_n, "active")
          }
       })
    );
@@ -2194,8 +2185,8 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "check_authorization",
       fc::raw::pack( check_auth {
-         .account    = N(testapi),
-         .permission = N(active),
+         .account    = "testapi"_n,
+         .permission = "active"_n,
          .pubkeys    = {}
       })
    );
@@ -2203,10 +2194,10 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "check_authorization",
       fc::raw::pack( check_auth {
-         .account    = N(testapi),
-         .permission = N(noname),
+         .account    = "testapi"_n,
+         .permission = "noname"_n,
          .pubkeys    = {
-            get_public_key(N(testapi), "active")
+            get_public_key("testapi"_n, "active")
          }
       })
    );
@@ -2220,39 +2211,39 @@ BOOST_FIXTURE_TEST_CASE(permission_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
 	produce_blocks(2);
-	create_account( N(testapi) );
-	create_account( N(acc1) );
+	create_account( "testapi"_n );
+	create_account( "acc1"_n );
 	produce_blocks(100);
-	set_code( N(testapi), contracts::test_api_wasm() );
+	set_code( "testapi"_n, contracts::test_api_wasm() );
 	produce_blocks(1);
 
    {
 		signed_transaction trx;
 
       auto pl = vector<permission_level>{{config::system_account_name, config::active_name}};
-      action act(pl, test_chain_action<N(setprods)>());
+      action act(pl, test_chain_action<"setprods"_n>());
       vector<producer_key> prod_keys = {
-                                          { N(inita), get_public_key( N(inita), "active" ) },
-                                          { N(initb), get_public_key( N(initb), "active" ) },
-                                          { N(initc), get_public_key( N(initc), "active" ) },
-                                          { N(initd), get_public_key( N(initd), "active" ) },
-                                          { N(inite), get_public_key( N(inite), "active" ) },
-                                          { N(initf), get_public_key( N(initf), "active" ) },
-                                          { N(initg), get_public_key( N(initg), "active" ) },
-                                          { N(inith), get_public_key( N(inith), "active" ) },
-                                          { N(initi), get_public_key( N(initi), "active" ) },
-                                          { N(initj), get_public_key( N(initj), "active" ) },
-                                          { N(initk), get_public_key( N(initk), "active" ) },
-                                          { N(initl), get_public_key( N(initl), "active" ) },
-                                          { N(initm), get_public_key( N(initm), "active" ) },
-                                          { N(initn), get_public_key( N(initn), "active" ) },
-                                          { N(inito), get_public_key( N(inito), "active" ) },
-                                          { N(initp), get_public_key( N(initp), "active" ) },
-                                          { N(initq), get_public_key( N(initq), "active" ) },
-                                          { N(initr), get_public_key( N(initr), "active" ) },
-                                          { N(inits), get_public_key( N(inits), "active" ) },
-                                          { N(initt), get_public_key( N(initt), "active" ) },
-                                          { N(initu), get_public_key( N(initu), "active" ) }
+                                          { "inita"_n, get_public_key( "inita"_n, "active" ) },
+                                          { "initb"_n, get_public_key( "initb"_n, "active" ) },
+                                          { "initc"_n, get_public_key( "initc"_n, "active" ) },
+                                          { "initd"_n, get_public_key( "initd"_n, "active" ) },
+                                          { "inite"_n, get_public_key( "inite"_n, "active" ) },
+                                          { "initf"_n, get_public_key( "initf"_n, "active" ) },
+                                          { "initg"_n, get_public_key( "initg"_n, "active" ) },
+                                          { "inith"_n, get_public_key( "inith"_n, "active" ) },
+                                          { "initi"_n, get_public_key( "initi"_n, "active" ) },
+                                          { "initj"_n, get_public_key( "initj"_n, "active" ) },
+                                          { "initk"_n, get_public_key( "initk"_n, "active" ) },
+                                          { "initl"_n, get_public_key( "initl"_n, "active" ) },
+                                          { "initm"_n, get_public_key( "initm"_n, "active" ) },
+                                          { "initn"_n, get_public_key( "initn"_n, "active" ) },
+                                          { "inito"_n, get_public_key( "inito"_n, "active" ) },
+                                          { "initp"_n, get_public_key( "initp"_n, "active" ) },
+                                          { "initq"_n, get_public_key( "initq"_n, "active" ) },
+                                          { "initr"_n, get_public_key( "initr"_n, "active" ) },
+                                          { "inits"_n, get_public_key( "inits"_n, "active" ) },
+                                          { "initt"_n, get_public_key( "initt"_n, "active" ) },
+                                          { "initu"_n, get_public_key( "initu"_n, "active" ) }
                                        };
       vector<char> data = fc::raw::pack(uint32_t(0));
       vector<char> keys = fc::raw::pack(prod_keys);
@@ -2283,9 +2274,9 @@ BOOST_FIXTURE_TEST_CASE(privileged_tests, tester) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(datastream_tests, TESTER) { try {
    produce_blocks(1000);
-   create_account(N(testapi) );
+   create_account("testapi"_n );
    produce_blocks(1000);
-   set_code(N(testapi), contracts::test_api_wasm() );
+   set_code("testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1000);
 
    CALL_TEST_FUNCTION( *this, "test_datastream", "test_basic", {} );
@@ -2298,16 +2289,16 @@ BOOST_FIXTURE_TEST_CASE(datastream_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
    produce_block();
-   create_accounts( {N(testapi), N(alice), N(bob)} );
+   create_accounts( {"testapi"_n, "alice"_n, "bob"_n} );
    produce_block();
-   set_code(N(testapi), contracts::test_api_wasm() );
+   set_code("testapi"_n, contracts::test_api_wasm() );
    produce_block();
 
-   push_reqauth( N(alice), {{N(alice), config::active_name}}, {get_private_key(N(alice), "active")} );
+   push_reqauth( "alice"_n, {{"alice"_n, config::active_name}}, {get_private_key("alice"_n, "active")} );
 
    CALL_TEST_FUNCTION( *this, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
-                           N(alice), config::active_name,
+                           "alice"_n, config::active_name,
                            control->pending_block_time()
                        })
    );
@@ -2315,16 +2306,16 @@ BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
    // Fails because the last used time is updated after the transaction executes.
    BOOST_CHECK_THROW( CALL_TEST_FUNCTION( *this, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
-                                       N(testapi), config::active_name,
+                                       "testapi"_n, config::active_name,
                                        control->head_block_time() + fc::milliseconds(config::block_interval_ms)
                                      })
    ), eosio_assert_message_exception );
 
    produce_blocks(5);
 
-   set_authority( N(bob), N(perm1), authority( get_private_key(N(bob), "perm1").get_public_key() ) );
+   set_authority( "bob"_n, "perm1"_n, authority( get_private_key("bob"_n, "perm1").get_public_key() ) );
 
-   push_action(config::system_account_name, linkauth::get_name(), N(bob), fc::mutable_variant_object()
+   push_action(config::system_account_name, linkauth::get_name(), "bob"_n, fc::mutable_variant_object()
            ("account", "bob")
            ("code", "eosio")
            ("type", "reqauth")
@@ -2337,34 +2328,34 @@ BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
 
    CALL_TEST_FUNCTION( *this, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
-                                       N(bob), N(perm1),
+                                       "bob"_n, "perm1"_n,
                                        permission_creation_time
                                      })
    );
 
    produce_blocks(5);
 
-   push_reqauth( N(bob), {{N(bob), N(perm1)}}, {get_private_key(N(bob), "perm1")} );
+   push_reqauth( "bob"_n, {{"bob"_n, "perm1"_n}}, {get_private_key("bob"_n, "perm1")} );
 
    auto perm1_last_used_time = control->pending_block_time();
 
    CALL_TEST_FUNCTION( *this, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
-                                       N(bob), config::active_name,
+                                       "bob"_n, config::active_name,
                                        permission_creation_time
                                      })
    );
 
    BOOST_CHECK_THROW( CALL_TEST_FUNCTION( *this, "test_permission", "test_permission_last_used",
                                           fc::raw::pack(test_permission_last_used_action{
-                                                            N(bob), N(perm1),
+                                                            "bob"_n, "perm1"_n,
                                                             permission_creation_time
                                           })
    ), eosio_assert_message_exception );
 
    CALL_TEST_FUNCTION( *this, "test_permission", "test_permission_last_used",
                        fc::raw::pack(test_permission_last_used_action{
-                                       N(bob), N(perm1),
+                                       "bob"_n, "perm1"_n,
                                        perm1_last_used_time
                                      })
    );
@@ -2379,19 +2370,19 @@ BOOST_FIXTURE_TEST_CASE(permission_usage_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(account_creation_time_tests, TESTER) { try {
    produce_block();
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
    produce_block();
-   set_code(N(testapi), contracts::test_api_wasm() );
+   set_code("testapi"_n, contracts::test_api_wasm() );
    produce_block();
 
-   create_account( N(alice) );
+   create_account( "alice"_n );
    auto alice_creation_time = control->pending_block_time();
 
    produce_blocks(10);
 
    CALL_TEST_FUNCTION( *this, "test_permission", "test_account_creation_time",
                        fc::raw::pack(test_permission_last_used_action{
-                           N(alice), config::active_name,
+                           "alice"_n, config::active_name,
                            alice_creation_time
                        })
    );
@@ -2406,9 +2397,9 @@ BOOST_FIXTURE_TEST_CASE(account_creation_time_tests, TESTER) { try {
  *************************************************************************************/
 BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
    produce_block();
-   create_account( N(testapi) );
+   create_account( "testapi"_n );
    produce_block();
-   set_code(N(testapi), contracts::test_api_wasm() );
+   set_code("testapi"_n, contracts::test_api_wasm() );
 
    const char* abi_string = R"=====(
 {
@@ -2426,7 +2417,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 }
 )=====";
 
-   set_abi( N(testapi), abi_string );
+   set_abi( "testapi"_n, abi_string );
 
    auto var = fc::json::from_string(abi_string);
    abi_serializer abis(var.as<abi_def>(), abi_serializer::create_yield_function( abi_serializer_max_time ));
@@ -2486,20 +2477,20 @@ BOOST_FIXTURE_TEST_CASE(eosio_assert_code_tests, TESTER) { try {
 BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
 
    produce_blocks(1);
-   create_account(N(testapi) );
-   set_code( N(testapi), contracts::test_api_wasm() );
+   create_account("testapi"_n );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(bob) );
-   set_code( N(bob), contracts::test_api_wasm() );
+   create_account("bob"_n );
+   set_code( "bob"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(charlie) );
-   set_code( N(charlie), contracts::test_api_wasm() );
+   create_account("charlie"_n );
+   set_code( "charlie"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(david) );
-   set_code( N(david), contracts::test_api_wasm() );
+   create_account("david"_n );
+   set_code( "david"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(erin) );
-   set_code( N(erin), contracts::test_api_wasm() );
+   create_account("erin"_n );
+   set_code( "erin"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
    // prove act digest
@@ -2533,7 +2524,7 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    };
 
    transaction_trace_ptr txn_trace = CALL_TEST_FUNCTION_SCOPE( *this, "test_action", "test_action_ordinal1",
-      {}, vector<account_name>{ N(testapi)});
+      {}, vector<account_name>{ "testapi"_n});
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 
@@ -2544,8 +2535,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<unsigned_int>(atrace[0].return_value), unsigned_int(1) );
@@ -2555,8 +2546,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[1].return_value), "bob" );
@@ -2566,8 +2557,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<name>(atrace[2].return_value), name("five") );
@@ -2577,8 +2568,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[3].action_ordinal, 4);
    BOOST_REQUIRE_EQUAL((int)atrace[3].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[3].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[3].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[3].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[3].act.name, TEST_METHOD("test_action", "test_action_ordinal3"));
    BOOST_REQUIRE_EQUAL(atrace[3].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<unsigned_int>(atrace[3].return_value), unsigned_int(9) );
@@ -2588,8 +2579,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[4].action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[4].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[4].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[4].receiver, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[4].receiver, "charlie"_n);
+   BOOST_REQUIRE_EQUAL(atrace[4].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[4].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[4].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[4].return_value), "charlie" );
@@ -2599,8 +2590,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[5].action_ordinal, 6);
    BOOST_REQUIRE_EQUAL((int)atrace[5].creator_action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[5].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[5].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.account, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[5].act.account, "bob"_n);
    BOOST_REQUIRE_EQUAL(atrace[5].act.name, TEST_METHOD("test_action", "test_action_ordinal_foo"));
    BOOST_REQUIRE_EQUAL(atrace[5].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<double>(atrace[5].return_value), 13.23 );
@@ -2610,8 +2601,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[6].action_ordinal, 7);
    BOOST_REQUIRE_EQUAL((int)atrace[6].creator_action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[6].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[6].receiver, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[6].receiver, "david"_n);
+   BOOST_REQUIRE_EQUAL(atrace[6].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[6].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[6].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[6].return_value), "david" );
@@ -2621,8 +2612,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[7].action_ordinal, 8);
    BOOST_REQUIRE_EQUAL((int)atrace[7].creator_action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[7].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[7].receiver, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.account, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].receiver, "charlie"_n);
+   BOOST_REQUIRE_EQUAL(atrace[7].act.account, "charlie"_n);
    BOOST_REQUIRE_EQUAL(atrace[7].act.name, TEST_METHOD("test_action", "test_action_ordinal_bar"));
    BOOST_REQUIRE_EQUAL(atrace[7].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<float>(atrace[7].return_value), 11.42f );
@@ -2632,8 +2623,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[8].action_ordinal, 9);
    BOOST_REQUIRE_EQUAL((int)atrace[8].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[8].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[8].receiver, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[8].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[8].receiver, "david"_n);
+   BOOST_REQUIRE_EQUAL(atrace[8].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[8].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[8].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<bool>(atrace[8].return_value), true );
@@ -2643,8 +2634,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[9].action_ordinal, 10);
    BOOST_REQUIRE_EQUAL((int)atrace[9].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[9].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[9].receiver, N(erin));
-   BOOST_REQUIRE_EQUAL(atrace[9].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[9].receiver, "erin"_n);
+   BOOST_REQUIRE_EQUAL(atrace[9].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[9].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[9].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<signed_int>(atrace[9].return_value), signed_int(7) );
@@ -2654,8 +2645,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[10].action_ordinal, 11);
    BOOST_REQUIRE_EQUAL((int)atrace[10].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[10].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[10].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[10].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[10].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[10].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[10].act.name, TEST_METHOD("test_action", "test_action_ordinal4"));
    BOOST_REQUIRE_EQUAL(atrace[10].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[10].return_value.size(), 0 );
@@ -2669,23 +2660,23 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_test, TESTER) { try {
 BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
 
    produce_blocks(1);
-   create_account(N(testapi) );
-   set_code( N(testapi), contracts::test_api_wasm() );
+   create_account("testapi"_n );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(bob) );
-   set_code( N(bob), contracts::test_api_wasm() );
+   create_account("bob"_n );
+   set_code( "bob"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(charlie) );
-   set_code( N(charlie), contracts::test_api_wasm() );
+   create_account("charlie"_n );
+   set_code( "charlie"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(david) );
-   set_code( N(david), contracts::test_api_wasm() );
+   create_account("david"_n );
+   set_code( "david"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(erin) );
-   set_code( N(erin), contracts::test_api_wasm() );
+   create_account("erin"_n );
+   set_code( "erin"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
-   create_account(N(fail1) ); // <- make first action fails in the middle
+   create_account("fail1"_n ); // <- make first action fails in the middle
    produce_blocks(1);
 
    transaction_trace_ptr txn_trace =
@@ -2702,8 +2693,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[0].except.valid(), true);
@@ -2713,8 +2704,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[1].except.valid(), false);
@@ -2723,8 +2714,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[2].except.valid(), false);
@@ -2737,23 +2728,23 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest1, TESTER) { try {
 BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
 
    produce_blocks(1);
-   create_account(N(testapi) );
-   set_code( N(testapi), contracts::test_api_wasm() );
+   create_account("testapi"_n );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(bob) );
-   set_code( N(bob), contracts::test_api_wasm() );
+   create_account("bob"_n );
+   set_code( "bob"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(charlie) );
-   set_code( N(charlie), contracts::test_api_wasm() );
+   create_account("charlie"_n );
+   set_code( "charlie"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(david) );
-   set_code( N(david), contracts::test_api_wasm() );
+   create_account("david"_n );
+   set_code( "david"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(erin) );
-   set_code( N(erin), contracts::test_api_wasm() );
+   create_account("erin"_n );
+   set_code( "erin"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
-   create_account(N(fail3) ); // <- make action 3 fails in the middle
+   create_account("fail3"_n ); // <- make action 3 fails in the middle
    produce_blocks(1);
 
    transaction_trace_ptr txn_trace =
@@ -2770,8 +2761,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<unsigned_int>(atrace[0].return_value), unsigned_int(1) );
@@ -2782,8 +2773,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[1].return_value), "bob" );
@@ -2793,8 +2784,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[2].except.valid(), false);
@@ -2803,8 +2794,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[3].action_ordinal, 4);
    BOOST_REQUIRE_EQUAL((int)atrace[3].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[3].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[3].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[3].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[3].act.name, TEST_METHOD("test_action", "test_action_ordinal3"));
    BOOST_REQUIRE_EQUAL(atrace[3].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[3].except.valid(), false);
@@ -2813,8 +2804,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[4].action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[4].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[4].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[4].receiver, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[4].receiver, "charlie"_n);
+   BOOST_REQUIRE_EQUAL(atrace[4].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[4].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[4].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[4].except.valid(), true);
@@ -2824,8 +2815,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[5].action_ordinal, 6);
    BOOST_REQUIRE_EQUAL((int)atrace[5].creator_action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[5].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[5].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.account, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[5].act.account, "bob"_n);
    BOOST_REQUIRE_EQUAL(atrace[5].act.name, TEST_METHOD("test_action", "test_action_ordinal_foo"));
    BOOST_REQUIRE_EQUAL(atrace[5].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[5].except.valid(), false);
@@ -2834,8 +2825,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[6].action_ordinal, 7);
    BOOST_REQUIRE_EQUAL((int)atrace[6].creator_action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[6].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[6].receiver, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[6].receiver, "david"_n);
+   BOOST_REQUIRE_EQUAL(atrace[6].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[6].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[6].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[6].except.valid(), false);
@@ -2844,8 +2835,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[7].action_ordinal, 8);
    BOOST_REQUIRE_EQUAL((int)atrace[7].creator_action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[7].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[7].receiver, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.account, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].receiver, "charlie"_n);
+   BOOST_REQUIRE_EQUAL(atrace[7].act.account, "charlie"_n);
    BOOST_REQUIRE_EQUAL(atrace[7].act.name, TEST_METHOD("test_action", "test_action_ordinal_bar"));
    BOOST_REQUIRE_EQUAL(atrace[7].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[7].except.valid(), false);
@@ -2858,23 +2849,23 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest2, TESTER) { try {
 BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
 
    produce_blocks(1);
-   create_account(N(testapi) );
-   set_code( N(testapi), contracts::test_api_wasm() );
+   create_account("testapi"_n );
+   set_code( "testapi"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(bob) );
-   set_code( N(bob), contracts::test_api_wasm() );
+   create_account("bob"_n );
+   set_code( "bob"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(charlie) );
-   set_code( N(charlie), contracts::test_api_wasm() );
+   create_account("charlie"_n );
+   set_code( "charlie"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(david) );
-   set_code( N(david), contracts::test_api_wasm() );
+   create_account("david"_n );
+   set_code( "david"_n, contracts::test_api_wasm() );
    produce_blocks(1);
-   create_account(N(erin) );
-   set_code( N(erin), contracts::test_api_wasm() );
+   create_account("erin"_n );
+   set_code( "erin"_n, contracts::test_api_wasm() );
    produce_blocks(1);
 
-   create_account(N(failnine) ); // <- make action 9 fails in the middle
+   create_account("failnine"_n ); // <- make action 9 fails in the middle
    produce_blocks(1);
 
    transaction_trace_ptr txn_trace =
@@ -2891,8 +2882,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[0].action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[0].creator_action_ordinal, 0);
    BOOST_REQUIRE_EQUAL((int)atrace[0].closest_unnotified_ancestor_action_ordinal, 0);
-   BOOST_REQUIRE_EQUAL(atrace[0].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[0].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[0].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[0].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[0].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[0].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<unsigned_int>(atrace[0].return_value), unsigned_int(1) );
@@ -2903,8 +2894,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[1].action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[1].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[1].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[1].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[1].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[1].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[1].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[1].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[1].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[1].return_value), "bob" );
@@ -2914,8 +2905,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[2].action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[2].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[2].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[2].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[2].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[2].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[2].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[2].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[2].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<name>(atrace[2].return_value), name("five") );
@@ -2925,8 +2916,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[3].action_ordinal, 4);
    BOOST_REQUIRE_EQUAL((int)atrace[3].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[3].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[3].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[3].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[3].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[3].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[3].act.name, TEST_METHOD("test_action", "test_action_ordinal3"));
    BOOST_REQUIRE_EQUAL(atrace[3].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[3].except.valid(), true);
@@ -2936,8 +2927,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[4].action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[4].creator_action_ordinal, 1);
    BOOST_REQUIRE_EQUAL((int)atrace[4].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[4].receiver, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[4].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[4].receiver, "charlie"_n);
+   BOOST_REQUIRE_EQUAL(atrace[4].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[4].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[4].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[4].return_value), "charlie" );
@@ -2947,8 +2938,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[5].action_ordinal, 6);
    BOOST_REQUIRE_EQUAL((int)atrace[5].creator_action_ordinal, 2);
    BOOST_REQUIRE_EQUAL((int)atrace[5].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[5].receiver, N(bob));
-   BOOST_REQUIRE_EQUAL(atrace[5].act.account, N(bob));
+   BOOST_REQUIRE_EQUAL(atrace[5].receiver, "bob"_n);
+   BOOST_REQUIRE_EQUAL(atrace[5].act.account, "bob"_n);
    BOOST_REQUIRE_EQUAL(atrace[5].act.name, TEST_METHOD("test_action", "test_action_ordinal_foo"));
    BOOST_REQUIRE_EQUAL(atrace[5].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[5].except.valid(), false);
@@ -2957,8 +2948,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[6].action_ordinal, 7);
    BOOST_REQUIRE_EQUAL((int)atrace[6].creator_action_ordinal,2);
    BOOST_REQUIRE_EQUAL((int)atrace[6].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[6].receiver, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[6].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[6].receiver, "david"_n);
+   BOOST_REQUIRE_EQUAL(atrace[6].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[6].act.name, TEST_METHOD("test_action", "test_action_ordinal1"));
    BOOST_REQUIRE_EQUAL(atrace[6].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<std::string>(atrace[6].return_value), "david" );
@@ -2968,8 +2959,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[7].action_ordinal, 8);
    BOOST_REQUIRE_EQUAL((int)atrace[7].creator_action_ordinal, 5);
    BOOST_REQUIRE_EQUAL((int)atrace[7].closest_unnotified_ancestor_action_ordinal, 1);
-   BOOST_REQUIRE_EQUAL(atrace[7].receiver, N(charlie));
-   BOOST_REQUIRE_EQUAL(atrace[7].act.account, N(charlie));
+   BOOST_REQUIRE_EQUAL(atrace[7].receiver, "charlie"_n);
+   BOOST_REQUIRE_EQUAL(atrace[7].act.account, "charlie"_n);
    BOOST_REQUIRE_EQUAL(atrace[7].act.name, TEST_METHOD("test_action", "test_action_ordinal_bar"));
    BOOST_REQUIRE_EQUAL(atrace[7].receipt.valid(), false);
    BOOST_REQUIRE_EQUAL(atrace[7].except.valid(), false);
@@ -2978,8 +2969,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[8].action_ordinal, 9);
    BOOST_REQUIRE_EQUAL((int)atrace[8].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[8].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[8].receiver, N(david));
-   BOOST_REQUIRE_EQUAL(atrace[8].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[8].receiver, "david"_n);
+   BOOST_REQUIRE_EQUAL(atrace[8].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[8].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[8].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<bool>(atrace[8].return_value), true );
@@ -2989,8 +2980,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[9].action_ordinal, 10);
    BOOST_REQUIRE_EQUAL((int)atrace[9].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[9].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[9].receiver, N(erin));
-   BOOST_REQUIRE_EQUAL(atrace[9].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[9].receiver, "erin"_n);
+   BOOST_REQUIRE_EQUAL(atrace[9].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[9].act.name, TEST_METHOD("test_action", "test_action_ordinal2"));
    BOOST_REQUIRE_EQUAL(atrace[9].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(fc::raw::unpack<signed_int>(atrace[9].return_value), signed_int(7) );
@@ -3000,8 +2991,8 @@ BOOST_FIXTURE_TEST_CASE(action_ordinal_failtest3, TESTER) { try {
    BOOST_REQUIRE_EQUAL((int)atrace[10].action_ordinal, 11);
    BOOST_REQUIRE_EQUAL((int)atrace[10].creator_action_ordinal, 3);
    BOOST_REQUIRE_EQUAL((int)atrace[10].closest_unnotified_ancestor_action_ordinal, 3);
-   BOOST_REQUIRE_EQUAL(atrace[10].receiver, N(testapi));
-   BOOST_REQUIRE_EQUAL(atrace[10].act.account, N(testapi));
+   BOOST_REQUIRE_EQUAL(atrace[10].receiver, "testapi"_n);
+   BOOST_REQUIRE_EQUAL(atrace[10].act.account, "testapi"_n);
    BOOST_REQUIRE_EQUAL(atrace[10].act.name, TEST_METHOD("test_action", "test_action_ordinal4"));
    BOOST_REQUIRE_EQUAL(atrace[10].receipt.valid(), true);
    BOOST_REQUIRE_EQUAL(atrace[10].return_value.size(), 0 );

--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -22,11 +22,11 @@ using namespace eosio::testing;
 BOOST_AUTO_TEST_SUITE(auth_tests)
 
 BOOST_FIXTURE_TEST_CASE( missing_sigs, TESTER ) { try {
-   create_accounts( {N(alice)} );
+   create_accounts( {"alice"_n} );
    produce_block();
 
-   BOOST_REQUIRE_THROW( push_reqauth( N(alice), {permission_level{N(alice), config::active_name}}, {} ), unsatisfied_authorization );
-   auto trace = push_reqauth(N(alice), "owner");
+   BOOST_REQUIRE_THROW( push_reqauth( "alice"_n, {permission_level{"alice"_n, config::active_name}}, {} ), unsatisfied_authorization );
+   auto trace = push_reqauth("alice"_n, "owner");
 
    produce_block();
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trace->id));
@@ -35,11 +35,11 @@ BOOST_FIXTURE_TEST_CASE( missing_sigs, TESTER ) { try {
 
 BOOST_FIXTURE_TEST_CASE( missing_multi_sigs, TESTER ) { try {
     produce_block();
-    create_account(N(alice), config::system_account_name, true);
+    create_account("alice"_n, config::system_account_name, true);
     produce_block();
 
-    BOOST_REQUIRE_THROW(push_reqauth(N(alice), "owner"), unsatisfied_authorization); // without multisig
-    auto trace = push_reqauth(N(alice), "owner", true); // with multisig
+    BOOST_REQUIRE_THROW(push_reqauth("alice"_n, "owner"), unsatisfied_authorization); // without multisig
+    auto trace = push_reqauth("alice"_n, "owner", true); // with multisig
 
     produce_block();
     BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trace->id));
@@ -47,11 +47,11 @@ BOOST_FIXTURE_TEST_CASE( missing_multi_sigs, TESTER ) { try {
  } FC_LOG_AND_RETHROW() } /// missing_multi_sigs
 
 BOOST_FIXTURE_TEST_CASE( missing_auths, TESTER ) { try {
-   create_accounts( {N(alice), N(bob)} );
+   create_accounts( {"alice"_n, "bob"_n} );
    produce_block();
 
    /// action not provided from authority
-   BOOST_REQUIRE_THROW( push_reqauth( N(alice), {permission_level{N(bob), config::active_name}}, { get_private_key(N(bob), "active") } ), missing_auth_exception);
+   BOOST_REQUIRE_THROW( push_reqauth( "alice"_n, {permission_level{"bob"_n, config::active_name}}, { get_private_key("bob"_n, "active") } ), missing_auth_exception);
 
 } FC_LOG_AND_RETHROW() } /// transfer_test
 
@@ -60,32 +60,32 @@ BOOST_FIXTURE_TEST_CASE( missing_auths, TESTER ) { try {
  *  of another account by updating the active authority.
  */
 BOOST_FIXTURE_TEST_CASE( delegate_auth, TESTER ) { try {
-   create_accounts( {N(alice),N(bob)});
+   create_accounts( {"alice"_n,"bob"_n});
    produce_block();
 
    auto delegated_auth = authority( 1, {},
                           {
-                            { .permission = {N(bob),config::active_name}, .weight = 1}
+                            { .permission = {"bob"_n,config::active_name}, .weight = 1}
                           });
 
-   auto original_auth = static_cast<authority>(control->get_authorization_manager().get_permission({N(alice), config::active_name}).auth);
+   auto original_auth = static_cast<authority>(control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth);
    wdump((original_auth));
 
-   set_authority( N(alice), config::active_name,  delegated_auth );
+   set_authority( "alice"_n, config::active_name,  delegated_auth );
 
-   auto new_auth = static_cast<authority>(control->get_authorization_manager().get_permission({N(alice), config::active_name}).auth);
+   auto new_auth = static_cast<authority>(control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth);
    wdump((new_auth));
    BOOST_CHECK_EQUAL((new_auth == delegated_auth), true);
 
    produce_block();
    produce_block();
 
-   auto auth = static_cast<authority>(control->get_authorization_manager().get_permission({N(alice), config::active_name}).auth);
+   auto auth = static_cast<authority>(control->get_authorization_manager().get_permission({"alice"_n, config::active_name}).auth);
    wdump((auth));
    BOOST_CHECK_EQUAL((new_auth == auth), true);
 
    /// execute nonce from alice signed by bob
-   auto trace = push_reqauth(N(alice), {permission_level{N(alice), config::active_name}}, { get_private_key(N(bob), "active") } );
+   auto trace = push_reqauth("alice"_n, {permission_level{"alice"_n, config::active_name}}, { get_private_key("bob"_n, "active") } );
 
    produce_block();
    //todoBOOST_REQUIRE_EQUAL(true, chain_has_transaction(trace->id));
@@ -240,11 +240,11 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
    chain.set_authority(name("alice"), name("scud"), scud_pub_key, name("spending"));
 
    // Send req auth action with alice's spending key, it should fail
-   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
    // Link authority for eosio reqauth action with alice's spending key
    chain.link_authority(name("alice"), name("eosio"), name("spending"), name("reqauth"));
    // Now, req auth action with alice's spending key should succeed
-   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key });
 
    chain.produce_block();
 
@@ -254,18 +254,18 @@ BOOST_AUTO_TEST_CASE(link_auths) { try {
    // Unlink alice with eosio reqauth
    chain.unlink_authority(name("alice"), name("eosio"), name("reqauth"));
    // Now, req auth action with alice's spending key should fail
-   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key }), irrelevant_auth_exception);
 
    chain.produce_block();
 
    // Send req auth action with scud key, it should fail
-   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("scud")} }, { scud_priv_key }), irrelevant_auth_exception);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("scud")} }, { scud_priv_key }), irrelevant_auth_exception);
    // Link authority for any eosio action with alice's scud key
    chain.link_authority(name("alice"), name("eosio"), name("scud"));
    // Now, req auth action with alice's scud key should succeed
-   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("scud")} }, { scud_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("scud")} }, { scud_priv_key });
    // req auth action with alice's spending key should also be fine, since it is the parent of alice's scud key
-   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key });
 
 } FC_LOG_AND_RETHROW() }
 
@@ -282,16 +282,16 @@ BOOST_AUTO_TEST_CASE(link_then_update_auth) { try {
    chain.set_authority(name("alice"), name("first"), first_pub_key, name("active"));
 
    chain.link_authority(name("alice"), name("eosio"), name("first"), name("reqauth"));
-   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("first")} }, { first_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("first")} }, { first_priv_key });
 
    chain.produce_blocks(13); // Wait at least 6 seconds for first push_reqauth transaction to expire.
 
    // Update "first" auth public key
    chain.set_authority(name("alice"), name("first"), second_pub_key, name("active"));
    // Authority updated, using previous "first" auth should fail on linked auth
-   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{N(alice), name("first")} }, { first_priv_key }), unsatisfied_authorization);
+   BOOST_CHECK_THROW(chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("first")} }, { first_priv_key }), unsatisfied_authorization);
    // Using updated authority, should succeed
-   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("first")} }, { second_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("first")} }, { second_priv_key });
 
 } FC_LOG_AND_RETHROW() }
 
@@ -348,21 +348,21 @@ BOOST_AUTO_TEST_CASE( any_auth ) { try {
    chain.set_authority(name("bob"), name("spending"), bob_spending_pub_key, name("active"));
 
    /// this should fail because spending is not active which is default for reqauth
-   BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key }),
+   BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key }),
                         irrelevant_auth_exception );
 
    chain.produce_block();
 
-   //test.push_reqauth( N(alice), { permission_level{N(alice),"spending"} }, { spending_priv_key });
+   //test.push_reqauth( "alice"_n, { permission_level{"alice"_n,"spending"} }, { spending_priv_key });
 
    chain.link_authority( name("alice"), name("eosio"), name("eosio.any"), name("reqauth") );
    chain.link_authority( name("bob"), name("eosio"), name("eosio.any"), name("reqauth") );
 
    /// this should succeed because eosio::reqauth is linked to any permission
-   chain.push_reqauth(name("alice"), { permission_level{N(alice), name("spending")} }, { spending_priv_key });
+   chain.push_reqauth(name("alice"), { permission_level{"alice"_n, name("spending")} }, { spending_priv_key });
 
    /// this should fail because bob cannot authorize for alice, the permission given must be one-of alices
-   BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{N(bob), name("spending")} }, { spending_priv_key }),
+   BOOST_REQUIRE_THROW( chain.push_reqauth(name("alice"), { permission_level{"bob"_n, name("spending")} }, { spending_priv_key }),
                         missing_auth_exception );
 
 
@@ -378,9 +378,9 @@ try {
 
    chain.produce_block();
 
-   account_name acc1 = N("bill1");
-   account_name acc2 = N("bill2");
-   account_name acc1a = N("bill1a");
+   account_name acc1 = "bill1"_n;
+   account_name acc2 = "bill2"_n;
+   account_name acc1a = "bill1a"_n;
 
    chain.create_account(acc1);
    chain.create_account(acc1a);
@@ -436,10 +436,10 @@ try {
 
    chain.produce_block();
 
-   account_name acc1 = N("acc1");
-   account_name acc2 = N("acc2");
-   account_name acc3 = N("acc3");
-   account_name acc4 = N("acc4");
+   account_name acc1 = "acc1"_n;
+   account_name acc2 = "acc2"_n;
+   account_name acc3 = "acc3"_n;
+   account_name acc4 = "acc4"_n;
 
    chain.create_account(acc1);
    chain.produce_block();
@@ -483,15 +483,15 @@ try {
 BOOST_AUTO_TEST_CASE( linkauth_special ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
    std::vector<transaction_id_type> ids;
 
    chain.produce_blocks();
-   chain.create_account(N(currency));
+   chain.create_account("currency"_n);
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks();
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()

--- a/unittests/block_tests.cpp
+++ b/unittests/block_tests.cpp
@@ -12,7 +12,7 @@ BOOST_AUTO_TEST_CASE(block_with_invalid_tx_test)
    tester main;
 
    // First we create a valid block with valid transaction
-   main.create_account(N(newacc));
+   main.create_account("newacc"_n);
    auto b = main.produce_block();
 
    // Make a copy of the valid block and corrupt the transaction
@@ -88,14 +88,14 @@ std::pair<signed_block_ptr, signed_block_ptr> corrupt_trx_in_block(validating_te
 // verify that a block with a transaction with an incorrect signature, is blindly accepted from a trusted producer
 BOOST_AUTO_TEST_CASE(trusted_producer_test)
 {
-   flat_set<account_name> trusted_producers = { N(defproducera), N(defproducerc) };
+   flat_set<account_name> trusted_producers = { "defproducera"_n, "defproducerc"_n };
    validating_tester main(trusted_producers);
    // only using validating_tester to keep the 2 chains in sync, not to validate that the validating_node matches the main node,
    // since it won't be
    main.skip_validate = true;
 
    // First we create a valid block with valid transaction
-   std::set<account_name> producers = { N(defproducera), N(defproducerb), N(defproducerc), N(defproducerd) };
+   std::set<account_name> producers = { "defproducera"_n, "defproducerb"_n, "defproducerc"_n, "defproducerd"_n };
    for (auto prod : producers)
        main.create_account(prod);
    auto b = main.produce_block();
@@ -103,25 +103,25 @@ BOOST_AUTO_TEST_CASE(trusted_producer_test)
    std::vector<account_name> schedule(producers.cbegin(), producers.cend());
    auto trace = main.set_producers(schedule);
 
-   while (b->producer != N(defproducera)) {
+   while (b->producer != "defproducera"_n) {
       b = main.produce_block();
    }
 
-   auto blocks = corrupt_trx_in_block(main, N(tstproducera));
+   auto blocks = corrupt_trx_in_block(main, "tstproducera"_n);
    main.validate_push_block( blocks.second );
 }
 
 // like trusted_producer_test, except verify that any entry in the trusted_producer list is accepted
 BOOST_AUTO_TEST_CASE(trusted_producer_verify_2nd_test)
 {
-   flat_set<account_name> trusted_producers = { N(defproducera), N(defproducerc) };
+   flat_set<account_name> trusted_producers = { "defproducera"_n, "defproducerc"_n };
    validating_tester main(trusted_producers);
    // only using validating_tester to keep the 2 chains in sync, not to validate that the validating_node matches the main node,
    // since it won't be
    main.skip_validate = true;
 
    // First we create a valid block with valid transaction
-   std::set<account_name> producers = { N(defproducera), N(defproducerb), N(defproducerc), N(defproducerd) };
+   std::set<account_name> producers = { "defproducera"_n, "defproducerb"_n, "defproducerc"_n, "defproducerd"_n };
    for (auto prod : producers)
        main.create_account(prod);
    auto b = main.produce_block();
@@ -129,25 +129,25 @@ BOOST_AUTO_TEST_CASE(trusted_producer_verify_2nd_test)
    std::vector<account_name> schedule(producers.cbegin(), producers.cend());
    auto trace = main.set_producers(schedule);
 
-   while (b->producer != N(defproducerc)) {
+   while (b->producer != "defproducerc"_n) {
       b = main.produce_block();
    }
 
-   auto blocks = corrupt_trx_in_block(main, N(tstproducera));
+   auto blocks = corrupt_trx_in_block(main, "tstproducera"_n);
    main.validate_push_block( blocks.second );
 }
 
 // verify that a block with a transaction with an incorrect signature, is rejected if it is not from a trusted producer
 BOOST_AUTO_TEST_CASE(untrusted_producer_test)
 {
-   flat_set<account_name> trusted_producers = { N(defproducera), N(defproducerc) };
+   flat_set<account_name> trusted_producers = { "defproducera"_n, "defproducerc"_n };
    validating_tester main(trusted_producers);
    // only using validating_tester to keep the 2 chains in sync, not to validate that the validating_node matches the main node,
    // since it won't be
    main.skip_validate = true;
 
    // First we create a valid block with valid transaction
-   std::set<account_name> producers = { N(defproducera), N(defproducerb), N(defproducerc), N(defproducerd) };
+   std::set<account_name> producers = { "defproducera"_n, "defproducerb"_n, "defproducerc"_n, "defproducerd"_n };
    for (auto prod : producers)
        main.create_account(prod);
    auto b = main.produce_block();
@@ -155,11 +155,11 @@ BOOST_AUTO_TEST_CASE(untrusted_producer_test)
    std::vector<account_name> schedule(producers.cbegin(), producers.cend());
    auto trace = main.set_producers(schedule);
 
-   while (b->producer != N(defproducerb)) {
+   while (b->producer != "defproducerb"_n) {
       b = main.produce_block();
    }
 
-   auto blocks = corrupt_trx_in_block(main, N(tstproducera));
+   auto blocks = corrupt_trx_in_block(main, "tstproducera"_n);
    BOOST_REQUIRE_EXCEPTION(main.validate_push_block( blocks.second ), fc::exception ,
    [] (const fc::exception &e)->bool {
       return e.code() == unsatisfied_authorization::code_value ;
@@ -201,7 +201,7 @@ BOOST_FIXTURE_TEST_CASE( abort_block_transactions, validating_tester) { try {
       produce_blocks(2);
       signed_transaction trx;
 
-      account_name a = N(newco);
+      account_name a = "newco"_n;
       account_name creator = config::system_account_name;
 
       // account does not exist before test
@@ -248,7 +248,7 @@ BOOST_FIXTURE_TEST_CASE( abort_block_transactions_tester, validating_tester) { t
       produce_blocks(2);
       signed_transaction trx;
 
-      account_name a = N(newco);
+      account_name a = "newco"_n;
       account_name creator = config::system_account_name;
 
       // account does not exist before test

--- a/unittests/bootseq_tests.cpp
+++ b/unittests/bootseq_tests.cpp
@@ -29,38 +29,38 @@ struct genesis_account {
 };
 
 std::vector<genesis_account> test_genesis( {
-  {N(b1),       100'000'000'0000ll},
-  {N(whale4),    40'000'000'0000ll},
-  {N(whale3),    30'000'000'0000ll},
-  {N(whale2),    20'000'000'0000ll},
-  {N(proda),      1'000'000'0000ll},
-  {N(prodb),      1'000'000'0000ll},
-  {N(prodc),      1'000'000'0000ll},
-  {N(prodd),      1'000'000'0000ll},
-  {N(prode),      1'000'000'0000ll},
-  {N(prodf),      1'000'000'0000ll},
-  {N(prodg),      1'000'000'0000ll},
-  {N(prodh),      1'000'000'0000ll},
-  {N(prodi),      1'000'000'0000ll},
-  {N(prodj),      1'000'000'0000ll},
-  {N(prodk),      1'000'000'0000ll},
-  {N(prodl),      1'000'000'0000ll},
-  {N(prodm),      1'000'000'0000ll},
-  {N(prodn),      1'000'000'0000ll},
-  {N(prodo),      1'000'000'0000ll},
-  {N(prodp),      1'000'000'0000ll},
-  {N(prodq),      1'000'000'0000ll},
-  {N(prodr),      1'000'000'0000ll},
-  {N(prods),      1'000'000'0000ll},
-  {N(prodt),      1'000'000'0000ll},
-  {N(produ),      1'000'000'0000ll},
-  {N(runnerup1),  1'000'000'0000ll},
-  {N(runnerup2),  1'000'000'0000ll},
-  {N(runnerup3),  1'000'000'0000ll},
-  {N(minow1),           100'0000ll},
-  {N(minow2),             1'0000ll},
-  {N(minow3),             1'0000ll},
-  {N(masses),   800'000'000'0000ll}
+  {"b1"_n,       100'000'000'0000ll},
+  {"whale4"_n,    40'000'000'0000ll},
+  {"whale3"_n,    30'000'000'0000ll},
+  {"whale2"_n,    20'000'000'0000ll},
+  {"proda"_n,      1'000'000'0000ll},
+  {"prodb"_n,      1'000'000'0000ll},
+  {"prodc"_n,      1'000'000'0000ll},
+  {"prodd"_n,      1'000'000'0000ll},
+  {"prode"_n,      1'000'000'0000ll},
+  {"prodf"_n,      1'000'000'0000ll},
+  {"prodg"_n,      1'000'000'0000ll},
+  {"prodh"_n,      1'000'000'0000ll},
+  {"prodi"_n,      1'000'000'0000ll},
+  {"prodj"_n,      1'000'000'0000ll},
+  {"prodk"_n,      1'000'000'0000ll},
+  {"prodl"_n,      1'000'000'0000ll},
+  {"prodm"_n,      1'000'000'0000ll},
+  {"prodn"_n,      1'000'000'0000ll},
+  {"prodo"_n,      1'000'000'0000ll},
+  {"prodp"_n,      1'000'000'0000ll},
+  {"prodq"_n,      1'000'000'0000ll},
+  {"prodr"_n,      1'000'000'0000ll},
+  {"prods"_n,      1'000'000'0000ll},
+  {"prodt"_n,      1'000'000'0000ll},
+  {"produ"_n,      1'000'000'0000ll},
+  {"runnerup1"_n,  1'000'000'0000ll},
+  {"runnerup2"_n,  1'000'000'0000ll},
+  {"runnerup3"_n,  1'000'000'0000ll},
+  {"minow1"_n,           100'0000ll},
+  {"minow2"_n,             1'0000ll},
+  {"minow3"_n,             1'0000ll},
+  {"masses"_n,   800'000'000'0000ll}
 });
 
 class bootseq_tester : public TESTER {
@@ -69,7 +69,7 @@ public:
       set_code( config::system_account_name, contracts::eosio_system_wasm() );
       set_abi( config::system_account_name, contracts::eosio_system_abi().data() );
       if( call_init ) {
-         base_tester::push_action(config::system_account_name, N(init),
+         base_tester::push_action(config::system_account_name, "init"_n,
                                   config::system_account_name,  mutable_variant_object()
                                   ("version", 0)
                                   ("core", CORE_SYM_STR)
@@ -82,13 +82,13 @@ public:
    }
 
    fc::variant get_global_state() {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global), N(global) );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "global"_n, "global"_n );
       if (data.empty()) std::cout << "\nData is empty\n" << std::endl;
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
     auto buyram( name payer, name receiver, asset ram ) {
-       auto r = base_tester::push_action(config::system_account_name, N(buyram), payer, mvo()
+       auto r = base_tester::push_action(config::system_account_name, "buyram"_n, payer, mvo()
                     ("payer", payer)
                     ("receiver", receiver)
                     ("quant", ram)
@@ -98,7 +98,7 @@ public:
     }
 
     auto delegate_bandwidth( name from, name receiver, asset net, asset cpu, uint8_t transfer = 1) {
-       auto r = base_tester::push_action(config::system_account_name, N(delegatebw), from, mvo()
+       auto r = base_tester::push_action(config::system_account_name, "delegatebw"_n, from, mvo()
                     ("from", from )
                     ("receiver", receiver)
                     ("stake_net_quantity", net)
@@ -114,11 +114,11 @@ public:
                 ("issuer",       manager )
                 ("maximum_supply", maxsupply );
 
-        base_tester::push_action(contract, N(create), contract, act );
+        base_tester::push_action(contract, "create"_n, contract, act );
     }
 
     auto issue( name contract, name manager, name to, asset amount ) {
-       auto r = base_tester::push_action( contract, N(issue), manager, mutable_variant_object()
+       auto r = base_tester::push_action( contract, "issue"_n, manager, mutable_variant_object()
                 ("to",      to )
                 ("quantity", amount )
                 ("memo", "")
@@ -128,19 +128,19 @@ public:
     }
 
     auto claim_rewards( name owner ) {
-       auto r = base_tester::push_action( config::system_account_name, N(claimrewards), owner, mvo()("owner",  owner ));
+       auto r = base_tester::push_action( config::system_account_name, "claimrewards"_n, owner, mvo()("owner",  owner ));
        produce_block();
        return r;
     }
 
     auto set_privileged( name account ) {
-       auto r = base_tester::push_action(config::system_account_name, N(setpriv), config::system_account_name,  mvo()("account", account)("is_priv", 1));
+       auto r = base_tester::push_action(config::system_account_name, "setpriv"_n, config::system_account_name,  mvo()("account", account)("is_priv", 1));
        produce_block();
        return r;
     }
 
     auto register_producer(name producer) {
-       auto r = base_tester::push_action(config::system_account_name, N(regproducer), producer, mvo()
+       auto r = base_tester::push_action(config::system_account_name, "regproducer"_n, producer, mvo()
                        ("producer",  name(producer))
                        ("producer_key", get_public_key( producer, "active" ) )
                        ("url", "" )
@@ -152,7 +152,7 @@ public:
 
 
     auto undelegate_bandwidth( name from, name receiver, asset net, asset cpu ) {
-       auto r = base_tester::push_action(config::system_account_name, N(undelegatebw), from, mvo()
+       auto r = base_tester::push_action(config::system_account_name, "undelegatebw"_n, from, mvo()
                     ("from", from )
                     ("receiver", receiver)
                     ("unstake_net_quantity", net)
@@ -163,7 +163,7 @@ public:
     }
 
     asset get_balance( const account_name& act ) {
-         return get_currency_balance(N(eosio.token), symbol(CORE_SYMBOL), act);
+         return get_currency_balance("eosio.token"_n, symbol(CORE_SYMBOL), act);
     }
 
     void set_code_abi(const account_name& account, const vector<uint8_t>& wasm, const char* abi, const private_key_type* signer = nullptr) {
@@ -189,38 +189,38 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
     try {
 
         // Create eosio.msig and eosio.token
-        create_accounts({N(eosio.msig), N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake), N(eosio.vpay), N(eosio.bpay), N(eosio.saving) });
+        create_accounts({"eosio.msig"_n, "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n, "eosio.vpay"_n, "eosio.bpay"_n, "eosio.saving"_n });
         // Set code for the following accounts:
         //  - eosio (code: eosio.bios) (already set by tester constructor)
         //  - eosio.msig (code: eosio.msig)
         //  - eosio.token (code: eosio.token)
-        // set_code_abi(N(eosio.msig), contracts::eosio_msig_wasm(), contracts::eosio_msig_abi().data());//, &eosio_active_pk);
-        // set_code_abi(N(eosio.token), contracts::eosio_token_wasm(), contracts::eosio_token_abi().data()); //, &eosio_active_pk);
+        // set_code_abi("eosio.msig"_n, contracts::eosio_msig_wasm(), contracts::eosio_msig_abi().data());//, &eosio_active_pk);
+        // set_code_abi("eosio.token"_n, contracts::eosio_token_wasm(), contracts::eosio_token_abi().data()); //, &eosio_active_pk);
 
-        set_code_abi(N(eosio.msig),
+        set_code_abi("eosio.msig"_n,
                      contracts::eosio_msig_wasm(),
                      contracts::eosio_msig_abi().data());//, &eosio_active_pk);
-        set_code_abi(N(eosio.token),
+        set_code_abi("eosio.token"_n,
                      contracts::eosio_token_wasm(),
                      contracts::eosio_token_abi().data()); //, &eosio_active_pk);
 
         // Set privileged for eosio.msig and eosio.token
-        set_privileged(N(eosio.msig));
-        set_privileged(N(eosio.token));
+        set_privileged("eosio.msig"_n);
+        set_privileged("eosio.token"_n);
 
         // Verify eosio.msig and eosio.token is privileged
-        const auto& eosio_msig_acc = get<account_metadata_object, by_name>(N(eosio.msig));
+        const auto& eosio_msig_acc = get<account_metadata_object, by_name>("eosio.msig"_n);
         BOOST_TEST(eosio_msig_acc.is_privileged() == true);
-        const auto& eosio_token_acc = get<account_metadata_object, by_name>(N(eosio.token));
+        const auto& eosio_token_acc = get<account_metadata_object, by_name>("eosio.token"_n);
         BOOST_TEST(eosio_token_acc.is_privileged() == true);
 
 
         // Create SYS tokens in eosio.token, set its manager as eosio
         auto max_supply = core_from_string("10000000000.0000"); /// 1x larger than 1B initial tokens
         auto initial_supply = core_from_string("1000000000.0000"); /// 1x larger than 1B initial tokens
-        create_currency(N(eosio.token), config::system_account_name, max_supply);
+        create_currency("eosio.token"_n, config::system_account_name, max_supply);
         // Issue the genesis supply of 1 billion SYS tokens to eosio.system
-        issue(N(eosio.token), config::system_account_name, config::system_account_name, initial_supply);
+        issue("eosio.token"_n, config::system_account_name, config::system_account_name, initial_supply);
 
         auto actual = get_balance(config::system_account_name);
         BOOST_REQUIRE_EQUAL(initial_supply, actual);
@@ -242,15 +242,15 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
            auto r = buyram(config::system_account_name, a.aname, asset(ram));
            BOOST_REQUIRE( !r->except_ptr );
 
-           r = delegate_bandwidth(N(eosio.stake), a.aname, asset(net), asset(cpu));
+           r = delegate_bandwidth("eosio.stake"_n, a.aname, asset(net), asset(cpu));
            BOOST_REQUIRE( !r->except_ptr );
         }
 
         auto producer_candidates = {
-                N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
-                N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
-                N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ),
-                N(runnerup1), N(runnerup2), N(runnerup3)
+                "proda"_n, "prodb"_n, "prodc"_n, "prodd"_n, "prode"_n, "prodf"_n, "prodg"_n,
+                "prodh"_n, "prodi"_n, "prodj"_n, "prodk"_n, "prodl"_n, "prodm"_n, "prodn"_n,
+                "prodo"_n, "prodp"_n, "prodq"_n, "prodr"_n, "prods"_n, "prodt"_n, "produ"_n,
+                "runnerup1"_n, "runnerup2"_n, "runnerup3"_n
         };
 
         // Register producers
@@ -261,20 +261,20 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         // Vote for producers
         auto votepro = [&]( account_name voter, vector<account_name> producers ) {
           std::sort( producers.begin(), producers.end() );
-          base_tester::push_action(config::system_account_name, N(voteproducer), voter, mvo()
+          base_tester::push_action(config::system_account_name, "voteproducer"_n, voter, mvo()
                                 ("voter",  name(voter))
                                 ("proxy", name(0) )
                                 ("producers", producers)
                      );
         };
-        votepro( N(b1), { N(proda), N(prodb), N(prodc), N(prodd), N(prode), N(prodf), N(prodg),
-                           N(prodh), N(prodi), N(prodj), N(prodk), N(prodl), N(prodm), N(prodn),
-                           N(prodo), N(prodp), N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
-        votepro( N(whale2), {N(runnerup1), N(runnerup2), N(runnerup3)} );
-        votepro( N(whale3), {N(proda), N(prodb), N(prodc), N(prodd), N(prode)} );
+        votepro( "b1"_n, { "proda"_n, "prodb"_n, "prodc"_n, "prodd"_n, "prode"_n, "prodf"_n, "prodg"_n,
+                           "prodh"_n, "prodi"_n, "prodj"_n, "prodk"_n, "prodl"_n, "prodm"_n, "prodn"_n,
+                           "prodo"_n, "prodp"_n, "prodq"_n, "prodr"_n, "prods"_n, "prodt"_n, "produ"_n} );
+        votepro( "whale2"_n, {"runnerup1"_n, "runnerup2"_n, "runnerup3"_n} );
+        votepro( "whale3"_n, {"proda"_n, "prodb"_n, "prodc"_n, "prodd"_n, "prode"_n} );
 
         // Total Stakes = b1 + whale2 + whale3 stake = (100,000,000 - 1,000) + (20,000,000 - 1,000) + (30,000,000 - 1,000)
-        vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global), N(global) );
+        vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "global"_n, "global"_n );
 
         BOOST_TEST(get_global_state()["total_activated_stake"].as<int64_t>() == 1499999997000);
 
@@ -287,10 +287,10 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         // Spend some time so the producer pay pool is filled by the inflation rate
         produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(30 * 24 * 3600)); // 30 days
         // Since the total activated stake is less than 150,000,000, it shouldn't be possible to claim rewards
-        BOOST_REQUIRE_THROW(claim_rewards(N(runnerup1)), eosio_assert_message_exception);
+        BOOST_REQUIRE_THROW(claim_rewards("runnerup1"_n), eosio_assert_message_exception);
 
         // This will increase the total vote stake by (40,000,000 - 1,000)
-        votepro( N(whale4), {N(prodq), N(prodr), N(prods), N(prodt), N(produ)} );
+        votepro( "whale4"_n, {"prodq"_n, "prodr"_n, "prods"_n, "prodt"_n, "produ"_n} );
         BOOST_TEST(get_global_state()["total_activated_stake"].as<int64_t>() == 1899999996000);
 
         // Since the total vote stake is more than 150,000,000, the new producer set will be set
@@ -322,8 +322,8 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
         // Spend some time so the producer pay pool is filled by the inflation rate
         produce_min_num_of_blocks_to_spend_time_wo_inactive_prod(fc::seconds(30 * 24 * 3600)); // 30 days
         // Since the total activated stake is larger than 150,000,000, pool should be filled reward should be bigger than zero
-        claim_rewards(N(runnerup1));
-        BOOST_TEST(get_balance(N(runnerup1)).get_amount() > 0);
+        claim_rewards("runnerup1"_n);
+        BOOST_TEST(get_balance("runnerup1"_n).get_amount() > 0);
 
         const auto first_june_2018 = fc::seconds(1527811200); // 2018-06-01
         const auto first_june_2028 = fc::seconds(1843430400); // 2028-06-01
@@ -332,18 +332,18 @@ BOOST_FIXTURE_TEST_CASE( bootseq_test, bootseq_tester ) {
 
         // This should thrown an error, since block one can only unstake all his stake after 10 years
 
-        BOOST_REQUIRE_THROW(undelegate_bandwidth(N(b1), N(b1), core_from_string("49999500.0000"), core_from_string("49999500.0000")), eosio_assert_message_exception);
+        BOOST_REQUIRE_THROW(undelegate_bandwidth("b1"_n, "b1"_n, core_from_string("49999500.0000"), core_from_string("49999500.0000")), eosio_assert_message_exception);
 
         // Skip 10 years
         produce_block(first_june_2028 - control->head_block_time().time_since_epoch());
 
         // Block one should be able to unstake all his stake now
-        undelegate_bandwidth(N(b1), N(b1), core_from_string("49999500.0000"), core_from_string("49999500.0000"));
+        undelegate_bandwidth("b1"_n, "b1"_n, core_from_string("49999500.0000"), core_from_string("49999500.0000"));
 
         return;
         produce_blocks(7000); /// produce blocks until virutal bandwidth can acomadate a small user
         wlog("minow" );
-        votepro( N(minow1), {N(p1), N(p2)} );
+        votepro( "minow1"_n, {"p1"_n, "p2"_n} );
 
 
 // TODO: Complete this test

--- a/unittests/delay_tests.cpp
+++ b/unittests/delay_tests.cpp
@@ -25,7 +25,7 @@ BOOST_FIXTURE_TEST_CASE( delay_create_account, validating_tester) { try {
    produce_blocks(2);
    signed_transaction trx;
 
-   account_name a = N(newco);
+   account_name a = "newco"_n;
    account_name creator = config::system_account_name;
 
    auto owner_auth =  authority( get_public_key( a, "owner" ) );
@@ -52,13 +52,13 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
    produce_blocks(2);
    signed_transaction trx;
 
-   account_name a = N(newco);
+   account_name a = "newco"_n;
    account_name creator = config::system_account_name;
 
    auto owner_auth =  authority( get_public_key( a, "owner" ) );
    trx.actions.emplace_back( vector<permission_level>{{creator,config::active_name}},
                              newaccount{
-                                .creator  = N(bad), /// a does not exist, this should error when execute
+                                .creator  = "bad"_n, /// a does not exist, this should error when execute
                                 .name     = a,
                                 .owner    = owner_auth,
                                 .active   = authority( get_public_key( a, "active" ) )
@@ -85,27 +85,27 @@ BOOST_FIXTURE_TEST_CASE( delay_error_create_account, validating_tester) { try {
 
 
 asset get_currency_balance(const TESTER& chain, account_name account) {
-   return chain.get_currency_balance(N(eosio.token), symbol(SY(4,CUR)), account);
+   return chain.get_currency_balance("eosio.token"_n, symbol(SY(4,CUR)), account);
 }
 
-const std::string eosio_token = name(N(eosio.token)).to_string();
+const std::string eosio_token = name("eosio.token"_n).to_string();
 
 // test link to permission with delay directly on it
 BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -120,19 +120,19 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
            ("type", "transfer")
            ("requirement", "first"));
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -144,12 +144,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -162,11 +162,11 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    trace = chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 
    chain.produce_blocks();
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -193,37 +193,37 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
    BOOST_REQUIRE_EQUAL(1, gen_size);
    BOOST_REQUIRE_EQUAL(0, trace->action_traces.size());
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(18);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -232,18 +232,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_test ) { try {
 BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    transaction_trace_ptr trace;
@@ -276,20 +276,20 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    // create CUR token
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", "eosio.token" )
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
    // issue to account "eosio.token"
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       "eosio.token")
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
    // transfer from eosio.token to tester
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", "eosio.token")
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -299,12 +299,12 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -313,11 +313,11 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // can't delete auth because it's linked
@@ -347,7 +347,7 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    chain.produce_blocks(1);;
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -357,9 +357,9 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// delete_auth_test
@@ -369,18 +369,18 @@ BOOST_AUTO_TEST_CASE(delete_auth_test) { try {
 BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -396,18 +396,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -419,12 +419,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -437,11 +437,11 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    trace = chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -456,7 +456,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 
    chain.produce_blocks();
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -468,37 +468,37 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
    BOOST_REQUIRE_EQUAL(1, gen_size);
    BOOST_REQUIRE_EQUAL(0, trace->action_traces.size());
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(28);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -507,18 +507,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_parent_permission_test ) { try {
 BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -540,18 +540,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
            ("requirement", "second"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -563,12 +563,12 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -581,11 +581,11 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    trace = chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -600,7 +600,7 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 
    chain.produce_blocks();
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "3.0000 CUR")
@@ -612,37 +612,37 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
    BOOST_REQUIRE_EQUAL(1, gen_size);
    BOOST_REQUIRE_EQUAL(0, trace->action_traces.size());
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(38);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -651,18 +651,18 @@ BOOST_AUTO_TEST_CASE( link_delay_direct_walk_parent_permissions_test ) { try {
 BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -678,18 +678,18 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token )
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -701,13 +701,13 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -722,11 +722,11 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
@@ -743,20 +743,20 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -770,16 +770,16 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
@@ -788,9 +788,9 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(2, gen_size);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // delayed update auth removing the delay will finally execute
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    BOOST_CHECK_EQUAL(1, gen_size);
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -810,16 +810,16 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(15);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
@@ -831,9 +831,9 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(0, gen_size);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -842,18 +842,18 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_test ) { try {
 BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -875,18 +875,18 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
            ("requirement", "second"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -898,13 +898,13 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -919,11 +919,11 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
@@ -942,20 +942,20 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -970,30 +970,30 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1006,31 +1006,31 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(14);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -1039,18 +1039,18 @@ BOOST_AUTO_TEST_CASE( link_delay_permission_change_with_delay_heirarchy_test ) {
 BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -1072,18 +1072,18 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    );
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1095,13 +1095,13 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1115,16 +1115,16 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    BOOST_REQUIRE_EXCEPTION(
       chain.push_action( config::system_account_name, linkauth::get_name(),
-                         vector<permission_level>{permission_level{tester_account, N(first)}},
+                         vector<permission_level>{permission_level{tester_account, "first"_n}},
                          fc::mutable_variant_object()
       ("account", "tester")
       ("code", eosio_token)
@@ -1137,7 +1137,7 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    // this transaction will be delayed 20 blocks
    chain.push_action( config::system_account_name, linkauth::get_name(),
-                      vector<permission_level>{{tester_account, N(first)}},
+                      vector<permission_level>{{tester_account, "first"_n}},
                       fc::mutable_variant_object()
            ("account", "tester")
            ("code", eosio_token)
@@ -1152,20 +1152,20 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1179,31 +1179,31 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // delay on minimum permission of transfer is finally removed
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1214,24 +1214,24 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
    BOOST_CHECK_EQUAL(1, gen_size);
 
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -1241,18 +1241,18 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_test ) { try {
 BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -1268,18 +1268,18 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token )
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1289,13 +1289,13 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1309,16 +1309,16 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    BOOST_REQUIRE_EXCEPTION(
       chain.push_action( config::system_account_name, unlinkauth::get_name(),
-                         vector<permission_level>{{tester_account, N(first)}},
+                         vector<permission_level>{{tester_account, "first"_n}},
                          fc::mutable_variant_object()
          ("account", "tester")
          ("code", eosio_token)
@@ -1343,20 +1343,20 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1370,31 +1370,31 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // the delayed unlinkauth finally occurs
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1404,24 +1404,24 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(15);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// link_delay_unlink_test
@@ -1430,18 +1430,18 @@ BOOST_AUTO_TEST_CASE( link_delay_unlink_test ) { try {
 BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -1469,18 +1469,18 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    );
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR" )
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1492,13 +1492,13 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1512,11 +1512,11 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
@@ -1534,20 +1534,20 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1561,31 +1561,31 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // first transfer will finally be performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // delay on minimum permission of transfer is finally removed
    chain.produce_blocks();
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1595,24 +1595,24 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(1, gen_size);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("89.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("11.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("84.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("16.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() } /// link_delay_link_change_heirarchy_test
@@ -1621,32 +1621,32 @@ BOOST_AUTO_TEST_CASE( link_delay_link_change_heirarchy_test ) { try {
 BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1658,12 +1658,12 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 
    chain.produce_blocks();
 
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1676,25 +1676,25 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    // send transfer with delay_sec set to 10
-   const auto& acnt = chain.control->db().get<account_object,by_name>(N(eosio.token));
+   const auto& acnt = chain.control->db().get<account_object,by_name>("eosio.token"_n);
    const auto abi = acnt.get_abi();
    chain::abi_serializer abis(abi, abi_serializer::create_yield_function( chain.abi_serializer_max_time ));
-   const auto a = chain.control->db().get<account_object,by_name>(N(eosio.token)).get_abi();
+   const auto a = chain.control->db().get<account_object,by_name>("eosio.token"_n).get_abi();
 
    string action_type_name = abis.get_action_type(name("transfer"));
 
    action act;
-   act.account = N(eosio.token);
+   act.account = "eosio.token"_n;
    act.name = name("transfer");
-   act.authorization.push_back(permission_level{N(tester), config::active_name});
+   act.authorization.push_back(permission_level{"tester"_n, config::active_name});
    act.data = abis.variant_to_binary(action_type_name, fc::mutable_variant_object()
       ("from", "tester")
       ("to", "tester2")
@@ -1707,44 +1707,44 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
    trx.actions.push_back(act);
 
    chain.set_transaction_headers(trx, 30, 10);
-   trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
+   trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
    trace = chain.push_transaction(trx);
    BOOST_REQUIRE_EQUAL(transaction_receipt::delayed, trace->receipt->status);
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_REQUIRE_EQUAL(1, gen_size);
    BOOST_REQUIRE_EQUAL(0, trace->action_traces.size());
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(18);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("99.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("1.0000 CUR"), liquid_balance);
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("96.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("4.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }/// schedule_test
@@ -1752,19 +1752,19 @@ BOOST_AUTO_TEST_CASE( mindelay_test ) { try {
 // test canceldelay action cancelling a delayed transaction
 BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    TESTER chain;
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
    std::vector<transaction_id_type> ids;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks(10);
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks(10);
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -1780,18 +1780,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -1802,13 +1802,13 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    BOOST_REQUIRE_EQUAL(0, gen_size);
 
    chain.produce_blocks();
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "1.0000 CUR")
@@ -1828,17 +1828,17 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(eosio.token));
+   liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    BOOST_REQUIRE_EXCEPTION(
       chain.push_action( config::system_account_name,
                          updateauth::get_name(),
-                         vector<permission_level>{{tester_account, N(first)}},
+                         vector<permission_level>{{tester_account, "first"_n}},
                          fc::mutable_variant_object()
             ("account", "tester")
             ("permission", "first")
@@ -1867,20 +1867,20 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(16);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transaction will be delayed 20 blocks
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "5.0000 CUR")
@@ -1896,18 +1896,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // send canceldelay for first delayed transaction
    signed_transaction trx;
-   trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
-                            chain::canceldelay{{N(tester), config::active_name}, ids[0]});
+   trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::active_name}},
+                            chain::canceldelay{{"tester"_n, config::active_name}, ids[0]});
 
    chain.set_transaction_headers(trx);
-   trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
+   trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
    trace = chain.push_transaction(trx);
    //wdump((fc::json::to_pretty_string(trace)));
    BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -1920,9 +1920,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
@@ -1939,13 +1939,13 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(1, gen_size);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
    // this transfer is performed right away since delay is removed
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
        ("from", "tester")
        ("to", "tester2")
        ("quantity", "10.0000 CUR")
@@ -1959,9 +1959,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 
    chain.produce_blocks();
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
 
    chain.produce_blocks(15);
@@ -1969,9 +1969,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(1, gen_size);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("90.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("10.0000 CUR"), liquid_balance);
 
    // second transfer finally is performed
@@ -1980,9 +1980,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
    gen_size = chain.control->db().get_index<generated_transaction_multi_index,by_trx_id>().size();
    BOOST_CHECK_EQUAL(0, gen_size);
 
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("85.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester2));
+   liquid_balance = get_currency_balance(chain, "tester2"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("15.0000 CUR"), liquid_balance);
 } FC_LOG_AND_RETHROW() }
 
@@ -1990,18 +1990,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test ) { try {
 BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(eosio.token));
+   chain.create_account("eosio.token"_n);
    chain.produce_blocks();
 
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
-   chain.create_account(N(tester2));
+   chain.create_account("tester"_n);
+   chain.create_account("tester2"_n);
    chain.produce_blocks();
 
    chain.push_action(config::system_account_name, updateauth::get_name(), tester_account, fc::mutable_variant_object()
@@ -2023,18 +2023,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
            ("requirement", "first"));
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", eosio_token)
            ("maximum_supply", "9000000.0000 CUR")
    );
 
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       eosio_token)
            ("quantity", "1000000.0000 CUR")
            ("memo", "for stuff")
    );
 
-   auto trace = chain.push_action(N(eosio.token), name("transfer"), N(eosio.token), fc::mutable_variant_object()
+   auto trace = chain.push_action("eosio.token"_n, name("transfer"), "eosio.token"_n, fc::mutable_variant_object()
        ("from", eosio_token)
        ("to", "tester")
        ("quantity", "100.0000 CUR")
@@ -2045,16 +2045,16 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    BOOST_REQUIRE_EQUAL(0, gen_size);
 
    chain.produce_blocks();
-   auto liquid_balance = get_currency_balance(chain, N(eosio.token));
+   auto liquid_balance = get_currency_balance(chain, "eosio.token"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("999900.0000 CUR"), liquid_balance);
-   liquid_balance = get_currency_balance(chain, N(tester));
+   liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
 
    ilog("attempting first delayed transfer");
 
    {
       // this transaction will be delayed 10 blocks
-      trace = chain.push_action(N(eosio.token), name("transfer"), vector<permission_level>{{N(tester), N(first)}}, fc::mutable_variant_object()
+      trace = chain.push_action("eosio.token"_n, name("transfer"), vector<permission_level>{{"tester"_n, "first"_n}}, fc::mutable_variant_object()
           ("from", "tester")
           ("to", "tester2")
           ("quantity", "1.0000 CUR")
@@ -2073,18 +2073,18 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       chain.produce_blocks();
 
-      liquid_balance = get_currency_balance(chain, N(tester));
+      liquid_balance = get_currency_balance(chain, "tester"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-      liquid_balance = get_currency_balance(chain, N(tester2));
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
       // attempt canceldelay with wrong canceling_auth for delayed transfer of 1.0000 CUR
       {
          signed_transaction trx;
-         trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
-                                  chain::canceldelay{{N(tester), config::active_name}, trx_id});
+         trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::active_name}},
+                                  chain::canceldelay{{"tester"_n, config::active_name}, trx_id});
          chain.set_transaction_headers(trx);
-         trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
+         trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
          BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), action_validate_exception,
                                   fc_exception_message_is("canceling_auth in canceldelay action was not found as authorization in the original delayed transaction") );
       }
@@ -2092,10 +2092,10 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
       // attempt canceldelay with "second" permission for delayed transfer of 1.0000 CUR
       {
          signed_transaction trx;
-         trx.actions.emplace_back(vector<permission_level>{{N(tester), N(second)}},
-                                  chain::canceldelay{{N(tester), N(first)}, trx_id});
+         trx.actions.emplace_back(vector<permission_level>{{"tester"_n, "second"_n}},
+                                  chain::canceldelay{{"tester"_n, "first"_n}, trx_id});
          chain.set_transaction_headers(trx);
-         trx.sign(chain.get_private_key(N(tester), "second"), chain.control->get_chain_id());
+         trx.sign(chain.get_private_key("tester"_n, "second"), chain.control->get_chain_id());
          BOOST_REQUIRE_THROW( chain.push_transaction(trx), irrelevant_auth_exception );
          BOOST_REQUIRE_EXCEPTION( chain.push_transaction(trx), irrelevant_auth_exception,
                                   fc_exception_message_starts_with("canceldelay action declares irrelevant authority") );
@@ -2103,10 +2103,10 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       // canceldelay with "active" permission for delayed transfer of 1.0000 CUR
       signed_transaction trx;
-      trx.actions.emplace_back(vector<permission_level>{{N(tester), config::active_name}},
-                               chain::canceldelay{{N(tester), N(first)}, trx_id});
+      trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::active_name}},
+                               chain::canceldelay{{"tester"_n, "first"_n}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
+      trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
       trace = chain.push_transaction(trx);
 
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2119,9 +2119,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       chain.produce_blocks(10);
 
-      liquid_balance = get_currency_balance(chain, N(tester));
+      liquid_balance = get_currency_balance(chain, "tester"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-      liquid_balance = get_currency_balance(chain, N(tester2));
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
    }
 
@@ -2141,7 +2141,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
    ilog("attempting second delayed transfer");
    {
       // this transaction will be delayed 10 blocks
-      trace = chain.push_action(N(eosio.token), name("transfer"), vector<permission_level>{{N(tester), N(second)}}, fc::mutable_variant_object()
+      trace = chain.push_action("eosio.token"_n, name("transfer"), vector<permission_level>{{"tester"_n, "second"_n}}, fc::mutable_variant_object()
           ("from", "tester")
           ("to", "tester2")
           ("quantity", "5.0000 CUR")
@@ -2160,17 +2160,17 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       chain.produce_blocks();
 
-      liquid_balance = get_currency_balance(chain, N(tester));
+      liquid_balance = get_currency_balance(chain, "tester"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-      liquid_balance = get_currency_balance(chain, N(tester2));
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
       // canceldelay with "first" permission for delayed transfer of 5.0000 CUR
       signed_transaction trx;
-      trx.actions.emplace_back(vector<permission_level>{{N(tester), N(first)}},
-                               chain::canceldelay{{N(tester), N(second)}, trx_id});
+      trx.actions.emplace_back(vector<permission_level>{{"tester"_n, "first"_n}},
+                               chain::canceldelay{{"tester"_n, "second"_n}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(N(tester), "first"), chain.control->get_chain_id());
+      trx.sign(chain.get_private_key("tester"_n, "first"), chain.control->get_chain_id());
       trace = chain.push_transaction(trx);
 
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2183,9 +2183,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       chain.produce_blocks(10);
 
-      liquid_balance = get_currency_balance(chain, N(tester));
+      liquid_balance = get_currency_balance(chain, "tester"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-      liquid_balance = get_currency_balance(chain, N(tester2));
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
    }
 
@@ -2193,7 +2193,7 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
    {
       // this transaction will be delayed 10 blocks
-      trace = chain.push_action(N(eosio.token), name("transfer"), vector<permission_level>{{N(tester), config::owner_name}}, fc::mutable_variant_object()
+      trace = chain.push_action("eosio.token"_n, name("transfer"), vector<permission_level>{{"tester"_n, config::owner_name}}, fc::mutable_variant_object()
           ("from", "tester")
           ("to", "tester2")
           ("quantity", "10.0000 CUR")
@@ -2212,27 +2212,27 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       chain.produce_blocks();
 
-      liquid_balance = get_currency_balance(chain, N(tester));
+      liquid_balance = get_currency_balance(chain, "tester"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-      liquid_balance = get_currency_balance(chain, N(tester2));
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
 
       // attempt canceldelay with "active" permission for delayed transfer of 10.0000 CUR
       {
          signed_transaction trx;
-         trx.actions.emplace_back(vector<permission_level>{{N(tester), N(active)}},
-                                  chain::canceldelay{{N(tester), config::owner_name}, trx_id});
+         trx.actions.emplace_back(vector<permission_level>{{"tester"_n, "active"_n}},
+                                  chain::canceldelay{{"tester"_n, config::owner_name}, trx_id});
          chain.set_transaction_headers(trx);
-         trx.sign(chain.get_private_key(N(tester), "active"), chain.control->get_chain_id());
+         trx.sign(chain.get_private_key("tester"_n, "active"), chain.control->get_chain_id());
          BOOST_REQUIRE_THROW( chain.push_transaction(trx), irrelevant_auth_exception );
       }
 
       // canceldelay with "owner" permission for delayed transfer of 10.0000 CUR
       signed_transaction trx;
-      trx.actions.emplace_back(vector<permission_level>{{N(tester), config::owner_name}},
-                               chain::canceldelay{{N(tester), config::owner_name}, trx_id});
+      trx.actions.emplace_back(vector<permission_level>{{"tester"_n, config::owner_name}},
+                               chain::canceldelay{{"tester"_n, config::owner_name}, trx_id});
       chain.set_transaction_headers(trx);
-      trx.sign(chain.get_private_key(N(tester), "owner"), chain.control->get_chain_id());
+      trx.sign(chain.get_private_key("tester"_n, "owner"), chain.control->get_chain_id());
       trace = chain.push_transaction(trx);
 
       BOOST_REQUIRE_EQUAL(transaction_receipt::executed, trace->receipt->status);
@@ -2245,9 +2245,9 @@ BOOST_AUTO_TEST_CASE( canceldelay_test2 ) { try {
 
       chain.produce_blocks(10);
 
-      liquid_balance = get_currency_balance(chain, N(tester));
+      liquid_balance = get_currency_balance(chain, "tester"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("100.0000 CUR"), liquid_balance);
-      liquid_balance = get_currency_balance(chain, N(tester2));
+      liquid_balance = get_currency_balance(chain, "tester2"_n);
       BOOST_REQUIRE_EQUAL(asset::from_string("0.0000 CUR"), liquid_balance);
    }
 } FC_LOG_AND_RETHROW() }
@@ -2257,10 +2257,10 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_create ) { try {
    //assuming max transaction delay is 45 days (default in config.hpp)
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(tester));
+   chain.create_account("tester"_n);
    chain.produce_blocks(10);
 
    BOOST_REQUIRE_EXCEPTION(
@@ -2279,21 +2279,21 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
    //assuming max transaction delay is 45 days (default in config.hpp)
    TESTER chain;
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
-   chain.create_account(N(eosio.token));
-   chain.set_code(N(eosio.token), contracts::eosio_token_wasm());
-   chain.set_abi(N(eosio.token), contracts::eosio_token_abi().data());
-
-   chain.produce_blocks();
-   chain.create_account(N(tester));
+   chain.create_account("eosio.token"_n);
+   chain.set_code("eosio.token"_n, contracts::eosio_token_wasm());
+   chain.set_abi("eosio.token"_n, contracts::eosio_token_abi().data());
 
    chain.produce_blocks();
-   chain.push_action(N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   chain.create_account("tester"_n);
+
+   chain.produce_blocks();
+   chain.push_action("eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
            ("issuer", "eosio.token" )
            ("maximum_supply", "9000000.0000 CUR" )
    );
-   chain.push_action(N(eosio.token), name("issue"), N(eosio.token), fc::mutable_variant_object()
+   chain.push_action("eosio.token"_n, name("issue"), "eosio.token"_n, fc::mutable_variant_object()
            ("to",       "tester")
            ("quantity", "100.0000 CUR")
            ("memo", "for stuff")
@@ -2320,12 +2320,12 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
    //change max_transaction_delay to 60 sec
    auto params = chain.control->get_global_properties().configuration;
    params.max_transaction_delay = 60;
-   chain.push_action( config::system_account_name, N(setparams), config::system_account_name, mutable_variant_object()
+   chain.push_action( config::system_account_name, "setparams"_n, config::system_account_name, mutable_variant_object()
                         ("params", params) );
 
    chain.produce_blocks();
    //should be able to create transaction with delay 60 sec, despite permission delay being 30 days, because max_transaction_delay is 60 sec
-   trace = chain.push_action(N(eosio.token), name("transfer"), N(tester), fc::mutable_variant_object()
+   trace = chain.push_action("eosio.token"_n, name("transfer"), "tester"_n, fc::mutable_variant_object()
                            ("from", "tester")
                            ("to", "eosio.token")
                            ("quantity", "9.0000 CUR")
@@ -2344,7 +2344,7 @@ BOOST_AUTO_TEST_CASE( max_transaction_delay_execute ) { try {
    BOOST_CHECK_EQUAL(0, gen_size);
 
    //check that the transfer really happened
-   auto liquid_balance = get_currency_balance(chain, N(tester));
+   auto liquid_balance = get_currency_balance(chain, "tester"_n);
    BOOST_REQUIRE_EQUAL(asset::from_string("91.0000 CUR"), liquid_balance);
 
 } FC_LOG_AND_RETHROW() }
@@ -2358,7 +2358,7 @@ BOOST_AUTO_TEST_CASE( test_blockchain_params_enabled ) { try {
    auto params = chain.control->get_global_properties().configuration;
    params.max_transaction_delay = 60;
    chain.push_action(config::system_account_name, 
-                     N(setparams), 
+                     "setparams"_n,
                      config::system_account_name, 
                      mutable_variant_object()("params", params) );
    
@@ -2373,7 +2373,7 @@ BOOST_FIXTURE_TEST_CASE( delay_expired, validating_tester) { try {
    produce_blocks(2);
    signed_transaction trx;
 
-   account_name a = N(newco);
+   account_name a = "newco"_n;
    account_name creator = config::system_account_name;
 
    auto owner_auth =  authority( get_public_key( a, "owner" ) );

--- a/unittests/eosio.token_tests.cpp
+++ b/unittests/eosio.token_tests.cpp
@@ -24,15 +24,15 @@ public:
    eosio_token_tester() {
       produce_blocks( 2 );
 
-      create_accounts( { N(alice), N(bob), N(carol), N(eosio.token) } );
+      create_accounts( { "alice"_n, "bob"_n, "carol"_n, "eosio.token"_n } );
       produce_blocks( 2 );
 
-      set_code( N(eosio.token), contracts::eosio_token_wasm() );
-      set_abi( N(eosio.token), contracts::eosio_token_abi().data() );
+      set_code( "eosio.token"_n, contracts::eosio_token_wasm() );
+      set_abi( "eosio.token"_n, contracts::eosio_token_abi().data() );
 
       produce_blocks();
 
-      const auto& accnt = control->db().get<account_object,by_name>( N(eosio.token) );
+      const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
       abi_def abi;
       BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
       abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
@@ -42,7 +42,7 @@ public:
       string action_type_name = abi_ser.get_action_type(name);
 
       action act;
-      act.account = N(eosio.token);
+      act.account = "eosio.token"_n;
       act.name    = name;
       act.data    = abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
 
@@ -53,7 +53,7 @@ public:
    {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), name(symbol_code), N(stat), name(symbol_code) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, name(symbol_code), "stat"_n, name(symbol_code) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "currency_stats", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
@@ -61,21 +61,21 @@ public:
    {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), acc, N(accounts), name(symbol_code) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, acc, "accounts"_n, name(symbol_code) );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "account", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
    action_result create( account_name issuer,
                 asset        maximum_supply ) {
 
-      return push_action( N(eosio.token), N(create), mvo()
+      return push_action( "eosio.token"_n, "create"_n, mvo()
            ( "issuer", issuer)
            ( "maximum_supply", maximum_supply)
       );
    }
 
    action_result issue( account_name issuer, account_name to, asset quantity, string memo ) {
-      return push_action( issuer, N(issue), mvo()
+      return push_action( issuer, "issue"_n, mvo()
            ( "to", to)
            ( "quantity", quantity)
            ( "memo", memo)
@@ -86,7 +86,7 @@ public:
                   account_name to,
                   asset        quantity,
                   string       memo ) {
-      return push_action( from, N(transfer), mvo()
+      return push_action( from, "transfer"_n, mvo()
            ( "from", from)
            ( "to", to)
            ( "quantity", quantity)
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_SUITE(eosio_token_tests)
 
 BOOST_FIXTURE_TEST_CASE( create_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000.000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1000.000 TKN"));
    auto stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0.000 TKN")
@@ -115,14 +115,14 @@ BOOST_FIXTURE_TEST_CASE( create_tests, eosio_token_tester ) try {
 BOOST_FIXTURE_TEST_CASE( create_negative_max_supply, eosio_token_tester ) try {
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "max-supply must be positive" ),
-      create( N(alice), asset::from_string("-1000.000 TKN"))
+      create( "alice"_n, asset::from_string("-1000.000 TKN"))
    );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( symbol_already_exists, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("100 TKN"));
+   auto token = create( "alice"_n, asset::from_string("100 TKN"));
    auto stats = get_stats("0,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0 TKN")
@@ -132,14 +132,14 @@ BOOST_FIXTURE_TEST_CASE( symbol_already_exists, eosio_token_tester ) try {
    produce_blocks(1);
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "token with symbol already exists" ),
-                        create( N(alice), asset::from_string("100 TKN"))
+                        create( "alice"_n, asset::from_string("100 TKN"))
    );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("4611686018427387903 TKN"));
+   auto token = create( "alice"_n, asset::from_string("4611686018427387903 TKN"));
    auto stats = get_stats("0,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0 TKN")
@@ -154,7 +154,7 @@ BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
    static_assert(std::is_trivially_copyable<asset>::value, "asset is not trivially copyable");
    memcpy(&max, &amount, sizeof(share_type)); // hack in an invalid amount
 
-   BOOST_CHECK_EXCEPTION( create( N(alice), max) , asset_type_exception, [](const asset_type_exception& e) {
+   BOOST_CHECK_EXCEPTION( create( "alice"_n, max) , asset_type_exception, [](const asset_type_exception& e) {
       return expect_assert_message(e, "magnitude of asset amount must be less than 2^62");
    });
 
@@ -163,7 +163,7 @@ BOOST_FIXTURE_TEST_CASE( create_max_supply, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1.000000000000000000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1.000000000000000000 TKN"));
    auto stats = get_stats("18,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
       ("supply", "0.000000000000000000 TKN")
@@ -179,7 +179,7 @@ BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
    static_assert(std::is_trivially_copyable<asset>::value, "asset is not trivially copyable");
    memcpy(&max, &amount, sizeof(share_type)); // hack in an invalid amount
 
-   BOOST_CHECK_EXCEPTION( create( N(alice), max) , asset_type_exception, [](const asset_type_exception& e) {
+   BOOST_CHECK_EXCEPTION( create( "alice"_n, max) , asset_type_exception, [](const asset_type_exception& e) {
       return expect_assert_message(e, "magnitude of asset amount must be less than 2^62");
    });
 
@@ -187,10 +187,10 @@ BOOST_FIXTURE_TEST_CASE( create_max_decimals, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( issue_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000.000 TKN"));
+   auto token = create( "alice"_n, asset::from_string("1000.000 TKN"));
    produce_blocks(1);
 
-   issue( N(alice), N(alice), asset::from_string("500.000 TKN"), "hola" );
+   issue( "alice"_n, "alice"_n, asset::from_string("500.000 TKN"), "hola" );
 
    auto stats = get_stats("3,TKN");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
@@ -199,21 +199,21 @@ BOOST_FIXTURE_TEST_CASE( issue_tests, eosio_token_tester ) try {
       ("issuer", "alice")
    );
 
-   auto alice_balance = get_account(N(alice), "3,TKN");
+   auto alice_balance = get_account("alice"_n, "3,TKN");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "500.000 TKN")
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "quantity exceeds available supply" ),
-      issue( N(alice), N(alice), asset::from_string("500.001 TKN"), "hola" )
+      issue( "alice"_n, "alice"_n, asset::from_string("500.001 TKN"), "hola" )
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "must issue positive quantity" ),
-      issue( N(alice), N(alice), asset::from_string("-1.000 TKN"), "hola" )
+      issue( "alice"_n, "alice"_n, asset::from_string("-1.000 TKN"), "hola" )
    );
 
    BOOST_REQUIRE_EQUAL( success(),
-      issue( N(alice), N(alice), asset::from_string("1.000 TKN"), "hola" )
+      issue( "alice"_n, "alice"_n, asset::from_string("1.000 TKN"), "hola" )
    );
 
 
@@ -221,10 +221,10 @@ BOOST_FIXTURE_TEST_CASE( issue_tests, eosio_token_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
 
-   auto token = create( N(alice), asset::from_string("1000 CERO"));
+   auto token = create( "alice"_n, asset::from_string("1000 CERO"));
    produce_blocks(1);
 
-   issue( N(alice), N(alice), asset::from_string("1000 CERO"), "hola" );
+   issue( "alice"_n, "alice"_n, asset::from_string("1000 CERO"), "hola" );
 
    auto stats = get_stats("0,CERO");
    REQUIRE_MATCHING_OBJECT( stats, mvo()
@@ -233,21 +233,21 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
       ("issuer", "alice")
    );
 
-   auto alice_balance = get_account(N(alice), "0,CERO");
+   auto alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "1000 CERO")
    );
 
-   transfer( N(alice), N(bob), asset::from_string("300 CERO"), "hola" );
+   transfer( "alice"_n, "bob"_n, asset::from_string("300 CERO"), "hola" );
 
-   alice_balance = get_account(N(alice), "0,CERO");
+   alice_balance = get_account("alice"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( alice_balance, mvo()
       ("balance", "700 CERO")
       ("frozen", 0)
       ("whitelist", 1)
    );
 
-   auto bob_balance = get_account(N(bob), "0,CERO");
+   auto bob_balance = get_account("bob"_n, "0,CERO");
    REQUIRE_MATCHING_OBJECT( bob_balance, mvo()
       ("balance", "300 CERO")
       ("frozen", 0)
@@ -255,11 +255,11 @@ BOOST_FIXTURE_TEST_CASE( transfer_tests, eosio_token_tester ) try {
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "overdrawn balance" ),
-      transfer( N(alice), N(bob), asset::from_string("701 CERO"), "hola" )
+      transfer( "alice"_n, "bob"_n, asset::from_string("701 CERO"), "hola" )
    );
 
    BOOST_REQUIRE_EQUAL( wasm_assert_msg( "must transfer positive quantity" ),
-      transfer( N(alice), N(bob), asset::from_string("-1000 CERO"), "hola" )
+      transfer( "alice"_n, "bob"_n, asset::from_string("-1000 CERO"), "hola" )
    );
 
 

--- a/unittests/eosio_system_tester.hpp
+++ b/unittests/eosio_system_tester.hpp
@@ -35,29 +35,29 @@ public:
 
       produce_blocks( 2 );
 
-      create_accounts({ N(eosio.token), N(eosio.ram), N(eosio.ramfee), N(eosio.stake),
-               N(eosio.bpay), N(eosio.vpay), N(eosio.saving), N(eosio.names) });
+      create_accounts({ "eosio.token"_n, "eosio.ram"_n, "eosio.ramfee"_n, "eosio.stake"_n,
+               "eosio.bpay"_n, "eosio.vpay"_n, "eosio.saving"_n, "eosio.names"_n });
 
       produce_blocks( 100 );
 
-      set_code( N(eosio.token), contracts::eosio_token_wasm() );
-      set_abi( N(eosio.token), contracts::eosio_token_abi().data() );
+      set_code( "eosio.token"_n, contracts::eosio_token_wasm() );
+      set_abi( "eosio.token"_n, contracts::eosio_token_abi().data() );
 
       {
-         const auto& accnt = control->db().get<account_object,by_name>( N(eosio.token) );
+         const auto& accnt = control->db().get<account_object,by_name>( "eosio.token"_n );
          abi_def abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
          token_abi_ser.set_abi(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
       }
 
-      create_currency( N(eosio.token), config::system_account_name, core_from_string("10000000000.0000") );
+      create_currency( "eosio.token"_n, config::system_account_name, core_from_string("10000000000.0000") );
       issue(config::system_account_name,      core_from_string("1000000000.0000"));
       BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"), get_balance( name("eosio") ) );
 
       set_code( config::system_account_name, contracts::eosio_system_wasm() );
       set_abi( config::system_account_name, contracts::eosio_system_abi().data() );
 
-      base_tester::push_action(config::system_account_name, N(init),
+      base_tester::push_action(config::system_account_name, "init"_n,
                             config::system_account_name,  mutable_variant_object()
                             ("version", 0)
                             ("core", CORE_SYM_STR));
@@ -71,9 +71,9 @@ public:
 
       produce_blocks();
 
-      create_account_with_resources( N(alice1111111), config::system_account_name, core_from_string("1.0000"), false );
-      create_account_with_resources( N(bob111111111), config::system_account_name, core_from_string("0.4500"), false );
-      create_account_with_resources( N(carol1111111), config::system_account_name, core_from_string("1.0000"), false );
+      create_account_with_resources( "alice1111111"_n, config::system_account_name, core_from_string("1.0000"), false );
+      create_account_with_resources( "bob111111111"_n, config::system_account_name, core_from_string("0.4500"), false );
+      create_account_with_resources( "carol1111111"_n, config::system_account_name, core_from_string("1.0000"), false );
 
       BOOST_REQUIRE_EQUAL( core_from_string("1000000000.0000"),
             get_balance(name("eosio")) + get_balance(name("eosio.ramfee")) + get_balance(name("eosio.stake")) + get_balance(name("eosio.ram")) );
@@ -82,7 +82,7 @@ public:
    action_result open( account_name  owner,
                        const string& symbolname,
                        account_name  ram_payer    ) {
-      return push_action( ram_payer, N(open), mvo()
+      return push_action( ram_payer, "open"_n, mvo()
                           ( "owner", owner )
                           ( "symbol", symbolname )
                           ( "ram_payer", ram_payer )
@@ -110,13 +110,13 @@ public:
                                    .active   = authority( get_public_key( a, "active" ) )
                                 });
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(buyrambytes), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "buyrambytes"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("payer", creator)
                                             ("receiver", a)
                                             ("bytes", ram_bytes) )
                               );
-      trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("from", creator)
                                             ("receiver", a)
@@ -152,14 +152,14 @@ public:
                                    .active   = authority( get_public_key( a, "active" ) )
                                 });
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(buyram), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "buyram"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("payer", creator)
                                             ("receiver", a)
                                             ("quant", ramfunds) )
                               );
 
-      trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw), vector<permission_level>{{creator,config::active_name}},
+      trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n, vector<permission_level>{{creator,config::active_name}},
                                             mvo()
                                             ("from", creator)
                                             ("receiver", a)
@@ -192,14 +192,14 @@ public:
                                          .active   = authority( get_public_key( a, "active" ) )
                                          });
 
-         trx.actions.emplace_back( get_action( config::system_account_name, N(buyram), vector<permission_level>{ {creator, config::active_name} },
+         trx.actions.emplace_back( get_action( config::system_account_name, "buyram"_n, vector<permission_level>{ {creator, config::active_name} },
                                                mvo()
                                                ("payer", creator)
                                                ("receiver", a)
                                                ("quant", ram) )
                                    );
 
-         trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw), vector<permission_level>{ {creator, config::active_name} },
+         trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n, vector<permission_level>{ {creator, config::active_name} },
                                                mvo()
                                                ("from", creator)
                                                ("receiver", a)
@@ -216,14 +216,14 @@ public:
    }
 
    action_result buyram( const account_name& payer, account_name receiver, const asset& eosin ) {
-      return push_action( payer, N(buyram), mvo()( "payer",payer)("receiver",receiver)("quant",eosin) );
+      return push_action( payer, "buyram"_n, mvo()( "payer",payer)("receiver",receiver)("quant",eosin) );
    }
    action_result buyrambytes( const account_name& payer, account_name receiver, uint32_t numbytes ) {
-      return push_action( payer, N(buyrambytes), mvo()( "payer",payer)("receiver",receiver)("bytes",numbytes) );
+      return push_action( payer, "buyrambytes"_n, mvo()( "payer",payer)("receiver",receiver)("bytes",numbytes) );
    }
 
    action_result sellram( const account_name& account, uint64_t numbytes ) {
-      return push_action( account, N(sellram), mvo()( "account", account)("bytes",numbytes) );
+      return push_action( account, "sellram"_n, mvo()( "account", account)("bytes",numbytes) );
    }
 
    action_result push_action( const account_name& signer, const action_name &name, const variant_object &data, bool auth = true ) {
@@ -235,11 +235,11 @@ public:
          act.data = abi_ser.variant_to_binary( action_type_name, data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
 
          return base_tester::push_action( std::move(act), auth ? signer.to_uint64_t() :
-                                                signer == N(bob111111111) ? N(alice1111111).to_uint64_t() : N(bob111111111).to_uint64_t() );
+                                                signer == "bob111111111"_n ? "alice1111111"_n.to_uint64_t() : "bob111111111"_n.to_uint64_t() );
    }
 
    action_result stake( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
-      return push_action( name(from), N(delegatebw), mvo()
+      return push_action( name(from), "delegatebw"_n, mvo()
                           ("from",     from)
                           ("receiver", to)
                           ("stake_net_quantity", net)
@@ -253,7 +253,7 @@ public:
    }
 
    action_result stake_with_transfer( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
-      return push_action( name(from), N(delegatebw), mvo()
+      return push_action( name(from), "delegatebw"_n, mvo()
                           ("from",     from)
                           ("receiver", to)
                           ("stake_net_quantity", net)
@@ -267,7 +267,7 @@ public:
    }
 
    action_result unstake( const account_name& from, const account_name& to, const asset& net, const asset& cpu ) {
-      return push_action( name(from), N(undelegatebw), mvo()
+      return push_action( name(from), "undelegatebw"_n, mvo()
                           ("from",     from)
                           ("receiver", to)
                           ("unstake_net_quantity", net)
@@ -280,7 +280,7 @@ public:
    }
 
    action_result bidname( const account_name& bidder, const account_name& newname, const asset& bid ) {
-      return push_action( name(bidder), N(bidname), mvo()
+      return push_action( name(bidder), "bidname"_n, mvo()
                           ("bidder",  bidder)
                           ("newname", newname)
                           ("bid", bid)
@@ -311,7 +311,7 @@ public:
    }
 
    action_result regproducer( const account_name& acnt, int params_fixture = 1 ) {
-      action_result r = push_action( acnt, N(regproducer), mvo()
+      action_result r = push_action( acnt, "regproducer"_n, mvo()
                           ("producer",  acnt )
                           ("producer_key", get_public_key( acnt, "active" ) )
                           ("url", "" )
@@ -322,7 +322,7 @@ public:
    }
 
    action_result vote( const account_name& voter, const std::vector<account_name>& producers, const account_name& proxy = name(0) ) {
-      return push_action(voter, N(voteproducer), mvo()
+      return push_action(voter, "voteproducer"_n, mvo()
                          ("voter",     voter)
                          ("proxy",     proxy)
                          ("producers", producers));
@@ -333,22 +333,22 @@ public:
    }
 
    asset get_balance( const account_name& act ) {
-      vector<char> data = get_row_by_account( N(eosio.token), act, N(accounts), name(symbol(CORE_SYMBOL).to_symbol_code().value) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, act, "accounts"_n, name(symbol(CORE_SYMBOL).to_symbol_code().value) );
       return data.empty() ? asset(0, symbol(CORE_SYMBOL)) : token_abi_ser.binary_to_variant("account", data, abi_serializer::create_yield_function( abi_serializer_max_time ))["balance"].as<asset>();
    }
 
    fc::variant get_total_stake( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, act, N(userres), act );
+      vector<char> data = get_row_by_account( config::system_account_name, act, "userres"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "user_resources", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
    fc::variant get_voter_info( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(voters), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "voters"_n, act );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "voter_info", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
    fc::variant get_producer_info( const account_name& act ) {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(producers), act );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "producers"_n, act );
       return abi_ser.binary_to_variant( "producer_info", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
@@ -357,18 +357,18 @@ public:
          ("issuer",       manager )
          ("maximum_supply", maxsupply );
 
-      base_tester::push_action(contract, N(create), contract, act );
+      base_tester::push_action(contract, "create"_n, contract, act );
    }
 
    void issue( name to, const asset& amount, name manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(issue), manager, mutable_variant_object()
+      base_tester::push_action( "eosio.token"_n, "issue"_n, manager, mutable_variant_object()
                                 ("to",      to )
                                 ("quantity", amount )
                                 ("memo", "")
                                 );
    }
    void transfer( name from, name to, const asset& amount, name manager = config::system_account_name ) {
-      base_tester::push_action( N(eosio.token), N(transfer), manager, mutable_variant_object()
+      base_tester::push_action( "eosio.token"_n, "transfer"_n, manager, mutable_variant_object()
                                 ("from",    from)
                                 ("to",      to )
                                 ("quantity", amount)
@@ -388,7 +388,7 @@ public:
    fc::variant get_stats( const string& symbolname ) {
       auto symb = eosio::chain::symbol::from_string(symbolname);
       auto symbol_code = symb.to_symbol_code().value;
-      vector<char> data = get_row_by_account( N(eosio.token), name(symbol_code), N(stat), name(symbol_code) );
+      vector<char> data = get_row_by_account( "eosio.token"_n, name(symbol_code), "stat"_n, name(symbol_code) );
       return data.empty() ? fc::variant() : token_abi_ser.binary_to_variant( "currency_stats", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
@@ -397,35 +397,35 @@ public:
    }
 
    fc::variant get_global_state() {
-      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, N(global), N(global) );
+      vector<char> data = get_row_by_account( config::system_account_name, config::system_account_name, "global"_n, "global"_n );
       if (data.empty()) std::cout << "\nData is empty\n" << std::endl;
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "eosio_global_state", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
 
    }
 
    fc::variant get_refund_request( name account ) {
-      vector<char> data = get_row_by_account( config::system_account_name, account, N(refunds), account );
+      vector<char> data = get_row_by_account( config::system_account_name, account, "refunds"_n, account );
       return data.empty() ? fc::variant() : abi_ser.binary_to_variant( "refund_request", data, abi_serializer::create_yield_function( abi_serializer_max_time ) );
    }
 
    abi_serializer initialize_multisig() {
       abi_serializer msig_abi_ser;
       {
-         create_account_with_resources( N(eosio.msig), config::system_account_name );
+         create_account_with_resources( "eosio.msig"_n, config::system_account_name );
          BOOST_REQUIRE_EQUAL( success(), buyram( name("eosio"), name("eosio.msig"), core_from_string("5000.0000") ) );
          produce_block();
 
-         auto trace = base_tester::push_action(config::system_account_name, N(setpriv),
+         auto trace = base_tester::push_action(config::system_account_name, "setpriv"_n,
                                                config::system_account_name,  mutable_variant_object()
                                                ("account", "eosio.msig")
                                                ("is_priv", 1)
          );
 
-         set_code( N(eosio.msig), contracts::eosio_msig_wasm() );
-         set_abi( N(eosio.msig), contracts::eosio_msig_abi().data() );
+         set_code( "eosio.msig"_n, contracts::eosio_msig_wasm() );
+         set_abi( "eosio.msig"_n, contracts::eosio_msig_abi().data() );
 
          produce_blocks();
-         const auto& accnt = control->db().get<account_object,by_name>( N(eosio.msig) );
+         const auto& accnt = control->db().get<account_object,by_name>( "eosio.msig"_n );
          abi_def msig_abi;
          BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, msig_abi), true);
          msig_abi_ser.set_abi(msig_abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
@@ -471,7 +471,7 @@ public:
          transfer( config::system_account_name, name("alice1111111"), core_from_string("100000000.0000"), config::system_account_name );
          BOOST_REQUIRE_EQUAL(success(), stake( name("alice1111111"), core_from_string("30000000.0000"), core_from_string("30000000.0000") ) );
          BOOST_REQUIRE_EQUAL(success(), buyram( name("alice1111111"), name("alice1111111"), core_from_string("30000000.0000") ) );
-         BOOST_REQUIRE_EQUAL(success(), push_action(N(alice1111111), N(voteproducer), mvo()
+         BOOST_REQUIRE_EQUAL(success(), push_action("alice1111111"_n, "voteproducer"_n, mvo()
                                                     ("voter",  "alice1111111")
                                                     ("proxy", name(0).to_string())
                                                     ("producers", vector<account_name>(producer_names.begin(), producer_names.begin()+21))
@@ -488,13 +488,13 @@ public:
    }
 
    void cross_15_percent_threshold() {
-      setup_producer_accounts({N(producer1111)});
-      regproducer(N(producer1111));
+      setup_producer_accounts({"producer1111"_n});
+      regproducer("producer1111"_n);
       {
          signed_transaction trx;
          set_transaction_headers(trx);
 
-         trx.actions.emplace_back( get_action( config::system_account_name, N(delegatebw),
+         trx.actions.emplace_back( get_action( config::system_account_name, "delegatebw"_n,
                                                vector<permission_level>{{config::system_account_name, config::active_name}},
                                                mvo()
                                                ("from", name{config::system_account_name})
@@ -504,16 +504,16 @@ public:
                                                ("transfer", 1 )
                                              )
                                  );
-         trx.actions.emplace_back( get_action( config::system_account_name, N(voteproducer),
-                                               vector<permission_level>{{N(producer1111), config::active_name}},
+         trx.actions.emplace_back( get_action( config::system_account_name, "voteproducer"_n,
+                                               vector<permission_level>{{"producer1111"_n, config::active_name}},
                                                mvo()
                                                ("voter", "producer1111")
                                                ("proxy", name(0).to_string())
-                                               ("producers", vector<account_name>(1, N(producer1111)))
+                                               ("producers", vector<account_name>(1, "producer1111"_n))
                                              )
                                  );
-         trx.actions.emplace_back( get_action( config::system_account_name, N(undelegatebw),
-                                               vector<permission_level>{{N(producer1111), config::active_name}},
+         trx.actions.emplace_back( get_action( config::system_account_name, "undelegatebw"_n,
+                                               vector<permission_level>{{"producer1111"_n, config::active_name}},
                                                mvo()
                                                ("from", "producer1111")
                                                ("receiver", "producer1111")
@@ -524,7 +524,7 @@ public:
 
          set_transaction_headers(trx);
          trx.sign( get_private_key( config::system_account_name, "active" ), control->get_chain_id()  );
-         trx.sign( get_private_key( N(producer1111), "active" ), control->get_chain_id()  );
+         trx.sign( get_private_key( "producer1111"_n, "active" ), control->get_chain_id()  );
          push_transaction( trx );
       }
    }

--- a/unittests/forked_tests.cpp
+++ b/unittests/forked_tests.cpp
@@ -22,8 +22,8 @@ BOOST_AUTO_TEST_SUITE(forked_tests)
 BOOST_AUTO_TEST_CASE( irrblock ) try {
    tester c;
    c.produce_blocks(10);
-   auto r = c.create_accounts( {N(dan),N(sam),N(pam),N(scott)} );
-   auto res = c.set_producers( {N(dan),N(sam),N(pam),N(scott)} );
+   auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n,"scott"_n} );
+   auto res = c.set_producers( {"dan"_n,"sam"_n,"pam"_n,"scott"_n} );
 
    wlog("set producer schedule to [dan,sam,pam]");
    c.produce_blocks(50);
@@ -39,13 +39,13 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
    tester bios;
    bios.produce_block();
    bios.produce_block();
-   bios.create_accounts( {N(a),N(b),N(c),N(d),N(e)} );
+   bios.create_accounts( {"a"_n,"b"_n,"c"_n,"d"_n,"e"_n} );
 
    bios.produce_block();
-   auto res = bios.set_producers( {N(a),N(b),N(c),N(d),N(e)} );
+   auto res = bios.set_producers( {"a"_n,"b"_n,"c"_n,"d"_n,"e"_n} );
 
    // run until the producers are installed and its the start of "a's" round
-   BOOST_REQUIRE( produce_until_transition( bios, N(e), N(a) ) );
+   BOOST_REQUIRE( produce_until_transition( bios, "e"_n, "a"_n ) );
 
    // sync remote node
    tester remote(setup_policy::none);
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE( fork_with_bad_block ) try {
             // re-sign the block
             auto header_bmroot = digest_type::hash( std::make_pair( copy_b->digest(), fork.block_merkle.get_root() ) );
             auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state()->pending_schedule.schedule_hash) );
-            copy_b->producer_signature = remote.get_private_key(N(b), "active").sign(sig_digest);
+            copy_b->producer_signature = remote.get_private_key("b"_n, "active").sign(sig_digest);
 
             // add this new block to our corrupted block merkle
             fork.block_merkle.append(copy_b->id());
@@ -131,34 +131,34 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    while (c.control->head_block_num() < 3) {
       c.produce_block();
    }
-   auto r = c.create_accounts( {N(dan),N(sam),N(pam)} );
+   auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
    wdump((fc::json::to_pretty_string(r)));
    c.produce_block();
-   auto res = c.set_producers( {N(dan),N(sam),N(pam)} );
+   auto res = c.set_producers( {"dan"_n,"sam"_n,"pam"_n} );
 
    wdump((fc::json::to_pretty_string(res)));
    wlog("set producer schedule to [dan,sam,pam]");
    c.produce_blocks(30);
 
-   auto r2 = c.create_accounts( {N(eosio.token)} );
+   auto r2 = c.create_accounts( {"eosio.token"_n} );
    wdump((fc::json::to_pretty_string(r2)));
-   c.set_code( N(eosio.token), contracts::eosio_token_wasm() );
-   c.set_abi( N(eosio.token), contracts::eosio_token_abi().data() );
+   c.set_code( "eosio.token"_n, contracts::eosio_token_wasm() );
+   c.set_abi( "eosio.token"_n, contracts::eosio_token_abi().data() );
    c.produce_blocks(10);
 
 
-   auto cr = c.push_action( N(eosio.token), N(create), N(eosio.token), mutable_variant_object()
+   auto cr = c.push_action( "eosio.token"_n, "create"_n, "eosio.token"_n, mutable_variant_object()
               ("issuer",       "eosio" )
               ("maximum_supply", core_from_string("10000000.0000"))
       );
 
-   cr = c.push_action( N(eosio.token), N(issue), config::system_account_name, mutable_variant_object()
+   cr = c.push_action( "eosio.token"_n, "issue"_n, config::system_account_name, mutable_variant_object()
               ("to",       "eosio" )
               ("quantity", core_from_string("100.0000"))
               ("memo", "")
       );
 
-   cr = c.push_action( N(eosio.token), N(transfer), config::system_account_name, mutable_variant_object()
+   cr = c.push_action( "eosio.token"_n, "transfer"_n, config::system_account_name, mutable_variant_object()
               ("from",     "eosio")
               ("to",       "dan" )
               ("quantity", core_from_string("100.0000"))
@@ -175,15 +175,15 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    c.produce_blocks(3);
    signed_block_ptr b;
    b = c.produce_block();
-   account_name expected_producer = N(dan);
+   account_name expected_producer = "dan"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
 
    b = c.produce_block();
-   expected_producer = N(sam);
+   expected_producer = "sam"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    c.produce_blocks(10);
-   c.create_accounts( {N(cam)} );
-   c.set_producers( {N(dan),N(sam),N(pam),N(cam)} );
+   c.create_accounts( {"cam"_n} );
+   c.set_producers( {"dan"_n,"sam"_n,"pam"_n,"cam"_n} );
    wlog("set producer schedule to [dan,sam,pam,cam]");
    c.produce_block();
    // The next block should be produced by pam.
@@ -201,14 +201,14 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    wlog( "c2 blocks:" );
    c2.produce_blocks(12); // pam produces 12 blocks
    b = c2.produce_block( fc::milliseconds(config::block_interval_ms * 13) ); // sam skips over dan's blocks
-   expected_producer = N(sam);
+   expected_producer = "sam"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    c2.produce_blocks(11 + 12);
 
 
    wlog( "c1 blocks:" );
    b = c.produce_block( fc::milliseconds(config::block_interval_ms * 13) ); // dan skips over pam's blocks
-   expected_producer = N(dan);
+   expected_producer = "dan"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    c.produce_blocks(11);
 
@@ -225,11 +225,11 @@ BOOST_AUTO_TEST_CASE( forking ) try {
    c.produce_blocks(24);
 
    b = c.produce_block(); // Switching active schedule to version 2 happens in this block.
-   expected_producer = N(pam);
+   expected_producer = "pam"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
 
    b = c.produce_block();
-   expected_producer = N(cam);
+   expected_producer = "cam"_n;
 //   BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    c.produce_blocks(10);
 
@@ -284,8 +284,8 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
    while (c.control->head_block_num() < 11) {
       c.produce_block();
    }
-   auto r = c.create_accounts( {N(dan),N(sam),N(pam),N(scott)} );
-   auto res = c.set_producers( {N(dan),N(sam),N(pam),N(scott)} );
+   auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n,"scott"_n} );
+   auto res = c.set_producers( {"dan"_n,"sam"_n,"pam"_n,"scott"_n} );
    wlog("set producer schedule to [dan,sam,pam,scott]");
    c.produce_blocks(50);
 
@@ -310,12 +310,12 @@ BOOST_AUTO_TEST_CASE( prune_remove_branch ) try {
    int skip1 = 1, skip2 = 1;
    for (int i = 0; i < 50; ++i) {
       account_name next1 = nextproducer(c, skip1);
-      if (next1 == N(dan) || next1 == N(sam)) {
+      if (next1 == "dan"_n || next1 == "sam"_n) {
          c.produce_block(fc::milliseconds(config::block_interval_ms * skip1)); skip1 = 1;
       }
       else ++skip1;
       account_name next2 = nextproducer(c2, skip2);
-      if (next2 == N(scott)) {
+      if (next2 == "scott"_n) {
          c2.produce_block(fc::milliseconds(config::block_interval_ms * skip2)); skip2 = 1;
       }
       else ++skip2;
@@ -378,9 +378,9 @@ BOOST_AUTO_TEST_CASE( read_modes ) try {
    tester c;
    c.produce_block();
    c.produce_block();
-   auto r = c.create_accounts( {N(dan),N(sam),N(pam)} );
+   auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
    c.produce_block();
-   auto res = c.set_producers( {N(dan),N(sam),N(pam)} );
+   auto res = c.set_producers( {"dan"_n,"sam"_n,"pam"_n} );
    c.produce_blocks(200);
    auto head_block_num = c.control->head_block_num();
    auto last_irreversible_block_num = c.control->last_irreversible_block_num();
@@ -412,18 +412,18 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 
    tester main;
 
-   main.create_accounts( {N(producer1), N(producer2)} );
+   main.create_accounts( {"producer1"_n, "producer2"_n} );
    main.produce_block();
-   main.set_producers( {N(producer1), N(producer2)} );
+   main.set_producers( {"producer1"_n, "producer2"_n} );
    main.produce_block();
-   BOOST_REQUIRE( produce_until_transition( main, N(producer1), N(producer2), 26) );
+   BOOST_REQUIRE( produce_until_transition( main, "producer1"_n, "producer2"_n, 26) );
 
-   main.create_accounts( {N(alice)} );
+   main.create_accounts( {"alice"_n} );
    main.produce_block();
    auto hbn1 = main.control->head_block_num();
    auto lib1 = main.control->last_irreversible_block_num();
 
-   BOOST_REQUIRE( produce_until_transition( main, N(producer2), N(producer1), 11) );
+   BOOST_REQUIRE( produce_until_transition( main, "producer2"_n, "producer1"_n, 11) );
 
    auto hbn2 = main.control->head_block_num();
    auto lib2 = main.control->last_irreversible_block_num();
@@ -435,15 +435,15 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    push_blocks( main, other );
    BOOST_CHECK_EQUAL( other.control->head_block_num(), hbn2 );
 
-   BOOST_REQUIRE( produce_until_transition( main, N(producer1), N(producer2), 12) );
-   BOOST_REQUIRE( produce_until_transition( main, N(producer2), N(producer1), 12) );
+   BOOST_REQUIRE( produce_until_transition( main, "producer1"_n, "producer2"_n, 12) );
+   BOOST_REQUIRE( produce_until_transition( main, "producer2"_n, "producer1"_n, 12) );
 
    auto hbn3 = main.control->head_block_num();
    auto lib3 = main.control->last_irreversible_block_num();
 
    BOOST_REQUIRE( lib3 >= hbn1 );
 
-   BOOST_CHECK_EQUAL( does_account_exist( main, N(alice) ), true );
+   BOOST_CHECK_EQUAL( does_account_exist( main, "alice"_n ), true );
 
    // other forks away from main after hbn2
    BOOST_REQUIRE_EQUAL( other.control->head_block_producer().to_string(), "producer2" );
@@ -453,15 +453,15 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
    auto fork_first_block_id = other.control->head_block_id();
    wlog( "{w}", ("w", fork_first_block_id));
 
-   BOOST_REQUIRE( produce_until_transition( other, N(producer2), N(producer1), 11) ); // finish producer2's round
+   BOOST_REQUIRE( produce_until_transition( other, "producer2"_n, "producer1"_n, 11) ); // finish producer2's round
    BOOST_REQUIRE_EQUAL( other.control->pending_block_producer().to_string(), "producer1" );
 
    // Repeat two more times to ensure other has a longer chain than main
    other.produce_block( fc::milliseconds( 13 * config::block_interval_ms ) ); // skip over producer1's round
-   BOOST_REQUIRE( produce_until_transition( other, N(producer2), N(producer1), 11) ); // finish producer2's round
+   BOOST_REQUIRE( produce_until_transition( other, "producer2"_n, "producer1"_n, 11) ); // finish producer2's round
 
    other.produce_block( fc::milliseconds( 13 * config::block_interval_ms ) ); // skip over producer1's round
-   BOOST_REQUIRE( produce_until_transition( other, N(producer2), N(producer1), 11) ); // finish producer2's round
+   BOOST_REQUIRE( produce_until_transition( other, "producer2"_n, "producer1"_n, 11) ); // finish producer2's round
 
    auto hbn4 = other.control->head_block_num();
    auto lib4 = other.control->last_irreversible_block_num();
@@ -475,13 +475,13 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 
    BOOST_CHECK_EQUAL( irreversible.control->fork_db_pending_head_block_num(), hbn1 );
    BOOST_CHECK_EQUAL( irreversible.control->head_block_num(), lib1 );
-   BOOST_CHECK_EQUAL( does_account_exist( irreversible, N(alice) ), false );
+   BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), false );
 
    push_blocks( other, irreversible, hbn4 );
 
    BOOST_CHECK_EQUAL( irreversible.control->fork_db_pending_head_block_num(), hbn4 );
    BOOST_CHECK_EQUAL( irreversible.control->head_block_num(), lib4 );
-   BOOST_CHECK_EQUAL( does_account_exist( irreversible, N(alice) ), false );
+   BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), false );
 
    // force push blocks from main to irreversible creating a new branch in irreversible's fork database
    for( uint32_t n = hbn2 + 1; n <= hbn3; ++n ) {
@@ -491,7 +491,7 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 
    BOOST_CHECK_EQUAL( irreversible.control->fork_db_pending_head_block_num(), hbn3 );
    BOOST_CHECK_EQUAL( irreversible.control->head_block_num(), lib3 );
-   BOOST_CHECK_EQUAL( does_account_exist( irreversible, N(alice) ), true );
+   BOOST_CHECK_EQUAL( does_account_exist( irreversible, "alice"_n ), true );
 
    {
       auto bs = irreversible.control->fetch_block_state_by_id( fork_first_block_id );
@@ -516,18 +516,18 @@ BOOST_AUTO_TEST_CASE( irreversible_mode ) try {
 BOOST_AUTO_TEST_CASE( reopen_forkdb ) try {
    tester c1;
 
-   c1.create_accounts( {N(alice),N(bob),N(carol)} );
+   c1.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    c1.produce_block();
 
-   auto res = c1.set_producers( {N(alice),N(bob),N(carol)} );
+   auto res = c1.set_producers( {"alice"_n,"bob"_n,"carol"_n} );
 
    c1.produce_blocks(2);
 
    BOOST_REQUIRE_EQUAL( c1.control->active_producers().version, 1u );
 
-   produce_until_transition( c1, N(carol), N(alice) );
+   produce_until_transition( c1, "carol"_n, "alice"_n );
    c1.produce_block();
-   produce_until_transition( c1, N(carol), N(alice) );
+   produce_until_transition( c1, "carol"_n, "alice"_n );
 
    tester c2(setup_policy::none);
 
@@ -572,9 +572,9 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    while (c.control->head_block_num() < 3) {
       c.produce_block();
    }
-   auto r = c.create_accounts( {N(dan),N(sam),N(pam)} );
+   auto r = c.create_accounts( {"dan"_n,"sam"_n,"pam"_n} );
    c.produce_block();
-   auto res = c.set_producers( {N(dan),N(sam),N(pam)} );
+   auto res = c.set_producers( {"dan"_n,"sam"_n,"pam"_n} );
    wlog("set producer schedule to [dan,sam,pam]");
    c.produce_blocks(40);
 
@@ -587,15 +587,15 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    c.produce_blocks(3);
    signed_block_ptr b;
    cb = b = c.produce_block();
-   account_name expected_producer = N(dan);
+   account_name expected_producer = "dan"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
 
    b = c.produce_block();
-   expected_producer = N(sam);
+   expected_producer = "sam"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    c.produce_blocks(10);
-   c.create_accounts( {N(cam)} );
-   c.set_producers( {N(dan),N(sam),N(pam),N(cam)} );
+   c.create_accounts( {"cam"_n} );
+   c.set_producers( {"dan"_n,"sam"_n,"pam"_n,"cam"_n} );
    wlog("set producer schedule to [dan,sam,pam,cam]");
    c.produce_block();
    // The next block should be produced by pam.
@@ -614,7 +614,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    wlog( "c2 blocks:" );
    c2.produce_blocks(12); // pam produces 12 blocks
    b = c2b = c2.produce_block( fc::milliseconds(config::block_interval_ms * 13) ); // sam skips over dan's blocks
-   expected_producer = N(sam);
+   expected_producer = "sam"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    // save blocks for verification of forking later
    std::vector<signed_block_ptr> c2blocks;
@@ -625,7 +625,7 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
 
    wlog( "c1 blocks:" );
    b = c.produce_block( fc::milliseconds(config::block_interval_ms * 13) ); // dan skips over pam's blocks
-   expected_producer = N(dan);
+   expected_producer = "dan"_n;
    BOOST_REQUIRE_EQUAL( b->producer.to_string(), expected_producer.to_string() );
    // create accounts on c1 which will be forked out
    c.produce_block();
@@ -633,12 +633,12 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    transaction_trace_ptr trace1, trace2, trace3, trace4;
    { // create account the hard way so we can set reference block and expiration
       signed_transaction trx;
-      authority active_auth( get_public_key( N(test1), "active" ) );
-      authority owner_auth( get_public_key( N(test1), "owner" ) );
+      authority active_auth( get_public_key( "test1"_n, "active" ) );
+      authority owner_auth( get_public_key( "test1"_n, "owner" ) );
       trx.actions.emplace_back( vector<permission_level>{{config::system_account_name,config::active_name}},
                                 newaccount{
                                       .creator  = config::system_account_name,
-                                      .name     = N(test1),
+                                      .name     = "test1"_n,
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
@@ -650,12 +650,12 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    c.produce_block();
    {
       signed_transaction trx;
-      authority active_auth( get_public_key( N(test2), "active" ) );
-      authority owner_auth( get_public_key( N(test2), "owner" ) );
+      authority active_auth( get_public_key( "test2"_n, "active" ) );
+      authority owner_auth( get_public_key( "test2"_n, "owner" ) );
       trx.actions.emplace_back( vector<permission_level>{{config::system_account_name,config::active_name}},
                                 newaccount{
                                       .creator  = config::system_account_name,
-                                      .name     = N(test2),
+                                      .name     = "test2"_n,
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
@@ -666,12 +666,12 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    }
    {
       signed_transaction trx;
-      authority active_auth( get_public_key( N(test3), "active" ) );
-      authority owner_auth( get_public_key( N(test3), "owner" ) );
+      authority active_auth( get_public_key( "test3"_n, "active" ) );
+      authority owner_auth( get_public_key( "test3"_n, "owner" ) );
       trx.actions.emplace_back( vector<permission_level>{{config::system_account_name,config::active_name}},
                                 newaccount{
                                       .creator  = config::system_account_name,
-                                      .name     = N(test3),
+                                      .name     = "test3"_n,
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
@@ -682,12 +682,12 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    }
    {
       signed_transaction trx;
-      authority active_auth( get_public_key( N(test4), "active" ) );
-      authority owner_auth( get_public_key( N(test4), "owner" ) );
+      authority active_auth( get_public_key( "test4"_n, "active" ) );
+      authority owner_auth( get_public_key( "test4"_n, "owner" ) );
       trx.actions.emplace_back( vector<permission_level>{{config::system_account_name,config::active_name}},
                                 newaccount{
                                       .creator  = config::system_account_name,
-                                      .name     = N(test4),
+                                      .name     = "test4"_n,
                                       .owner    = owner_auth,
                                       .active   = active_auth,
                                 });
@@ -731,20 +731,20 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    BOOST_REQUIRE_EQUAL( trace3->id, (++(++c.get_unapplied_transaction_queue().begin()))->id() );
    BOOST_REQUIRE_EQUAL( trace4->id, (++(++(++c.get_unapplied_transaction_queue().begin())))->id() );
 
-   BOOST_REQUIRE_EXCEPTION(c.control->get_account( N(test1) ), fc::exception,
-                           [a=N(test1)] (const fc::exception& e)->bool {
+   BOOST_REQUIRE_EXCEPTION(c.control->get_account( "test1"_n ), fc::exception,
+                           [a="test1"_n] (const fc::exception& e)->bool {
                               return std::string( e.what() ).find( a.to_string() ) != std::string::npos;
                            }) ;
-   BOOST_REQUIRE_EXCEPTION(c.control->get_account( N(test2) ), fc::exception,
-                           [a=N(test2)] (const fc::exception& e)->bool {
+   BOOST_REQUIRE_EXCEPTION(c.control->get_account( "test2"_n ), fc::exception,
+                           [a="test2"_n] (const fc::exception& e)->bool {
                               return std::string( e.what() ).find( a.to_string() ) != std::string::npos;
                            }) ;
-   BOOST_REQUIRE_EXCEPTION(c.control->get_account( N(test3) ), fc::exception,
-                           [a=N(test3)] (const fc::exception& e)->bool {
+   BOOST_REQUIRE_EXCEPTION(c.control->get_account( "test3"_n ), fc::exception,
+                           [a="test3"_n] (const fc::exception& e)->bool {
                               return std::string( e.what() ).find( a.to_string() ) != std::string::npos;
                            }) ;
-   BOOST_REQUIRE_EXCEPTION(c.control->get_account( N(test4) ), fc::exception,
-                           [a=N(test4)] (const fc::exception& e)->bool {
+   BOOST_REQUIRE_EXCEPTION(c.control->get_account( "test4"_n ), fc::exception,
+                           [a="test4"_n] (const fc::exception& e)->bool {
                               return std::string( e.what() ).find( a.to_string() ) != std::string::npos;
                            }) ;
 
@@ -765,13 +765,13 @@ BOOST_AUTO_TEST_CASE( push_block_returns_forked_transactions ) try {
    BOOST_CHECK( !!traces.at(3)->except );
 
    // verify unapplied transactions ran
-   BOOST_REQUIRE_EQUAL( c.control->get_account( N(test1) ).name,  N(test1) );
-   BOOST_REQUIRE_EQUAL( c.control->get_account( N(test2) ).name,  N(test2) );
-   BOOST_REQUIRE_EQUAL( c.control->get_account( N(test3) ).name,  N(test3) );
+   BOOST_REQUIRE_EQUAL( c.control->get_account( "test1"_n ).name,  "test1"_n );
+   BOOST_REQUIRE_EQUAL( c.control->get_account( "test2"_n ).name,  "test2"_n );
+   BOOST_REQUIRE_EQUAL( c.control->get_account( "test3"_n ).name,  "test3"_n );
 
    // failed because of tapos to forked out block
-   BOOST_REQUIRE_EXCEPTION(c.control->get_account( N(test4) ), fc::exception,
-                           [a=N(test4)] (const fc::exception& e)->bool {
+   BOOST_REQUIRE_EXCEPTION(c.control->get_account( "test4"_n ), fc::exception,
+                           [a="test4"_n] (const fc::exception& e)->bool {
                               return std::string( e.what() ).find( a.to_string() ) != std::string::npos;
                            }) ;
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -129,20 +129,20 @@ BOOST_AUTO_TEST_CASE(reverse_endian_tests)
 BOOST_AUTO_TEST_CASE(name_suffix_tests)
 {
    BOOST_CHECK_EQUAL( name{name_suffix(name(0))}, name{0} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abcdehijklmn))}, name{N(abcdehijklmn)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abcdehijklmn1))}, name{N(abcdehijklmn1)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abc.def))}, name{N(def)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(.abc.def))}, name{N(def)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(..abc.def))}, name{N(def)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abc..def))}, name{N(def)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abc.def.ghi))}, name{N(ghi)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(.abcdefghij))}, name{N(abcdefghij)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(.abcdefghij.1))}, name{N(1)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(a.bcdefghij))}, name{N(bcdefghij)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(a.bcdefghij.1))}, name{N(1)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(......a.b.c))}, name{N(c)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abcdefhi.123))}, name{N(123)} );
-   BOOST_CHECK_EQUAL( name{name_suffix(N(abcdefhij.123))}, name{N(123)} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abcdehijklmn"_n)}, name{"abcdehijklmn"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abcdehijklmn1"_n)}, name{"abcdehijklmn1"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abc.def"_n)}, name{"def"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix(".abc.def"_n)}, name{"def"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("..abc.def"_n)}, name{"def"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abc..def"_n)}, name{"def"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abc.def.ghi"_n)}, name{"ghi"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix(".abcdefghij"_n)}, name{"abcdefghij"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix(".abcdefghij.1"_n)}, name{"1"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("a.bcdefghij"_n)}, name{"bcdefghij"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("a.bcdefghij.1"_n)}, name{"1"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("......a.b.c"_n)}, name{"c"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abcdefhi.123"_n)}, name{"123"_n} );
+   BOOST_CHECK_EQUAL( name{name_suffix("abcdefhij.123"_n)}, name{"123"_n} );
 }
 
 /// Test processing of unbalanced strings

--- a/unittests/payloadless_tests.cpp
+++ b/unittests/payloadless_tests.cpp
@@ -34,11 +34,11 @@ BOOST_AUTO_TEST_SUITE(payloadless_tests)
 
 BOOST_FIXTURE_TEST_CASE( test_doit, payloadless_tester ) {
    
-   create_accounts( {N(payloadless)} );
-   set_code( N(payloadless), contracts::payloadless_wasm() );
-   set_abi( N(payloadless), contracts::payloadless_abi().data() );
+   create_accounts( {"payloadless"_n} );
+   set_code( "payloadless"_n, contracts::payloadless_wasm() );
+   set_abi( "payloadless"_n, contracts::payloadless_abi().data() );
 
-   auto trace = push_action(N(payloadless), N(doit), N(payloadless), mutable_variant_object());
+   auto trace = push_action("payloadless"_n, "doit"_n, "payloadless"_n, mutable_variant_object());
    auto msg = trace->action_traces.front().console;
    BOOST_CHECK_EQUAL(msg == "Im a payloadless action", true);
 }
@@ -47,18 +47,18 @@ BOOST_FIXTURE_TEST_CASE( test_doit, payloadless_tester ) {
 // abi_serializer was failing when action data was empty.
 BOOST_FIXTURE_TEST_CASE( test_abi_serializer, payloadless_tester ) {
 
-   create_accounts( {N(payloadless)} );
-   set_code( N(payloadless), contracts::payloadless_wasm() );
-   set_abi( N(payloadless), contracts::payloadless_abi().data() );
+   create_accounts( {"payloadless"_n} );
+   set_code( "payloadless"_n, contracts::payloadless_wasm() );
+   set_abi( "payloadless"_n, contracts::payloadless_abi().data() );
 
    variant pretty_trx = fc::mutable_variant_object()
       ("actions", fc::variants({
          fc::mutable_variant_object()
-            ("account", name(N(payloadless)))
+            ("account", name("payloadless"_n))
             ("name", "doit")
             ("authorization", fc::variants({
                fc::mutable_variant_object()
-                  ("actor", name(N(payloadless)))
+                  ("actor", name("payloadless"_n))
                   ("permission", name(config::active_name))
             }))
             ("data", fc::mutable_variant_object()
@@ -71,7 +71,7 @@ BOOST_FIXTURE_TEST_CASE( test_abi_serializer, payloadless_tester ) {
    abi_serializer::from_variant(pretty_trx, trx, get_resolver(), abi_serializer::create_yield_function( abi_serializer_max_time ));
    set_transaction_headers(trx);
 
-   trx.sign( get_private_key( N(payloadless), "active" ), control->get_chain_id() );
+   trx.sign( get_private_key( "payloadless"_n, "active" ), control->get_chain_id() );
    auto trace = push_transaction( trx );
    auto msg = trace->action_traces.front().console;
    BOOST_CHECK_EQUAL(msg == "Im a payloadless action", true);

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_SUITE(producer_schedule_tests)
 
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
-   create_accounts( {N(alice),N(bob),N(carol)} );
+   create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    while (control->head_block_num() < 3) {
       produce_block();
    }
@@ -209,10 +209,10 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
    };
 
-   auto res = set_producers( {N(alice),N(bob)} );
+   auto res = set_producers( {"alice"_n,"bob"_n} );
    vector<producer_authority> sch1 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{1, {{get_public_key(N(alice), "active"), 1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{1, {{get_public_key(N(bob),   "active"), 1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{1, {{get_public_key("alice"_n, "active"), 1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{1, {{get_public_key("bob"_n,   "active"), 1}}}}
                                };
    //wdump((fc::json::to_pretty_string(res)));
    wlog("set producer schedule to [alice,bob]");
@@ -229,11 +229,11 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
    produce_blocks(6);
 
-   res = set_producers( {N(alice),N(bob),N(carol)} );
+   res = set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    vector<producer_authority> sch2 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{1, {{get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{1, {{get_public_key(N(bob),   "active"),1}}}},
-                                 producer_authority{N(carol), block_signing_authority_v0{1, {{get_public_key(N(carol), "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{1, {{get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{1, {{get_public_key("bob"_n,   "active"),1}}}},
+                                 producer_authority{"carol"_n, block_signing_authority_v0{1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
    BOOST_REQUIRE_EQUAL( true, control->proposed_producers().valid() );
@@ -242,16 +242,16 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    produce_block();
    produce_blocks(23); // Alice produces the last block of her first round.
                     // Bob's first block (which advances LIB to Alice's last block) is started but not finalized.
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(alice) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(bob) );
+   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "alice"_n );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "bob"_n );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2u );
 
    produce_blocks(12); // Bob produces his first 11 blocks
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    produce_blocks(12); // Bob produces his 12th block.
                     // Alice's first block of the second round is started but not finalized (which advances LIB to Bob's last block).
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(alice) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(bob) );
+   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "alice"_n );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "bob"_n );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
 
@@ -259,13 +259,13 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
 
    // The next block will be produced according to the new schedule
    produce_block();
-   BOOST_CHECK_EQUAL( control->head_block_producer(), N(carol) ); // And that next block happens to be produced by Carol.
+   BOOST_CHECK_EQUAL( control->head_block_producer(), "carol"_n ); // And that next block happens to be produced by Carol.
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
-   create_accounts( {N(alice),N(bob),N(carol)} );
+   create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    while (control->head_block_num() < 3) {
       produce_block();
    }
@@ -274,11 +274,11 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
    };
 
-   auto res = set_producers( {N(alice),N(bob),N(carol)} );
+   auto res = set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    vector<producer_authority> sch1 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{ 1, {{get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{ 1, {{get_public_key(N(bob),   "active"),1}}}},
-                                 producer_authority{N(carol), block_signing_authority_v0{ 1, {{get_public_key(N(carol), "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{get_public_key("bob"_n,   "active"),1}}}},
+                                 producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
    BOOST_REQUIRE_EQUAL( true, control->proposed_producers().valid() );
@@ -294,31 +294,31 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_reduction, tester ) try {
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
    produce_blocks(6);
 
-   res = set_producers( {N(alice),N(bob)} );
+   res = set_producers( {"alice"_n,"bob"_n} );
    vector<producer_authority> sch2 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{ 1, {{ get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{ 1, {{ get_public_key(N(bob),   "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{ get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{ get_public_key("bob"_n,   "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob]");
    BOOST_REQUIRE_EQUAL( true, control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *control->proposed_producers() ) );
 
    produce_blocks(48);
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(bob) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(carol) );
+   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "bob"_n );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "carol"_n );
    BOOST_CHECK_EQUAL( control->pending_producers().version, 2u );
 
    produce_blocks(47);
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    produce_blocks(1);
 
-   BOOST_REQUIRE_EQUAL( control->head_block_producer(), N(carol) );
-   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), N(alice) );
+   BOOST_REQUIRE_EQUAL( control->head_block_producer(), "carol"_n );
+   BOOST_REQUIRE_EQUAL( control->pending_block_producer(), "alice"_n );
    BOOST_CHECK_EQUAL( control->active_producers().version, 2u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, control->active_producers() ) );
 
    produce_blocks(2);
-   BOOST_CHECK_EQUAL( control->head_block_producer(), N(bob) );
+   BOOST_CHECK_EQUAL( control->head_block_producer(), "bob"_n );
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
@@ -328,7 +328,7 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
    validating_tester c( tempdir, true );
    c.execute_setup_policy( setup_policy::preactivate_feature_and_new_bios );
 
-   c.create_accounts( {N(alice),N(bob),N(carol)} );
+   c.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    while (c.control->head_block_num() < 3) {
       c.produce_block();
    }
@@ -337,10 +337,10 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
    };
 
-   auto res = c.set_producers_legacy( {N(alice),N(bob)} );
+   auto res = c.set_producers_legacy( {"alice"_n,"bob"_n} );
    vector<producer_authority> sch1 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{ 1, {{ get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{ 1, {{ get_public_key(N(bob),   "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{ get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{ get_public_key("bob"_n,   "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob]");
    BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().valid() );
@@ -379,11 +379,11 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
    BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
 
    // Setting a new producer schedule should still use version 2
-   res = c.set_producers_legacy( {N(alice),N(bob),N(carol)} );
+   res = c.set_producers_legacy( {"alice"_n,"bob"_n,"carol"_n} );
    vector<producer_authority> sch2 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{ 1, {{get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{ 1, {{get_public_key(N(bob),   "active"),1}}}},
-                                 producer_authority{N(carol), block_signing_authority_v0{ 1, {{get_public_key(N(carol), "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{get_public_key("bob"_n,   "active"),1}}}},
+                                 producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
    BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().valid() );
@@ -407,18 +407,18 @@ BOOST_AUTO_TEST_CASE( empty_producer_schedule_has_no_effect ) try {
 BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    tester c;
 
-   c.create_accounts( {N(alice),N(bob),N(carol)} );
+   c.create_accounts( {"alice"_n,"bob"_n,"carol"_n} );
    c.produce_block();
 
    auto compare_schedules = [&]( const vector<producer_authority>& a, const producer_authority_schedule& b ) {
       return std::equal( a.begin(), a.end(), b.producers.begin(), b.producers.end() );
    };
 
-   auto res = c.set_producers( {N(alice),N(bob),N(carol)} );
+   auto res = c.set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    vector<producer_authority> sch1 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{ 1, {{c.get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{ 1, {{c.get_public_key(N(bob),   "active"),1}}}},
-                                 producer_authority{N(carol), block_signing_authority_v0{ 1, {{c.get_public_key(N(carol), "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{c.get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{c.get_public_key("bob"_n,   "active"),1}}}},
+                                 producer_authority{"carol"_n, block_signing_authority_v0{ 1, {{c.get_public_key("carol"_n, "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob,carol]");
    BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().valid() );
@@ -433,49 +433,49 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 1u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, c.control->active_producers() ) );
 
-   produce_until_transition( c, N(carol), N(alice) );
+   produce_until_transition( c, "carol"_n, "alice"_n );
    c.produce_block();
-   produce_until_transition( c, N(carol), N(alice) );
+   produce_until_transition( c, "carol"_n, "alice"_n );
 
-   res = c.set_producers( {N(alice),N(bob)} );
+   res = c.set_producers( {"alice"_n,"bob"_n} );
    vector<producer_authority> sch2 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{ 1, {{c.get_public_key(N(alice), "active"),1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{ 1, {{c.get_public_key(N(bob),   "active"),1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{ 1, {{c.get_public_key("alice"_n, "active"),1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{ 1, {{c.get_public_key("bob"_n,   "active"),1}}}}
                                };
    wlog("set producer schedule to [alice,bob]");
    BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch2, *c.control->proposed_producers() ) );
 
-   produce_until_transition( c, N(bob), N(carol) );
-   produce_until_transition( c, N(alice), N(bob) );
+   produce_until_transition( c, "bob"_n, "carol"_n );
+   produce_until_transition( c, "alice"_n, "bob"_n );
    BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 1u );
 
-   produce_until_transition( c, N(carol), N(alice) );
+   produce_until_transition( c, "carol"_n, "alice"_n );
    BOOST_CHECK_EQUAL( c.control->pending_producers().version, 2u );
    BOOST_CHECK_EQUAL( c.control->active_producers().version, 1u );
 
-   produce_until_transition( c, N(bob), N(carol) );
-   BOOST_CHECK_EQUAL( c.control->pending_block_producer(), N(carol) );
+   produce_until_transition( c, "bob"_n, "carol"_n );
+   BOOST_CHECK_EQUAL( c.control->pending_block_producer(), "carol"_n );
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 2u );
 
    auto carol_last_produced_block_num = c.control->head_block_num() + 1;
    wdump((carol_last_produced_block_num));
 
    c.produce_block();
-   BOOST_CHECK( c.control->pending_block_producer() == N(alice) );
+   BOOST_CHECK( c.control->pending_block_producer() == "alice"_n );
 
-   res = c.set_producers( {N(alice),N(bob),N(carol)} );
+   res = c.set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    wlog("set producer schedule to [alice,bob,carol]");
    BOOST_REQUIRE_EQUAL( true, c.control->proposed_producers().valid() );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, *c.control->proposed_producers() ) );
 
-   produce_until_transition( c, N(bob), N(alice) );
+   produce_until_transition( c, "bob"_n, "alice"_n );
 
    auto bob_last_produced_block_num = c.control->head_block_num();
    wdump((bob_last_produced_block_num));
 
-   produce_until_transition( c, N(alice), N(bob) );
+   produce_until_transition( c, "alice"_n, "bob"_n );
 
    auto alice_last_produced_block_num = c.control->head_block_num();
    wdump((alice_last_produced_block_num));
@@ -483,13 +483,13 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    {
       wdump((c.control->head_block_state()->producer_to_last_produced));
       const auto& last_produced = c.control->head_block_state()->producer_to_last_produced;
-      auto alice_itr = last_produced.find( N(alice) );
+      auto alice_itr = last_produced.find( "alice"_n );
       BOOST_REQUIRE( alice_itr != last_produced.end() );
       BOOST_CHECK_EQUAL( alice_itr->second, alice_last_produced_block_num );
-      auto bob_itr = last_produced.find( N(bob) );
+      auto bob_itr = last_produced.find( "bob"_n );
       BOOST_REQUIRE( bob_itr != last_produced.end() );
       BOOST_CHECK_EQUAL( bob_itr->second, bob_last_produced_block_num );
-      auto carol_itr = last_produced.find( N(carol) );
+      auto carol_itr = last_produced.find( "carol"_n );
       BOOST_REQUIRE( carol_itr != last_produced.end() );
       BOOST_CHECK_EQUAL( carol_itr->second, carol_last_produced_block_num );
    }
@@ -497,12 +497,12 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    BOOST_CHECK_EQUAL( c.control->pending_producers().version, 3u );
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 2u );
 
-   produce_until_transition( c, N(bob), N(alice) );
+   produce_until_transition( c, "bob"_n, "alice"_n );
    BOOST_REQUIRE_EQUAL( c.control->active_producers().version, 3u );
 
-   produce_until_transition( c, N(alice), N(bob) );
+   produce_until_transition( c, "alice"_n, "bob"_n );
    c.produce_blocks(11);
-   BOOST_CHECK_EQUAL( c.control->pending_block_producer(), N(bob) );
+   BOOST_CHECK_EQUAL( c.control->pending_block_producer(), "bob"_n );
    c.finish_block();
 
    auto carol_block_num = c.control->head_block_num() + 1;
@@ -510,62 +510,62 @@ BOOST_AUTO_TEST_CASE( producer_watermark_test ) try {
    auto confirmed = carol_block_num - carol_last_produced_block_num - 1;
 
    c.control->start_block( carol_block_time, confirmed );
-   BOOST_CHECK_EQUAL( c.control->pending_block_producer(), N(carol) );
+   BOOST_CHECK_EQUAL( c.control->pending_block_producer(), "carol"_n );
    c.produce_block();
    auto h = c.control->head_block_header();
 
-   BOOST_CHECK_EQUAL( h.producer, N(carol) );
+   BOOST_CHECK_EQUAL( h.producer, "carol"_n );
    BOOST_CHECK_EQUAL( h.confirmed,  confirmed );
 
-   produce_until_transition( c, N(carol), N(alice) );
+   produce_until_transition( c, "carol"_n, "alice"_n );
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( producer_one_of_n_test, TESTER ) try {
-   create_accounts( {N(alice),N(bob)} );
+   create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
    vector<producer_authority> sch1 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{1, {{get_public_key(N(alice), "bs1"), 1}, {get_public_key(N(alice), "bs2"), 1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{1, {{get_public_key(N(bob),   "bs1"), 1}, {get_public_key(N(bob),   "bs2"), 1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{1, {{get_public_key("alice"_n, "bs1"), 1}, {get_public_key("alice"_n, "bs2"), 1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{1, {{get_public_key("bob"_n,   "bs1"), 1}, {get_public_key("bob"_n,   "bs2"), 1}}}}
                                };
 
    auto res = set_producer_schedule( sch1 );
-   block_signing_private_keys.emplace(get_public_key(N(alice), "bs1"), get_private_key(N(alice), "bs1"));
-   block_signing_private_keys.emplace(get_public_key(N(bob),   "bs1"), get_private_key(N(bob),   "bs1"));
+   block_signing_private_keys.emplace(get_public_key("alice"_n, "bs1"), get_private_key("alice"_n, "bs1"));
+   block_signing_private_keys.emplace(get_public_key("bob"_n,   "bs1"), get_private_key("bob"_n,   "bs1"));
 
-   BOOST_REQUIRE(produce_until_blocks_from(*this, {N(alice), N(bob)}, 300));
+   BOOST_REQUIRE(produce_until_blocks_from(*this, {"alice"_n, "bob"_n}, 300));
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( producer_m_of_n_test, TESTER ) try {
-   create_accounts( {N(alice),N(bob)} );
+   create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
 
    vector<producer_authority> sch1 = {
-                                 producer_authority{N(alice), block_signing_authority_v0{2, {{get_public_key(N(alice), "bs1"), 1}, {get_public_key(N(alice), "bs2"), 1}}}},
-                                 producer_authority{N(bob),   block_signing_authority_v0{2, {{get_public_key(N(bob),   "bs1"), 1}, {get_public_key(N(bob),   "bs2"), 1}}}}
+                                 producer_authority{"alice"_n, block_signing_authority_v0{2, {{get_public_key("alice"_n, "bs1"), 1}, {get_public_key("alice"_n, "bs2"), 1}}}},
+                                 producer_authority{"bob"_n,   block_signing_authority_v0{2, {{get_public_key("bob"_n,   "bs1"), 1}, {get_public_key("bob"_n,   "bs2"), 1}}}}
                                };
 
    auto res = set_producer_schedule( sch1 );
-   block_signing_private_keys.emplace(get_public_key(N(alice), "bs1"), get_private_key(N(alice), "bs1"));
-   block_signing_private_keys.emplace(get_public_key(N(alice), "bs2"), get_private_key(N(alice), "bs2"));
-   block_signing_private_keys.emplace(get_public_key(N(bob),   "bs1"), get_private_key(N(bob),   "bs1"));
-   block_signing_private_keys.emplace(get_public_key(N(bob),   "bs2"), get_private_key(N(bob),   "bs2"));
+   block_signing_private_keys.emplace(get_public_key("alice"_n, "bs1"), get_private_key("alice"_n, "bs1"));
+   block_signing_private_keys.emplace(get_public_key("alice"_n, "bs2"), get_private_key("alice"_n, "bs2"));
+   block_signing_private_keys.emplace(get_public_key("bob"_n,   "bs1"), get_private_key("bob"_n,   "bs1"));
+   block_signing_private_keys.emplace(get_public_key("bob"_n,   "bs2"), get_private_key("bob"_n,   "bs2"));
 
-   BOOST_REQUIRE(produce_until_blocks_from(*this, {N(alice), N(bob)}, 300));
+   BOOST_REQUIRE(produce_until_blocks_from(*this, {"alice"_n, "bob"_n}, 300));
 
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( satisfiable_msig_test, TESTER ) try {
-   create_accounts( {N(alice),N(bob)} );
+   create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
    vector<producer_authority> sch1 = {
-           producer_authority{N(alice), block_signing_authority_v0{2, {{get_public_key(N(alice), "bs1"), 1}}}}
+           producer_authority{"alice"_n, block_signing_authority_v0{2, {{get_public_key("alice"_n, "bs1"), 1}}}}
    };
 
    // ensure that the entries in a wtmsig schedule are rejected if not satisfiable
@@ -579,12 +579,12 @@ BOOST_FIXTURE_TEST_CASE( satisfiable_msig_test, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( duplicate_producers_test, TESTER ) try {
-   create_accounts( {N(alice)} );
+   create_accounts( {"alice"_n} );
    produce_block();
 
    vector<producer_authority> sch1 = {
-           producer_authority{N(alice), block_signing_authority_v0{1, {{get_public_key(N(alice), "bs1"), 1}}}},
-           producer_authority{N(alice), block_signing_authority_v0{1, {{get_public_key(N(alice), "bs2"), 1}}}}
+           producer_authority{"alice"_n, block_signing_authority_v0{1, {{get_public_key("alice"_n, "bs1"), 1}}}},
+           producer_authority{"alice"_n, block_signing_authority_v0{1, {{get_public_key("alice"_n, "bs2"), 1}}}}
    };
 
    // ensure that the schedule is rejected if it has duplicate producers in it
@@ -598,11 +598,11 @@ BOOST_FIXTURE_TEST_CASE( duplicate_producers_test, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( duplicate_keys_test, TESTER ) try {
-   create_accounts( {N(alice),N(bob)} );
+   create_accounts( {"alice"_n,"bob"_n} );
    produce_block();
 
    vector<producer_authority> sch1 = {
-           producer_authority{N(alice), block_signing_authority_v0{2, {{get_public_key(N(alice), "bs1"), 1}, {get_public_key(N(alice), "bs1"), 1}}}}
+           producer_authority{"alice"_n, block_signing_authority_v0{2, {{get_public_key("alice"_n, "bs1"), 1}, {get_public_key("alice"_n, "bs1"), 1}}}}
    };
 
    // ensure that the schedule is rejected if it has duplicate keys for a single producer in it
@@ -615,8 +615,8 @@ BOOST_FIXTURE_TEST_CASE( duplicate_keys_test, TESTER ) try {
 
    // ensure that multiple producers are allowed to share keys
    vector<producer_authority> sch2 = {
-           producer_authority{N(alice), block_signing_authority_v0{1, {{get_public_key(N(alice), "bs1"), 1}}}},
-           producer_authority{N(bob),   block_signing_authority_v0{1, {{get_public_key(N(alice), "bs1"), 1}}}}
+           producer_authority{"alice"_n, block_signing_authority_v0{1, {{get_public_key("alice"_n, "bs1"), 1}}}},
+           producer_authority{"bob"_n,   block_signing_authority_v0{1, {{get_public_key("alice"_n, "bs1"), 1}}}}
    };
 
    set_producer_schedule( sch2 );
@@ -632,14 +632,14 @@ BOOST_AUTO_TEST_CASE( large_authority_overflow_test ) try {
 
       for (int i = 0; i < pre_overflow_count; i++) {
          auto key_str = std::to_string(i) + "_bsk";
-         auth.keys.emplace_back(key_weight{get_public_key(N(alice), key_str), 0xFFFFU});
+         auth.keys.emplace_back(key_weight{get_public_key("alice"_n, key_str), 0xFFFFU});
       }
 
       // reduce the last weight by 1 so that its unsatisfiable
       auth.keys.back().weight = 0xFFFEU;
 
       // add one last key with a weight of 2 so that its only satisfiable with values that sum to an overflow of 32bit uint
-      auth.keys.emplace_back(key_weight{get_public_key(N(alice), std::to_string(pre_overflow_count) + "_bsk"), 0x0002U});
+      auth.keys.emplace_back(key_weight{get_public_key("alice"_n, std::to_string(pre_overflow_count) + "_bsk"), 0x0002U});
 
       auth.threshold = 0xFFFFFFFFUL;
    }

--- a/unittests/protocol_feature_tests.cpp
+++ b/unittests/protocol_feature_tests.cpp
@@ -53,13 +53,13 @@ BOOST_AUTO_TEST_CASE( activate_preactivate_feature ) try {
 
    c.produce_block();
 
-   BOOST_CHECK_EXCEPTION( c.push_action( config::system_account_name, N(reqactivated), config::system_account_name,
+   BOOST_CHECK_EXCEPTION( c.push_action( config::system_account_name, "reqactivated"_n, config::system_account_name,
                                           mutable_variant_object()("feature_digest",  digest_type()) ),
                            eosio_assert_message_exception,
                            eosio_assert_message_is( "protocol feature is not activated" )
    );
 
-   c.push_action( config::system_account_name, N(reqactivated), config::system_account_name, mutable_variant_object()
+   c.push_action( config::system_account_name, "reqactivated"_n, config::system_account_name, mutable_variant_object()
       ("feature_digest",  *d )
    );
 
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE( double_preactivation ) try {
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::only_link_to_existing_permission );
    BOOST_REQUIRE( d );
 
-   c.push_action( config::system_account_name, N(activate), config::system_account_name,
+   c.push_action( config::system_account_name, "activate"_n, config::system_account_name,
                   fc::mutable_variant_object()("feature_digest", *d), 10 );
 
    std::string expected_error_msg("protocol feature with digest '");
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE( double_preactivation ) try {
       expected_error_msg += "' is already pre-activated";
    }
 
-   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, N(activate), config::system_account_name,
+   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, "activate"_n, config::system_account_name,
                                           fc::mutable_variant_object()("feature_digest", *d), 20 ),
                            protocol_feature_exception,
                            fc_exception_message_is( expected_error_msg )
@@ -208,9 +208,9 @@ BOOST_AUTO_TEST_CASE( only_link_to_existing_permission_test ) try {
    auto d = pfm.get_builtin_digest( builtin_protocol_feature_t::only_link_to_existing_permission );
    BOOST_REQUIRE( d );
 
-   c.create_accounts( {N(alice), N(bob), N(charlie)} );
+   c.create_accounts( {"alice"_n, "bob"_n, "charlie"_n} );
 
-   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, N(linkauth), N(bob), fc::mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, "linkauth"_n, "bob"_n, fc::mutable_variant_object()
                               ("account", "bob")
                               ("code", name(config::system_account_name))
                               ("type", "")
@@ -219,7 +219,7 @@ BOOST_AUTO_TEST_CASE( only_link_to_existing_permission_test ) try {
                            fc_exception_message_is( "Failed to retrieve permission: test" )
    );
 
-   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, N(linkauth), N(charlie), fc::mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, "linkauth"_n, "charlie"_n, fc::mutable_variant_object()
                               ("account", "charlie")
                               ("code", name(config::system_account_name))
                               ("type", "")
@@ -228,7 +228,7 @@ BOOST_AUTO_TEST_CASE( only_link_to_existing_permission_test ) try {
                            fc_exception_message_is( "Failed to retrieve permission: test" )
    );
 
-   c.push_action( config::system_account_name, N(updateauth), N(alice), fc::mutable_variant_object()
+   c.push_action( config::system_account_name, "updateauth"_n, "alice"_n, fc::mutable_variant_object()
       ("account", "alice")
       ("permission", "test")
       ("parent", "active")
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE( only_link_to_existing_permission_test ) try {
    c.produce_block();
 
    // Verify the incorrect behavior prior to ONLY_LINK_TO_EXISTING_PERMISSION activation.
-   c.push_action( config::system_account_name, N(linkauth), N(bob), fc::mutable_variant_object()
+   c.push_action( config::system_account_name, "linkauth"_n, "bob"_n, fc::mutable_variant_object()
       ("account", "bob")
       ("code", name(config::system_account_name))
       ("type", "")
@@ -249,7 +249,7 @@ BOOST_AUTO_TEST_CASE( only_link_to_existing_permission_test ) try {
    c.produce_block();
 
    // Verify the correct behavior after ONLY_LINK_TO_EXISTING_PERMISSION activation.
-   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, N(linkauth), N(charlie), fc::mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  c.push_action( config::system_account_name, "linkauth"_n, "charlie"_n, fc::mutable_variant_object()
                               ("account", "charlie")
                               ("code", name(config::system_account_name))
                               ("type", "")
@@ -373,25 +373,25 @@ BOOST_AUTO_TEST_CASE( subjective_restrictions_test ) try {
 BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
    tester c( setup_policy::preactivate_feature_and_new_bios );
 
-   c.create_accounts( {N(alice), N(bob), N(test)} );
-   c.set_code( N(test), contracts::deferred_test_wasm() );
-   c.set_abi( N(test), contracts::deferred_test_abi().data() );
+   c.create_accounts( {"alice"_n, "bob"_n, "test"_n} );
+   c.set_code( "test"_n, contracts::deferred_test_wasm() );
+   c.set_abi( "test"_n, contracts::deferred_test_abi().data() );
    c.produce_block();
 
-   auto alice_ram_usage0 = c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) );
+   auto alice_ram_usage0 = c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n );
 
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 42)
       ("contract", "test")
       ("payload", 100)
    );
 
-   auto alice_ram_usage1 = c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) );
+   auto alice_ram_usage1 = c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n );
 
    // Verify subjective mitigation is in place
    BOOST_CHECK_EXCEPTION(
-      c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+      c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
                         ("payer", "alice")
                         ("sender_id", 42)
                         ("contract", "test")
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
       fc_exception_message_is( "Replacing a deferred transaction is temporarily disabled." )
    );
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage1 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage1 );
 
    c.control->abort_block();
 
@@ -410,29 +410,29 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
    cfg.disable_all_subjective_mitigations = true;
    c.init( cfg );
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage0 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage0 );
 
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 42)
       ("contract", "test")
       ("payload", 100)
    );
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage1 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage1 );
    auto dtrxs = c.get_scheduled_transactions();
    BOOST_CHECK_EQUAL( dtrxs.size(), 1 );
    auto first_dtrx_id = dtrxs[0];
 
    // With the subjective mitigation disabled, replacing the deferred transaction is allowed.
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 42)
       ("contract", "test")
       ("payload", 101)
    );
 
-   auto alice_ram_usage2 = c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) );
+   auto alice_ram_usage2 = c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n );
    BOOST_CHECK_EQUAL( alice_ram_usage2, alice_ram_usage1 + (alice_ram_usage1 - alice_ram_usage0) );
 
    dtrxs = c.get_scheduled_transactions();
@@ -441,7 +441,7 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
 
    c.produce_block();
 
-   auto alice_ram_usage3 = c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) );
+   auto alice_ram_usage3 = c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n );
    BOOST_CHECK_EQUAL( alice_ram_usage3, alice_ram_usage1 );
 
    dtrxs = c.get_scheduled_transactions();
@@ -461,37 +461,37 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
    c.preactivate_protocol_features( {*d} );
    c.produce_block();
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage0 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage0 );
 
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 42)
       ("contract", "test")
       ("payload", 100)
    );
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage1 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage1 );
 
    dtrxs = c.get_scheduled_transactions();
    BOOST_CHECK_EQUAL( dtrxs.size(), 1 );
    auto first_dtrx_id2 = dtrxs[0];
 
    // With REPLACE_DEFERRED activated, replacing the deferred transaction is allowed and now should work properly.
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 42)
       ("contract", "test")
       ("payload", 101)
    );
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage1 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage1 );
 
    dtrxs = c.get_scheduled_transactions();
    BOOST_CHECK_EQUAL( dtrxs.size(), 1 );
    BOOST_CHECK( first_dtrx_id2 != dtrxs[0] );
 
    // Replace again with a deferred transaction identical to the first one
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 42)
       ("contract", "test")
@@ -499,7 +499,7 @@ BOOST_AUTO_TEST_CASE( replace_deferred_test ) try {
       100 // Needed to make this input transaction unique
    );
 
-   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( N(alice) ), alice_ram_usage1 );
+   BOOST_CHECK_EQUAL( c.control->get_resource_limits_manager().get_account_ram_usage( "alice"_n ), alice_ram_usage1 );
 
    dtrxs = c.get_scheduled_transactions();
    BOOST_CHECK_EQUAL( dtrxs.size(), 1 );
@@ -511,14 +511,14 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
    tester c( setup_policy::preactivate_feature_and_new_bios );
    tester c2( setup_policy::none );
 
-   c.create_accounts( {N(alice), N(test)} );
-   c.set_code( N(test), contracts::deferred_test_wasm() );
-   c.set_abi( N(test), contracts::deferred_test_abi().data() );
+   c.create_accounts( {"alice"_n, "test"_n} );
+   c.set_code( "test"_n, contracts::deferred_test_wasm() );
+   c.set_abi( "test"_n, contracts::deferred_test_abi().data() );
    c.produce_block();
 
    push_blocks( c, c2 );
 
-   c2.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c2.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 1)
       ("contract", "test")
@@ -563,7 +563,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 
    BOOST_REQUIRE_EQUAL(0, index.size());
 
-   c.push_action( config::system_account_name, N(reqauth), N(alice), fc::mutable_variant_object()
+   c.push_action( config::system_account_name, "reqauth"_n, "alice"_n, fc::mutable_variant_object()
       ("from", "alice"),
       5, 2
    );
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
    auto d2 = pfm.get_builtin_digest( builtin_protocol_feature_t::no_duplicate_deferred_id );
    BOOST_REQUIRE( d2 );
 
-   c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 1)
       ("contract", "test")
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
    };
 
    BOOST_CHECK_EXCEPTION(
-      c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+      c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
                         ("payer", "alice")
                         ("sender_id", 1)
                         ("contract", "test")
@@ -645,7 +645,7 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 
    BOOST_REQUIRE_EQUAL(0, index.size());
 
-   auto trace2 = c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   auto trace2 = c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 1)
       ("contract", "test")
@@ -656,14 +656,14 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 
    check_generation_context( index.begin()->packed_trx,
                              trace2->id,
-                             ((static_cast<unsigned __int128>(N(alice).to_uint64_t()) << 64) | 1),
-                             N(test) );
+                             ((static_cast<unsigned __int128>("alice"_n.to_uint64_t()) << 64) | 1),
+                             "test"_n );
 
    c.produce_block();
 
    BOOST_REQUIRE_EQUAL(0, index.size());
 
-   auto trace3 = c.push_action( N(test), N(defercall), N(alice), fc::mutable_variant_object()
+   auto trace3 = c.push_action( "test"_n, "defercall"_n, "alice"_n, fc::mutable_variant_object()
       ("payer", "alice")
       ("sender_id", 1)
       ("contract", "test")
@@ -674,8 +674,8 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 
    check_generation_context( index.begin()->packed_trx,
                              trace3->id,
-                             ((static_cast<unsigned __int128>(N(alice).to_uint64_t()) << 64) | 1),
-                             N(test) );
+                             ((static_cast<unsigned __int128>("alice"_n.to_uint64_t()) << 64) | 1),
+                             "test"_n );
 
    c.produce_block();
 
@@ -684,10 +684,10 @@ BOOST_AUTO_TEST_CASE( no_duplicate_deferred_id_test ) try {
 BOOST_AUTO_TEST_CASE( fix_linkauth_restriction ) { try {
    tester chain( setup_policy::preactivate_feature_and_new_bios );
 
-   const auto& tester_account = N(tester);
+   const auto& tester_account = "tester"_n;
 
    chain.produce_blocks();
-   chain.create_account(N(currency));
+   chain.create_account("currency"_n);
    chain.create_account(tester_account);
    chain.produce_blocks();
 
@@ -769,7 +769,7 @@ BOOST_AUTO_TEST_CASE( disallow_empty_producer_schedule_test ) { try {
                             fc_exception_message_is( "Producer schedule cannot be empty" ) );
 
    // Setting non empty producer schedule should still be fine
-   vector<name> producer_names = {N(alice),N(bob),N(carol)};
+   vector<name> producer_names = {"alice"_n,"bob"_n,"carol"_n};
    c.create_accounts( producer_names );
    c.set_producers_legacy( producer_names );
    c.produce_blocks(2);
@@ -785,30 +785,30 @@ BOOST_AUTO_TEST_CASE( restrict_action_to_self_test ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::restrict_action_to_self );
    BOOST_REQUIRE( d );
 
-   c.create_accounts( {N(testacc), N(acctonotify), N(alice)} );
-   c.set_code( N(testacc), contracts::restrict_action_test_wasm() );
-   c.set_abi( N(testacc), contracts::restrict_action_test_abi().data() );
+   c.create_accounts( {"testacc"_n, "acctonotify"_n, "alice"_n} );
+   c.set_code( "testacc"_n, contracts::restrict_action_test_wasm() );
+   c.set_abi( "testacc"_n, contracts::restrict_action_test_abi().data() );
 
-   c.set_code( N(acctonotify), contracts::restrict_action_test_wasm() );
-   c.set_abi( N(acctonotify), contracts::restrict_action_test_abi().data() );
+   c.set_code( "acctonotify"_n, contracts::restrict_action_test_wasm() );
+   c.set_abi( "acctonotify"_n, contracts::restrict_action_test_abi().data() );
 
    // Before the protocol feature is preactivated
    // - Sending inline action to self = no problem
    // - Sending deferred trx to self = throw subjective exception
    // - Sending inline action to self from notification = throw subjective exception
    // - Sending deferred trx to self from notification = throw subjective exception
-   BOOST_CHECK_NO_THROW( c.push_action( N(testacc), N(sendinline), N(alice), mutable_variant_object()("authorizer", "alice")) );
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(senddefer), N(alice),
+   BOOST_CHECK_NO_THROW( c.push_action( "testacc"_n, "sendinline"_n, "alice"_n, mutable_variant_object()("authorizer", "alice")) );
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "senddefer"_n, "alice"_n,
                                            mutable_variant_object()("authorizer", "alice")("senderid", 0)),
                             subjective_block_production_exception,
                             fc_exception_message_starts_with( "Authorization failure with sent deferred transaction" ) );
 
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(notifyinline), N(alice),
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "notifyinline"_n, "alice"_n,
                                         mutable_variant_object()("acctonotify", "acctonotify")("authorizer", "alice")),
                             subjective_block_production_exception,
                             fc_exception_message_starts_with( "Authorization failure with inline action sent to self" ) );
 
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(notifydefer), N(alice),
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "notifydefer"_n, "alice"_n,
                                            mutable_variant_object()("acctonotify", "acctonotify")("authorizer", "alice")("senderid", 1)),
                             subjective_block_production_exception,
                             fc_exception_message_starts_with( "Authorization failure with sent deferred transaction" ) );
@@ -817,21 +817,21 @@ BOOST_AUTO_TEST_CASE( restrict_action_to_self_test ) { try {
    c.produce_block();
 
    // After the protocol feature is preactivated, all the 4 cases will throw an objective unsatisfied_authorization exception
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(sendinline), N(alice), mutable_variant_object()("authorizer", "alice") ),
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "sendinline"_n, "alice"_n, mutable_variant_object()("authorizer", "alice") ),
                             unsatisfied_authorization,
                             fc_exception_message_starts_with( "transaction declares authority" ) );
 
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(senddefer), N(alice),
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "senddefer"_n, "alice"_n,
                                            mutable_variant_object()("authorizer", "alice")("senderid", 3)),
                             unsatisfied_authorization,
                             fc_exception_message_starts_with( "transaction declares authority" ) );
 
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(notifyinline), N(alice),
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "notifyinline"_n, "alice"_n,
                                            mutable_variant_object()("acctonotify", "acctonotify")("authorizer", "alice") ),
                             unsatisfied_authorization,
                             fc_exception_message_starts_with( "transaction declares authority" ) );
 
-   BOOST_REQUIRE_EXCEPTION( c.push_action( N(testacc), N(notifydefer), N(alice),
+   BOOST_REQUIRE_EXCEPTION( c.push_action( "testacc"_n, "notifydefer"_n, "alice"_n,
                                            mutable_variant_object()("acctonotify", "acctonotify")("authorizer", "alice")("senderid", 4)),
                             unsatisfied_authorization,
                             fc_exception_message_starts_with( "transaction declares authority" ) );
@@ -841,20 +841,20 @@ BOOST_AUTO_TEST_CASE( restrict_action_to_self_test ) { try {
 BOOST_AUTO_TEST_CASE( only_bill_to_first_authorizer ) { try {
    tester chain( setup_policy::preactivate_feature_and_new_bios );
 
-   const auto& tester_account = N(tester);
-   const auto& tester_account2 = N(tester2);
+   const auto& tester_account = "tester"_n;
+   const auto& tester_account2 = "tester2"_n;
 
    chain.produce_blocks();
    chain.create_account(tester_account);
    chain.create_account(tester_account2);
 
-   chain.push_action(config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+   chain.push_action(config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
       ("account", name(tester_account).to_string())
       ("ram_bytes", 10000)
       ("net_weight", 1000)
       ("cpu_weight", 1000));
 
-   chain.push_action(config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+   chain.push_action(config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
       ("account", name(tester_account2).to_string())
       ("ram_bytes", 10000)
       ("net_weight", 1000)
@@ -867,7 +867,7 @@ BOOST_AUTO_TEST_CASE( only_bill_to_first_authorizer ) { try {
    {
       action act;
       act.account = tester_account;
-      act.name = N(null);
+      act.name = "null"_n;
       act.authorization = vector<permission_level>{
          {tester_account, config::active_name},
          {tester_account2, config::active_name}
@@ -912,7 +912,7 @@ BOOST_AUTO_TEST_CASE( only_bill_to_first_authorizer ) { try {
    {
       action act;
       act.account = tester_account;
-      act.name = N(null2);
+      act.name = "null2"_n;
       act.authorization = vector<permission_level>{
          {tester_account, config::active_name},
          {tester_account2, config::active_name}
@@ -948,8 +948,8 @@ BOOST_AUTO_TEST_CASE( only_bill_to_first_authorizer ) { try {
 BOOST_AUTO_TEST_CASE( forward_setcode_test ) { try {
    tester c( setup_policy::preactivate_feature_only );
 
-   const auto& tester1_account = N(tester1);
-   const auto& tester2_account = N(tester2);
+   const auto& tester1_account = "tester1"_n;
+   const auto& tester2_account = "tester2"_n;
    c.create_accounts( {tester1_account, tester2_account} );
 
    // Deploy contract that rejects all actions dispatched to it with the following exceptions:
@@ -982,7 +982,7 @@ BOOST_AUTO_TEST_CASE( forward_setcode_test ) { try {
    push_blocks( c, c2 ); // make a backup of the chain to enable testing further conditions.
 
    c.set_before_producer_authority_bios_contract(); // To allow pushing further actions for setting up the other part of the test.
-   c.create_account( N(rejectall) );
+   c.create_account( "rejectall"_n );
    c.produce_block();
    // The existence of the rejectall account will make the reject_all contract reject all actions with no exception.
 
@@ -995,7 +995,7 @@ BOOST_AUTO_TEST_CASE( forward_setcode_test ) { try {
 
    // Going back to the backup chain, we can create the rejectall account while the reject_all contract is
    // already deployed on eosio.
-   c2.create_account( N(rejectall) );
+   c2.create_account( "rejectall"_n );
    c2.produce_block();
    // Now all actions dispatched to the eosio account should be rejected.
 
@@ -1030,30 +1030,30 @@ BOOST_AUTO_TEST_CASE( get_sender_test ) { try {
    c.set_abi( tester2_account, contracts::get_sender_test_abi().data() );
    c.produce_block();
 
-   BOOST_CHECK_EXCEPTION(  c.push_action( tester1_account, N(sendinline), tester1_account, mutable_variant_object()
+   BOOST_CHECK_EXCEPTION(  c.push_action( tester1_account, "sendinline"_n, tester1_account, mutable_variant_object()
                                              ("to", tester2_account.to_string())
                                              ("expected_sender", account_name{}) ),
                            eosio_assert_message_exception,
                            eosio_assert_message_is( "sender did not match" ) );
 
-   c.push_action( tester1_account, N(sendinline), tester1_account, mutable_variant_object()
+   c.push_action( tester1_account, "sendinline"_n, tester1_account, mutable_variant_object()
       ("to", tester2_account.to_string())
       ("expected_sender", tester1_account.to_string())
    );
 
-   c.push_action( tester1_account, N(notify), tester1_account, mutable_variant_object()
+   c.push_action( tester1_account, "notify"_n, tester1_account, mutable_variant_object()
       ("to", tester2_account.to_string())
       ("expected_sender", tester1_account.to_string())
       ("send_inline", false)
    );
 
-   c.push_action( tester1_account, N(notify), tester1_account, mutable_variant_object()
+   c.push_action( tester1_account, "notify"_n, tester1_account, mutable_variant_object()
       ("to", tester2_account.to_string())
       ("expected_sender", tester2_account.to_string())
       ("send_inline", true)
    );
 
-   c.push_action( tester1_account, N(assertsender), tester1_account, mutable_variant_object()
+   c.push_action( tester1_account, "assertsender"_n, tester1_account, mutable_variant_object()
       ("expected_sender", account_name{})
    );
 } FC_LOG_AND_RETHROW() }
@@ -1075,7 +1075,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    c.produce_block();
 
    // Basic setup
-   c.push_action( tester1_account, N(setdata), alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, alice_account, mutable_variant_object()
       ("len1", 10)
       ("len2", 0)
       ("payer", alice_account)
@@ -1083,7 +1083,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Cannot bill more RAM to another account that has not authorized the action.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, N(setdata), bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
          ("len1", 20)
          ("len2", 0)
          ("payer", alice_account)
@@ -1095,7 +1095,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // Cannot migrate data from table1 to table2 paid by another account
    // in a RAM usage neutral way without the authority of that account.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, N(setdata), bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
          ("len1", 0)
          ("len2", 10)
          ("payer", alice_account)
@@ -1108,7 +1108,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // even if the account authorized the original action.
    // This is due to the subjective mitigation in place.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, N(notifysetdat), alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 20)
          ("len2", 0)
@@ -1122,7 +1122,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // in a RAM usage neutral way within a notification.
    // This is due to the subjective mitigation in place.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, N(notifysetdat), alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 0)
          ("len2", 10)
@@ -1134,7 +1134,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Cannot send deferred transaction paid by another account that has not authorized the action.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, N(senddefer), bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "senddefer"_n, bob_account, mutable_variant_object()
          ("senderid", 123)
          ("payer", alice_account)
       ),
@@ -1146,7 +1146,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // even if the account authorized the original action.
    // This is due to the subjective mitigation in place.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, N(notifydefer), alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifydefer"_n, alice_account, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("senderid", 123)
          ("payer", alice_account)
@@ -1156,7 +1156,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    );
 
    // Can send deferred transaction paid by another account if it has authorized the action.
-   c.push_action( tester1_account, N(senddefer), alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "senddefer"_n, alice_account, mutable_variant_object()
       ("senderid", 123)
       ("payer", alice_account)
    );
@@ -1164,7 +1164,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Can migrate data from table1 to table2 paid by another account
    // in a RAM usage neutral way with the authority of that account.
-   c.push_action( tester1_account, N(setdata), alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, alice_account, mutable_variant_object()
       ("len1", 0)
       ("len2", 10)
       ("payer", alice_account)
@@ -1183,7 +1183,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // Without the subjective mitigation, it is now possible to bill more RAM to another account
    // within a notification if the account authorized the original action.
    // This is due to the subjective mitigation in place.
-   c.push_action( tester2_account, N(notifysetdat), alice_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
       ("acctonotify", tester1_account)
       ("len1", 10)
       ("len2", 10)
@@ -1191,7 +1191,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    );
 
    // Reset back to the original state.
-   c.push_action( tester1_account, N(setdata), alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, alice_account, mutable_variant_object()
       ("len1", 10)
       ("len2", 0)
       ("payer", alice_account)
@@ -1209,7 +1209,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // even if the account authorized the original action.
    // This is due to the subjective mitigation in place.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, N(notifysetdat), alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 10)
          ("len2", 10)
@@ -1230,7 +1230,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // Cannot send deferred transaction paid by another account that has not authorized the action.
    // This still fails objectively, but now with another error message.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, N(senddefer), bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "senddefer"_n, bob_account, mutable_variant_object()
          ("senderid", 123)
          ("payer", alice_account)
       ),
@@ -1242,7 +1242,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // even if the account authorized the original action.
    // This now fails with an objective error.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, N(notifydefer), alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifydefer"_n, alice_account, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("senderid", 123)
          ("payer", alice_account)
@@ -1255,7 +1255,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // even if the account authorized the original action.
    // This now fails with an objective error.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester2_account, N(notifysetdat), alice_account, mutable_variant_object()
+      c.push_action( tester2_account, "notifysetdat"_n, alice_account, mutable_variant_object()
          ("acctonotify", tester1_account)
          ("len1", 20)
          ("len2", 0)
@@ -1268,7 +1268,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // Cannot bill more RAM to another account that has not authorized the action.
    // This still fails objectively, but now with another error message.
    BOOST_REQUIRE_EXCEPTION(
-      c.push_action( tester1_account, N(setdata), bob_account, mutable_variant_object()
+      c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
          ("len1", 20)
          ("len2", 0)
          ("payer", alice_account)
@@ -1278,7 +1278,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    );
 
    // Still can send deferred transaction paid by another account if it has authorized the action.
-   c.push_action( tester1_account, N(senddefer), alice_account, mutable_variant_object()
+   c.push_action( tester1_account, "senddefer"_n, alice_account, mutable_variant_object()
       ("senderid", 123)
       ("payer", alice_account)
    );
@@ -1286,7 +1286,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Now can migrate data from table1 to table2 paid by another account
    // in a RAM usage neutral way without the authority of that account.
-   c.push_action( tester1_account, N(setdata), bob_account, mutable_variant_object()
+   c.push_action( tester1_account, "setdata"_n, bob_account, mutable_variant_object()
       ("len1", 0)
       ("len2", 10)
       ("payer", alice_account)
@@ -1294,7 +1294,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Now can also migrate data from table2 to table1 paid by another account
    // in a RAM usage neutral way even within a notification .
-   c.push_action( tester2_account, N(notifysetdat), bob_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, bob_account, mutable_variant_object()
       ("acctonotify", "tester1")
       ("len1", 10)
       ("len2", 0)
@@ -1303,7 +1303,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
 
    // Of course it should also be possible to migrate data from table1 to table2 paid by another account
    // in a way that reduces RAM usage as well, even within a notification.
-   c.push_action( tester2_account, N(notifysetdat), bob_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, bob_account, mutable_variant_object()
       ("acctonotify", "tester1")
       ("len1", 0)
       ("len2", 5)
@@ -1313,7 +1313,7 @@ BOOST_AUTO_TEST_CASE( ram_restrictions_test ) { try {
    // It should also still be possible for the receiver to take over payment of the RAM
    // if it is necessary to increase RAM usage without the authorization of the original payer.
    // This should all be possible to do even within a notification.
-   c.push_action( tester2_account, N(notifysetdat), bob_account, mutable_variant_object()
+   c.push_action( tester2_account, "notifysetdat"_n, bob_account, mutable_variant_object()
       ("acctonotify", "tester1")
       ("len1", 10)
       ("len2", 10)
@@ -1331,20 +1331,20 @@ BOOST_AUTO_TEST_CASE( webauthn_producer ) { try {
    const auto& d = pfm.get_builtin_digest( builtin_protocol_feature_t::webauthn_key );
    BOOST_REQUIRE( d );
 
-   c.create_account(N(waprod));
+   c.create_account("waprod"_n);
    c.produce_block();
 
-   vector<legacy::producer_key> waprodsched = {{N(waprod), public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s)}};
+   vector<legacy::producer_key> waprodsched = {{"waprod"_n, public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s)}};
 
    BOOST_CHECK_THROW(
-      c.push_action(config::system_account_name, N(setprods), config::system_account_name, fc::mutable_variant_object()("schedule", waprodsched)),
+      c.push_action(config::system_account_name, "setprods"_n, config::system_account_name, fc::mutable_variant_object()("schedule", waprodsched)),
       eosio::chain::unactivated_key_type
    );
 
    c.preactivate_protocol_features( {*d} );
    c.produce_block();
 
-   c.push_action(config::system_account_name, N(setprods), config::system_account_name, fc::mutable_variant_object()("schedule", waprodsched));
+   c.push_action(config::system_account_name, "setprods"_n, config::system_account_name, fc::mutable_variant_object()("schedule", waprodsched));
 } FC_LOG_AND_RETHROW() }
 
 BOOST_AUTO_TEST_CASE( webauthn_create_account ) { try {
@@ -1361,7 +1361,7 @@ BOOST_AUTO_TEST_CASE( webauthn_create_account ) { try {
    trx.actions.emplace_back(vector<permission_level>{{config::system_account_name,config::active_name}},
                               newaccount{
                                  .creator  = config::system_account_name,
-                                 .name     = N(waaccount),
+                                 .name     = "waaccount"_n,
                                  .owner    = auth,
                                  .active   = auth,
                               });
@@ -1382,17 +1382,17 @@ BOOST_AUTO_TEST_CASE( webauthn_update_account_auth ) { try {
    const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::webauthn_key);
    BOOST_REQUIRE(d);
 
-   c.create_account(N(billy));
+   c.create_account("billy"_n);
    c.produce_block();
 
-   BOOST_CHECK_THROW(c.set_authority(N(billy), config::active_name,
+   BOOST_CHECK_THROW(c.set_authority("billy"_n, config::active_name,
                         authority(public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s))),
                      eosio::chain::unactivated_key_type);
 
    c.preactivate_protocol_features( {*d} );
    c.produce_block();
 
-   c.set_authority(N(billy), config::active_name, authority(public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s)));
+   c.set_authority("billy"_n, config::active_name, authority(public_key_type("PUB_WA_WdCPfafVNxVMiW5ybdNs83oWjenQXvSt1F49fg9mv7qrCiRwHj5b38U3ponCFWxQTkDsMC"s)));
 } FC_LOG_AND_RETHROW() }
 
 /*
@@ -1433,19 +1433,19 @@ BOOST_AUTO_TEST_CASE( webauthn_recover_key ) { try {
    const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::webauthn_key);
    BOOST_REQUIRE(d);
 
-   c.create_account(N(bob));
-   c.set_code(N(bob), webauthn_recover_key_wast);
+   c.create_account("bob"_n);
+   c.set_code("bob"_n, webauthn_recover_key_wast);
    c.produce_block();
 
    signed_transaction trx;
    action act;
-   act.account = N(bob);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(bob),config::active_name}};
+   act.account = "bob"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"bob"_n,config::active_name}};
    trx.actions.push_back(act);
 
    c.set_transaction_headers(trx);
-   trx.sign(c.get_private_key( N(bob), "active" ), c.control->get_chain_id());
+   trx.sign(c.get_private_key( "bob"_n, "active" ), c.control->get_chain_id());
    BOOST_CHECK_THROW(c.push_transaction(trx), eosio::chain::unactivated_signature_type);
 
    c.preactivate_protocol_features( {*d} );
@@ -1481,19 +1481,19 @@ BOOST_AUTO_TEST_CASE( webauthn_assert_recover_key ) { try {
    const auto& d = pfm.get_builtin_digest(builtin_protocol_feature_t::webauthn_key);
    BOOST_REQUIRE(d);
 
-   c.create_account(N(bob));
-   c.set_code(N(bob), webauthn_assert_recover_key_wast);
+   c.create_account("bob"_n);
+   c.set_code("bob"_n, webauthn_assert_recover_key_wast);
    c.produce_block();
 
    signed_transaction trx;
    action act;
-   act.account = N(bob);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(bob),config::active_name}};
+   act.account = "bob"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"bob"_n,config::active_name}};
    trx.actions.push_back(act);
 
    c.set_transaction_headers(trx);
-   trx.sign(c.get_private_key( N(bob), "active" ), c.control->get_chain_id());
+   trx.sign(c.get_private_key( "bob"_n, "active" ), c.control->get_chain_id());
    BOOST_CHECK_THROW(c.push_transaction(trx), eosio::chain::unactivated_signature_type);
 
    c.preactivate_protocol_features( {*d} );
@@ -1547,7 +1547,7 @@ BOOST_AUTO_TEST_CASE( set_proposed_producers_ex_test ) { try {
            "alice does not have permission to call this API"
    );
 
-   c.push_action(config::system_account_name, N(setpriv), config::system_account_name,  fc::mutable_variant_object()("account", alice_account)("is_priv", 1));
+   c.push_action(config::system_account_name, "setpriv"_n, config::system_account_name,  fc::mutable_variant_object()("account", alice_account)("is_priv", 1));
 
    //ensure it can be called w/ privilege
    BOOST_REQUIRE_EQUAL(c.push_action(action({{ alice_account, permission_name("active") }}, alice_account, action_name(), {} ), alice_account.to_uint64_t()), c.success());
@@ -1593,7 +1593,7 @@ BOOST_AUTO_TEST_CASE( producer_schedule_change_extension_test ) { try {
       // re-sign the bad block
       auto header_bmroot = digest_type::hash( std::make_pair( bad_block->digest(), remote.control->head_block_state()->blockroot_merkle ) );
       auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state()->pending_schedule.schedule_hash) );
-      bad_block->producer_signature = remote.get_private_key(N(eosio), "active").sign(sig_digest);
+      bad_block->producer_signature = remote.get_private_key("eosio"_n, "active").sign(sig_digest);
 
       // ensure it is rejected as an unknown extension
       BOOST_REQUIRE_EXCEPTION(
@@ -1612,7 +1612,7 @@ BOOST_AUTO_TEST_CASE( producer_schedule_change_extension_test ) { try {
       // re-sign the bad block
       auto header_bmroot = digest_type::hash( std::make_pair( bad_block->digest(), remote.control->head_block_state()->blockroot_merkle ) );
       auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state()->pending_schedule.schedule_hash) );
-      bad_block->producer_signature = remote.get_private_key(N(eosio), "active").sign(sig_digest);
+      bad_block->producer_signature = remote.get_private_key("eosio"_n, "active").sign(sig_digest);
 
       // ensure it is accepted (but rejected because it doesn't match expected state)
       BOOST_REQUIRE_EXCEPTION(
@@ -1640,7 +1640,7 @@ BOOST_AUTO_TEST_CASE( producer_schedule_change_extension_test ) { try {
       // re-sign the bad block
       auto header_bmroot = digest_type::hash( std::make_pair( bad_block->digest(), remote.control->head_block_state()->blockroot_merkle ) );
       auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state()->pending_schedule.schedule_hash) );
-      bad_block->producer_signature = remote.get_private_key(N(eosio), "active").sign(sig_digest);
+      bad_block->producer_signature = remote.get_private_key("eosio"_n, "active").sign(sig_digest);
 
       // ensure it is rejected because it doesn't match expected state (but the extention was accepted)
       BOOST_REQUIRE_EXCEPTION(
@@ -1659,7 +1659,7 @@ BOOST_AUTO_TEST_CASE( producer_schedule_change_extension_test ) { try {
       // re-sign the bad block
       auto header_bmroot = digest_type::hash( std::make_pair( bad_block->digest(), remote.control->head_block_state()->blockroot_merkle ) );
       auto sig_digest = digest_type::hash( std::make_pair(header_bmroot, remote.control->head_block_state()->pending_schedule.schedule_hash) );
-      bad_block->producer_signature = remote.get_private_key(N(eosio), "active").sign(sig_digest);
+      bad_block->producer_signature = remote.get_private_key("eosio"_n, "active").sign(sig_digest);
 
       // ensure it is rejected because the new_producers field is not null
       BOOST_REQUIRE_EXCEPTION(
@@ -1683,8 +1683,8 @@ BOOST_AUTO_TEST_CASE( wtmsig_block_signing_inflight_legacy_test ) { try {
 
    // activate the feature, and start an in-flight producer schedule change with the legacy format
    c.preactivate_protocol_features( {*d} );
-   vector<legacy::producer_key> sched = {{N(eosio), c.get_public_key(N(eosio), "bsk")}};
-   c.push_action(config::system_account_name, N(setprods), config::system_account_name, fc::mutable_variant_object()("schedule", sched));
+   vector<legacy::producer_key> sched = {{"eosio"_n, c.get_public_key("eosio"_n, "bsk")}};
+   c.push_action(config::system_account_name, "setprods"_n, config::system_account_name, fc::mutable_variant_object()("schedule", sched));
    c.produce_block();
 
    // ensure the last legacy block contains a new_producers
@@ -1698,7 +1698,7 @@ BOOST_AUTO_TEST_CASE( wtmsig_block_signing_inflight_legacy_test ) { try {
    BOOST_REQUIRE_EXCEPTION( c.produce_block(), no_block_signatures, fc_exception_message_is( "Signer returned no signatures" ));
    c.control->abort_block();
 
-   c.block_signing_private_keys.emplace(get_public_key(N(eosio), "bsk"), get_private_key(N(eosio), "bsk"));
+   c.block_signing_private_keys.emplace(get_public_key("eosio"_n, "bsk"), get_private_key("eosio"_n, "bsk"));
    c.produce_block();
 
 } FC_LOG_AND_RETHROW() }
@@ -1717,8 +1717,8 @@ BOOST_AUTO_TEST_CASE( wtmsig_block_signing_inflight_extension_test ) { try {
    c.produce_block();
 
    // start an in-flight producer schedule change before the activation is availble to header only validators
-   vector<legacy::producer_key> sched = {{N(eosio), c.get_public_key(N(eosio), "bsk")}};
-   c.push_action(config::system_account_name, N(setprods), config::system_account_name, fc::mutable_variant_object()("schedule", sched));
+   vector<legacy::producer_key> sched = {{"eosio"_n, c.get_public_key("eosio"_n, "bsk")}};
+   c.push_action(config::system_account_name, "setprods"_n, config::system_account_name, fc::mutable_variant_object()("schedule", sched));
    c.produce_block();
 
    // ensure the first possible new block contains a producer_schedule_change_extension
@@ -1734,7 +1734,7 @@ BOOST_AUTO_TEST_CASE( wtmsig_block_signing_inflight_extension_test ) { try {
    BOOST_REQUIRE_EXCEPTION( c.produce_block(), no_block_signatures, fc_exception_message_is( "Signer returned no signatures" ));
    c.control->abort_block();
 
-   c.block_signing_private_keys.emplace(get_public_key(N(eosio), "bsk"), get_private_key(N(eosio), "bsk"));
+   c.block_signing_private_keys.emplace(get_public_key("eosio"_n, "bsk"), get_private_key("eosio"_n, "bsk"));
    c.produce_block();
 
 } FC_LOG_AND_RETHROW() }

--- a/unittests/ram_tests.cpp
+++ b/unittests/ram_tests.cpp
@@ -29,70 +29,70 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    BOOST_REQUIRE_MESSAGE(table_allocation_bytes > increment_contract_bytes, "increment_contract_bytes must be less than table_allocation_bytes for this test setup to work");
    buyrambytes(config::system_account_name, config::system_account_name, 70000);
    produce_blocks(10);
-   create_account_with_resources(N(testram11111),config::system_account_name, init_request_bytes + 40);
-   create_account_with_resources(N(testram22222),config::system_account_name, init_request_bytes + 1190);
+   create_account_with_resources("testram11111"_n,config::system_account_name, init_request_bytes + 40);
+   create_account_with_resources("testram22222"_n,config::system_account_name, init_request_bytes + 1190);
    produce_blocks(10);
    BOOST_REQUIRE_EQUAL( success(), stake( name("eosio.stake"), name("testram11111"), core_from_string("10.0000"), core_from_string("5.0000") ) );
    produce_blocks(10);
 
    for (auto i = 0; i < 10; ++i) {
       try {
-         set_code( N(testram11111), contracts::test_ram_limit_wasm() );
+         set_code( "testram11111"_n, contracts::test_ram_limit_wasm() );
          break;
       } catch (const ram_usage_exceeded&) {
          init_request_bytes += increment_contract_bytes;
-         buyrambytes(config::system_account_name, N(testram11111), increment_contract_bytes);
-         buyrambytes(config::system_account_name, N(testram22222), increment_contract_bytes);
+         buyrambytes(config::system_account_name, "testram11111"_n, increment_contract_bytes);
+         buyrambytes(config::system_account_name, "testram22222"_n, increment_contract_bytes);
       }
    }
    produce_blocks(10);
 
    for (auto i = 0; i < 10; ++i) {
       try {
-         set_abi( N(testram11111), contracts::test_ram_limit_abi().data() );
+         set_abi( "testram11111"_n, contracts::test_ram_limit_abi().data() );
          break;
       } catch (const ram_usage_exceeded&) {
          init_request_bytes += increment_contract_bytes;
-         buyrambytes(config::system_account_name, N(testram11111), increment_contract_bytes);
-         buyrambytes(config::system_account_name, N(testram22222), increment_contract_bytes);
+         buyrambytes(config::system_account_name, "testram11111"_n, increment_contract_bytes);
+         buyrambytes(config::system_account_name, "testram22222"_n, increment_contract_bytes);
       }
    }
    produce_blocks(10);
-   set_code( N(testram22222), contracts::test_ram_limit_wasm() );
-   set_abi( N(testram22222), contracts::test_ram_limit_abi().data() );
+   set_code( "testram22222"_n, contracts::test_ram_limit_wasm() );
+   set_abi( "testram22222"_n, contracts::test_ram_limit_abi().data() );
    produce_blocks(10);
 
-   auto total = get_total_stake( N(testram11111) );
+   auto total = get_total_stake( "testram11111"_n );
    const auto init_bytes =  total["ram_bytes"].as_uint64();
 
    auto rlm = control->get_resource_limits_manager();
-   auto initial_ram_usage = rlm.get_account_ram_usage(N(testram11111));
+   auto initial_ram_usage = rlm.get_account_ram_usage("testram11111"_n);
 
    // calculate how many more bytes we need to have table_allocation_bytes for database stores
    auto more_ram = table_allocation_bytes + init_bytes - init_request_bytes;
    BOOST_REQUIRE_MESSAGE(more_ram >= 0, "Underlying understanding changed, need to reduce size of init_request_bytes");
    wdump((init_bytes)(initial_ram_usage)(init_request_bytes)(more_ram) );
-   buyrambytes(config::system_account_name, N(testram11111), more_ram);
-   buyrambytes(config::system_account_name, N(testram22222), more_ram);
+   buyrambytes(config::system_account_name, "testram11111"_n, more_ram);
+   buyrambytes(config::system_account_name, "testram22222"_n, more_ram);
 
    TESTER* tester = this;
    // allocate just under the allocated bytes
-   tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                         ("payer", "testram11111")
                         ("from", 1)
                         ("to", 10)
                         ("size", 1780 /*1910*/));
    produce_blocks(1);
-   auto ram_usage = rlm.get_account_ram_usage(N(testram11111));
+   auto ram_usage = rlm.get_account_ram_usage("testram11111"_n);
 
-   total = get_total_stake( N(testram11111) );
+   total = get_total_stake( "testram11111"_n );
    const auto ram_bytes =  total["ram_bytes"].as_uint64();
    wdump((ram_bytes)(ram_usage)(initial_ram_usage)(init_bytes)(ram_usage - initial_ram_usage)(init_bytes - ram_usage) );
 
    wlog("ram_tests 1    %%%%%%");
    // allocate just beyond the allocated bytes
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                            ("payer", "testram11111")
                            ("from", 1)
                            ("to", 10)
@@ -101,20 +101,20 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
    wlog("ram_tests 2    %%%%%%");
    produce_blocks(1);
-   BOOST_REQUIRE_EQUAL(ram_usage, rlm.get_account_ram_usage(N(testram11111)));
+   BOOST_REQUIRE_EQUAL(ram_usage, rlm.get_account_ram_usage("testram11111"_n));
 
    // update the entries with smaller allocations so that we can verify space is freed and new allocations can be made
-   tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                         ("payer", "testram11111")
                         ("from", 1)
                         ("to", 10)
                         ("size", 1680/*1810*/));
    produce_blocks(1);
-   BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage(N(testram11111)));
+   BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage("testram11111"_n));
 
    // verify the added entry is beyond the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                            ("payer", "testram11111")
                            ("from", 1)
                            ("to", 11)
@@ -122,11 +122,11 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
    produce_blocks(1);
-   BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage(N(testram11111)));
+   BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage("testram11111"_n));
 
    // verify the new entry's bytes minus the freed up bytes for existing entries still exceeds the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                            ("payer", "testram11111")
                            ("from", 1)
                            ("to", 11)
@@ -134,24 +134,24 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
                            ram_usage_exceeded,
                            fc_exception_message_starts_with("account testram11111 has insufficient ram"));
    produce_blocks(1);
-   BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage(N(testram11111)));
+   BOOST_REQUIRE_EQUAL(ram_usage - 1000, rlm.get_account_ram_usage("testram11111"_n));
 
    // verify the new entry's bytes minus the freed up bytes for existing entries are under the allocation bytes limit
-   tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                         ("payer", "testram11111")
                         ("from", 1)
                         ("to", 11)
                         ("size", 1600/*1720*/));
    produce_blocks(1);
 
-   tester->push_action( N(testram11111), N(rmentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "rmentry"_n, "testram11111"_n, mvo()
                         ("from", 3)
                         ("to", 3));
    produce_blocks(1);
    
    // verify that the new entry will exceed the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                            ("payer", "testram11111")
                            ("from", 12)
                            ("to", 12)
@@ -161,7 +161,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    produce_blocks(1);
 
    // verify that the new entry is under the allocation bytes limit
-   tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                         ("payer", "testram11111")
                         ("from", 12)
                         ("to", 12)
@@ -170,7 +170,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
 
    // verify that anoth new entry will exceed the allocation bytes limit, to setup testing of new payer
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                            ("payer", "testram11111")
                            ("from", 13)
                            ("to", 13)
@@ -180,7 +180,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    produce_blocks(1);
 
    // verify that the new entry is under the allocation bytes limit
-   tester->push_action( N(testram11111), N(setentry), {N(testram11111),N(testram22222)}, mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
                         ("payer", "testram22222")
                         ("from", 12)
                         ("to", 12)
@@ -189,7 +189,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
 
    // verify that another new entry that is too big will exceed the allocation bytes limit, to setup testing of new payer
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                            ("payer", "testram11111")
                            ("from", 13)
                            ("to", 13)
@@ -200,7 +200,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
 
    wlog("ram_tests 18    %%%%%%");
    // verify that the new entry is under the allocation bytes limit, because entry 12 is now charged to testram22222
-   tester->push_action( N(testram11111), N(setentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, "testram11111"_n, mvo()
                         ("payer", "testram11111")
                         ("from", 13)
                         ("to", 13)
@@ -209,7 +209,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    
    // verify that new entries for testram22222 exceed the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), {N(testram11111),N(testram22222)}, mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
                            ("payer", "testram22222")
                            ("from", 12)
                            ("to", 21)
@@ -219,7 +219,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
    produce_blocks(1);
 
    // verify that new entries for testram22222 are under the allocation bytes limit
-   tester->push_action( N(testram11111), N(setentry), {N(testram11111),N(testram22222)}, mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
                         ("payer", "testram22222")
                         ("from", 12)
                         ("to", 21)
@@ -228,7 +228,7 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
 
    // verify that new entry for testram22222 exceed the allocation bytes limit
    BOOST_REQUIRE_EXCEPTION(
-      tester->push_action( N(testram11111), N(setentry), {N(testram11111),N(testram22222)}, mvo()
+      tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
                            ("payer", "testram22222")
                            ("from", 22)
                            ("to", 22)
@@ -237,13 +237,13 @@ BOOST_FIXTURE_TEST_CASE(ram_tests, eosio_system::eosio_system_tester) { try {
                            fc_exception_message_starts_with("account testram22222 has insufficient ram"));
    produce_blocks(1);
 
-   tester->push_action( N(testram11111), N(rmentry), N(testram11111), mvo()
+   tester->push_action( "testram11111"_n, "rmentry"_n, "testram11111"_n, mvo()
                         ("from", 20)
                         ("to", 20));
    produce_blocks(1);
 
    // verify that new entry for testram22222 are under the allocation bytes limit
-   tester->push_action( N(testram11111), N(setentry), {N(testram11111),N(testram22222)}, mvo()
+   tester->push_action( "testram11111"_n, "setentry"_n, {"testram11111"_n,"testram22222"_n}, mvo()
                         ("payer", "testram22222")
                         ("from", 22)
                         ("to", 22)

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -318,20 +318,20 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
       double uncongested_cpu_time_per_period = congested_cpu_time_per_period * config::maximum_elastic_resource_multiplier;
       wdump((uncongested_cpu_time_per_period));
 
-      initialize_account( N(dan) );
-      initialize_account( N(everyone) );
-      set_account_limits( N(dan), 0, 0, user_stake );
-      set_account_limits( N(everyone), 0, 0, (total_staked_tokens - user_stake) );
+      initialize_account( "dan"_n );
+      initialize_account( "everyone"_n );
+      set_account_limits( "dan"_n, 0, 0, user_stake );
+      set_account_limits( "everyone"_n, 0, 0, (total_staked_tokens - user_stake) );
       process_account_limit_updates();
 
       // dan cannot consume more than 34 us per day
-      BOOST_REQUIRE_THROW( add_transaction_usage( {N(dan)}, 35, 0, 1 ), tx_cpu_usage_exceeded );
+      BOOST_REQUIRE_THROW( add_transaction_usage( {"dan"_n}, 35, 0, 1 ), tx_cpu_usage_exceeded );
 
       // Ensure CPU usage is 0 by "waiting" for one day's worth of blocks to pass.
-      add_transaction_usage( {N(dan)}, 0, 0, 1 + blocks_per_day );
+      add_transaction_usage( {"dan"_n}, 0, 0, 1 + blocks_per_day );
 
       // But dan should be able to consume up to 34 us per day.
-      add_transaction_usage( {N(dan)}, 34, 0, 2 + blocks_per_day );
+      add_transaction_usage( {"dan"_n}, 34, 0, 2 + blocks_per_day );
    } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/snapshot_tests.cpp
+++ b/unittests/snapshot_tests.cpp
@@ -181,10 +181,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot
 {
    tester chain;
 
-   chain.create_account(N(snapshot));
+   chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
-   chain.set_code(N(snapshot), contracts::snapshot_test_wasm());
-   chain.set_abi(N(snapshot), contracts::snapshot_test_abi().data());
+   chain.set_code("snapshot"_n, contracts::snapshot_test_wasm());
+   chain.set_abi("snapshot"_n, contracts::snapshot_test_abi().data());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_exhaustive_snapshot, SNAPSHOT_SUITE, snapshot
       sub_testers.emplace_back(chain.get_config(), SNAPSHOT_SUITE::get_reader(snapshot), generation);
 
       // increment the test contract
-      chain.push_action(N(snapshot), N(increment), N(snapshot), mutable_variant_object()
+      chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
          ( "value", 1 )
       );
 
@@ -226,10 +226,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_replay_over_snapshot, SNAPSHOT_SUITE, snapsho
    tester chain;
    const chainbase::bfs::path parent_path = chain.get_config().blocks_dir.parent_path();
 
-   chain.create_account(N(snapshot));
+   chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
-   chain.set_code(N(snapshot), contracts::snapshot_test_wasm());
-   chain.set_abi(N(snapshot), contracts::snapshot_test_abi().data());
+   chain.set_code("snapshot"_n, contracts::snapshot_test_wasm());
+   chain.set_abi("snapshot"_n, contracts::snapshot_test_abi().data());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -238,7 +238,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_replay_over_snapshot, SNAPSHOT_SUITE, snapsho
 
    for (int itr = 0; itr < pre_snapshot_block_count; itr++) {
       // increment the contract
-      chain.push_action(N(snapshot), N(increment), N(snapshot), mutable_variant_object()
+      chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
          ( "value", 1 )
       );
 
@@ -261,7 +261,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_replay_over_snapshot, SNAPSHOT_SUITE, snapsho
    // push more blocks to build up a block log
    for (int itr = 0; itr < post_snapshot_block_count; itr++) {
       // increment the contract
-      chain.push_action(N(snapshot), N(increment), N(snapshot), mutable_variant_object()
+      chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
          ( "value", 1 )
       );
 
@@ -321,10 +321,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_chain_id_in_snapshot, SNAPSHOT_SUITE, snapsho
    tester chain;
    const chainbase::bfs::path parent_path = chain.get_config().blocks_dir.parent_path();
 
-   chain.create_account(N(snapshot));
+   chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
-   chain.set_code(N(snapshot), contracts::snapshot_test_wasm());
-   chain.set_abi(N(snapshot), contracts::snapshot_test_abi().data());
+   chain.set_code("snapshot"_n, contracts::snapshot_test_wasm());
+   chain.set_abi("snapshot"_n, contracts::snapshot_test_abi().data());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -481,10 +481,10 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
    tester chain;
    const chainbase::bfs::path parent_path = chain.get_config().blocks_dir.parent_path();
 
-   chain.create_account(N(snapshot));
+   chain.create_account("snapshot"_n);
    chain.produce_blocks(1);
-   chain.set_code(N(snapshot), contracts::snapshot_test_wasm());
-   chain.set_abi(N(snapshot), contracts::snapshot_test_abi().data());
+   chain.set_code("snapshot"_n, contracts::snapshot_test_wasm());
+   chain.set_abi("snapshot"_n, contracts::snapshot_test_abi().data());
    chain.produce_blocks(1);
    chain.control->abort_block();
 
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_restart_with_existing_state_and_truncated_blo
 
    for (int itr = 0; itr < pre_snapshot_block_count; itr++) {
       // increment the contract
-      chain.push_action(N(snapshot), N(increment), N(snapshot), mutable_variant_object()
+      chain.push_action("snapshot"_n, "increment"_n, "snapshot"_n, mutable_variant_object()
                         ( "value", 1 )
                         );
 

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -47,11 +47,11 @@ struct assertdef {
    string      message;
 
    static account_name get_account() {
-      return N(asserter);
+      return "asserter"_n;
    }
 
    static action_name get_name() {
-      return N(procassert);
+      return "procassert"_n;
    }
 };
 
@@ -59,11 +59,11 @@ FC_REFLECT(assertdef, (condition)(message));
 
 struct provereset {
    static account_name get_account() {
-      return N(asserter);
+      return "asserter"_n;
    }
 
    static action_name get_name() {
-      return N(provereset);
+      return "provereset"_n;
    }
 };
 
@@ -82,29 +82,29 @@ struct old_wasm_tester : tester {
 BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(asserter)} );
+   create_accounts( {"asserter"_n} );
    produce_block();
 
-   set_code(N(asserter), contracts::asserter_wasm());
+   set_code("asserter"_n, contracts::asserter_wasm());
    produce_blocks(1);
 
    transaction_id_type no_assert_id;
    {
       signed_transaction trx;
-      trx.actions.emplace_back( vector<permission_level>{{N(asserter),config::active_name}},
+      trx.actions.emplace_back( vector<permission_level>{{"asserter"_n,config::active_name}},
                                 assertdef {1, "Should Not Assert!"} );
-      trx.actions[0].authorization = {{N(asserter),config::active_name}};
+      trx.actions[0].authorization = {{"asserter"_n,config::active_name}};
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
+      trx.sign( get_private_key( "asserter"_n, "active" ), control->get_chain_id() );
       auto result = push_transaction( trx );
       BOOST_CHECK_EQUAL(result->receipt->status, transaction_receipt::executed);
       BOOST_CHECK_EQUAL(result->action_traces.size(), 1u);
-      BOOST_CHECK_EQUAL(result->action_traces.at(0).receiver.to_string(),  name(N(asserter)).to_string() );
-      BOOST_CHECK_EQUAL(result->action_traces.at(0).act.account.to_string(), name(N(asserter)).to_string() );
-      BOOST_CHECK_EQUAL(result->action_traces.at(0).act.name.to_string(),  name(N(procassert)).to_string() );
+      BOOST_CHECK_EQUAL(result->action_traces.at(0).receiver.to_string(),  name("asserter"_n).to_string() );
+      BOOST_CHECK_EQUAL(result->action_traces.at(0).act.account.to_string(), name("asserter"_n).to_string() );
+      BOOST_CHECK_EQUAL(result->action_traces.at(0).act.name.to_string(),  name("procassert"_n).to_string() );
       BOOST_CHECK_EQUAL(result->action_traces.at(0).act.authorization.size(),  1u );
-      BOOST_CHECK_EQUAL(result->action_traces.at(0).act.authorization.at(0).actor.to_string(),  name(N(asserter)).to_string() );
+      BOOST_CHECK_EQUAL(result->action_traces.at(0).act.authorization.at(0).actor.to_string(),  name("asserter"_n).to_string() );
       BOOST_CHECK_EQUAL(result->action_traces.at(0).act.authorization.at(0).permission.to_string(),  name(config::active_name).to_string() );
       no_assert_id = trx.id();
    }
@@ -118,11 +118,11 @@ BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
    transaction_id_type yes_assert_id;
    {
       signed_transaction trx;
-      trx.actions.emplace_back( vector<permission_level>{{N(asserter),config::active_name}},
+      trx.actions.emplace_back( vector<permission_level>{{"asserter"_n,config::active_name}},
                                 assertdef {0, "Should Assert!"} );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
+      trx.sign( get_private_key( "asserter"_n, "active" ), control->get_chain_id() );
       yes_assert_id = trx.id();
 
       BOOST_CHECK_THROW(push_transaction( trx ), eosio_assert_message_exception);
@@ -141,21 +141,21 @@ BOOST_FIXTURE_TEST_CASE( basic_test, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( prove_mem_reset, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(asserter)} );
+   create_accounts( {"asserter"_n} );
    produce_block();
 
-   set_code(N(asserter), contracts::asserter_wasm());
+   set_code("asserter"_n, contracts::asserter_wasm());
    produce_blocks(1);
 
    // repeat the action multiple times, each time the action handler checks for the expected
    // default value then modifies the value which should not survive until the next invoction
    for (int i = 0; i < 5; i++) {
       signed_transaction trx;
-      trx.actions.emplace_back( vector<permission_level>{{N(asserter),config::active_name}},
+      trx.actions.emplace_back( vector<permission_level>{{"asserter"_n,config::active_name}},
                                 provereset {} );
 
       set_transaction_headers(trx);
-      trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
+      trx.sign( get_private_key( "asserter"_n, "active" ), control->get_chain_id() );
       push_transaction( trx );
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -171,11 +171,11 @@ BOOST_FIXTURE_TEST_CASE( prove_mem_reset, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(asserter)} );
+   create_accounts( {"asserter"_n} );
    produce_block();
 
-   set_code(N(asserter), contracts::asserter_wasm());
-   set_abi(N(asserter), contracts::asserter_abi().data());
+   set_code("asserter"_n, contracts::asserter_wasm());
+   set_abi("asserter"_n, contracts::asserter_abi().data());
    produce_blocks(1);
 
    auto resolver = [&,this]( const account_name& name ) -> optional<abi_serializer> {
@@ -209,7 +209,7 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
    signed_transaction trx;
    abi_serializer::from_variant(pretty_trx, trx, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
    set_transaction_headers(trx);
-   trx.sign( get_private_key( N(asserter), "active" ), control->get_chain_id() );
+   trx.sign( get_private_key( "asserter"_n, "active" ), control->get_chain_id() );
    push_transaction( trx );
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -222,20 +222,20 @@ BOOST_FIXTURE_TEST_CASE( abi_from_variant, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( f32_tests, TESTER ) try {
    produce_blocks(2);
    produce_block();
-   create_accounts( {N(f32_tests)} );
+   create_accounts( {"f32.tests"_n} );
    {
-      set_code(N(f32_tests), f32_test_wast);
+      set_code("f32.tests"_n, f32_test_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f32_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f32_tests),config::active_name}};
+      act.account = "f32.tests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"f32.tests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f32_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "f32.tests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -244,21 +244,21 @@ BOOST_FIXTURE_TEST_CASE( f32_tests, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(f32_tests)} );
+   create_accounts( {"f32.tests"_n} );
    produce_block();
    {
-      set_code(N(f32_tests), f32_bitwise_test_wast);
+      set_code("f32.tests"_n, f32_bitwise_test_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f32_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f32_tests),config::active_name}};
+      act.account = "f32.tests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"f32.tests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f32_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "f32.tests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -267,21 +267,21 @@ BOOST_FIXTURE_TEST_CASE( f32_test_bitwise, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(f32_tests)} );
+   create_accounts( {"f32.tests"_n} );
    produce_block();
    {
-      set_code(N(f32_tests), f32_cmp_test_wast);
+      set_code("f32.tests"_n, f32_cmp_test_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f32_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f32_tests),config::active_name}};
+      act.account = "f32.tests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"f32.tests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f32_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "f32.tests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -292,21 +292,21 @@ BOOST_FIXTURE_TEST_CASE( f32_test_cmp, TESTER ) try {
 // test softfloat 64 bit operations
 BOOST_FIXTURE_TEST_CASE( f64_tests, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(f_tests)} );
+   create_accounts( {"f.tests"_n} );
    produce_block();
    {
-      set_code(N(f_tests), f64_test_wast);
+      set_code("f.tests"_n, f64_test_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f_tests),config::active_name}};
+      act.account = "f.tests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"f.tests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "f.tests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -315,21 +315,21 @@ BOOST_FIXTURE_TEST_CASE( f64_tests, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(f_tests)} );
+   create_accounts( {"f.tests"_n} );
    produce_block();
    {
-      set_code(N(f_tests), f64_bitwise_test_wast);
+      set_code("f.tests"_n, f64_bitwise_test_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f_tests),config::active_name}};
+      act.account = "f.tests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"f.tests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "f.tests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -338,21 +338,21 @@ BOOST_FIXTURE_TEST_CASE( f64_test_bitwise, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(f_tests)} );
+   create_accounts( {"f.tests"_n} );
    produce_block();
    {
-      set_code(N(f_tests), f64_cmp_test_wast);
+      set_code("f.tests"_n, f64_cmp_test_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f_tests),config::active_name}};
+      act.account = "f.tests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"f.tests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "f.tests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -364,21 +364,21 @@ BOOST_FIXTURE_TEST_CASE( f64_test_cmp, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( f32_f64_conversion_tests, tester ) try {
    produce_blocks(2);
 
-   create_accounts( {N(f_tests)} );
+   create_accounts( {"ftests"_n} );
    produce_block();
    {
-      set_code(N(f_tests), f32_f64_conv_wast);
+      set_code("ftests"_n, f32_f64_conv_wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(f_tests);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(f_tests),config::active_name}};
+      act.account = "ftests"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"ftests"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(f_tests), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "ftests"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_blocks(1);
       BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -391,23 +391,23 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
    int count = 0;
    auto check = [&](const char *wast_template, const char *op, const char *param) -> bool {
       count+=16;
-      create_accounts( {name(N(f_tests).to_uint64_t()+count)} );
+      create_accounts( {name("ftests"_n.to_uint64_t()+count)} );
       produce_blocks(1);
       std::vector<char> wast;
       wast.resize(strlen(wast_template) + 128);
       sprintf(&(wast[0]), wast_template, op, param);
-      set_code(name(N(f_tests).to_uint64_t()+count), &(wast[0]));
+      set_code(name("ftests"_n.to_uint64_t()+count), &(wast[0]));
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = name(N(f_tests).to_uint64_t()+count);
-      act.name = N();
-      act.authorization = vector<permission_level>{{name(N(f_tests).to_uint64_t()+count),config::active_name}};
+      act.account = name("ftests"_n.to_uint64_t()+count);
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{name("ftests"_n.to_uint64_t()+count),config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( name(N(f_tests).to_uint64_t()+count), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( name("ftests"_n.to_uint64_t()+count), "active" ), control->get_chain_id());
 
       try {
          push_transaction(trx);
@@ -490,22 +490,22 @@ BOOST_FIXTURE_TEST_CASE( f32_f64_overflow_tests, tester ) try {
 
 BOOST_FIXTURE_TEST_CASE(misaligned_tests, tester ) try {
    produce_blocks(2);
-   create_accounts( {N(aligncheck)} );
+   create_accounts( {"aligncheck"_n} );
    produce_block();
 
    auto check_aligned = [&]( auto wast ) {
-      set_code(N(aligncheck), wast);
+      set_code("aligncheck"_n, wast);
       produce_blocks(10);
 
       signed_transaction trx;
       action act;
-      act.account = N(aligncheck);
-      act.name = N();
-      act.authorization = vector<permission_level>{{N(aligncheck),config::active_name}};
+      act.account = "aligncheck"_n;
+      act.name = ""_n;
+      act.authorization = vector<permission_level>{{"aligncheck"_n,config::active_name}};
       trx.actions.push_back(act);
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(aligncheck), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "aligncheck"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
       produce_block();
 
@@ -523,21 +523,21 @@ BOOST_FIXTURE_TEST_CASE(misaligned_tests, tester ) try {
  */
 BOOST_FIXTURE_TEST_CASE( check_entry_behavior, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(entrycheck)} );
+   create_accounts( {"entrycheck"_n} );
    produce_block();
 
-   set_code(N(entrycheck), entry_wast);
+   set_code("entrycheck"_n, entry_wast);
    produce_blocks(10);
 
    signed_transaction trx;
    action act;
-   act.account = N(entrycheck);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(entrycheck),config::active_name}};
+   act.account = "entrycheck"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"entrycheck"_n,config::active_name}};
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(entrycheck), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "entrycheck"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -547,21 +547,21 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior, TESTER ) try {
 
 BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(entrycheck)} );
+   create_accounts( {"entrycheck"_n} );
    produce_block();
 
-   set_code(N(entrycheck), entry_wast_2);
+   set_code("entrycheck"_n, entry_wast_2);
    produce_blocks(10);
 
    signed_transaction trx;
    action act;
-   act.account = N(entrycheck);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(entrycheck),config::active_name}};
+   act.account = "entrycheck"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"entrycheck"_n,config::active_name}};
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(entrycheck), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "entrycheck"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -570,20 +570,20 @@ BOOST_FIXTURE_TEST_CASE( check_entry_behavior_2, TESTER ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( entry_import, TESTER ) try {
-   create_accounts( {N(enterimport)} );
+   create_accounts( {"enterimport"_n} );
    produce_block();
 
-   set_code(N(enterimport), entry_import_wast);
+   set_code("enterimport"_n, entry_import_wast);
 
    signed_transaction trx;
    action act;
-   act.account = N(enterimport);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(enterimport),config::active_name}};
+   act.account = "enterimport"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"enterimport"_n,config::active_name}};
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(enterimport), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "enterimport"_n, "active" ), control->get_chain_id());
    BOOST_CHECK_THROW(push_transaction(trx), abort_called);
 } FC_LOG_AND_RETHROW()
 
@@ -611,22 +611,22 @@ BOOST_FIXTURE_TEST_CASE( entry_db, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(nomem)} );
+   create_accounts( {"nomem"_n} );
    produce_block();
 
-   set_code(N(nomem), simple_no_memory_wast);
+   set_code("nomem"_n, simple_no_memory_wast);
    produce_blocks(1);
 
    //the apply func of simple_no_memory_wast tries to call a native func with linear memory pointer
    signed_transaction trx;
    action act;
-   act.account = N(nomem);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(nomem),config::active_name}};
+   act.account = "nomem"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"nomem"_n,config::active_name}};
    trx.actions.push_back(act);
    trx.expiration = control->head_block_time();
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(nomem), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "nomem"_n, "active" ), control->get_chain_id());
    BOOST_CHECK_THROW(push_transaction( trx ), wasm_execution_error);
 } FC_LOG_AND_RETHROW()
 
@@ -634,30 +634,30 @@ BOOST_FIXTURE_TEST_CASE( simple_no_memory_check, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( check_global_reset, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(globalreset)} );
+   create_accounts( {"globalreset"_n} );
    produce_block();
 
-   set_code(N(globalreset), mutable_global_wast);
+   set_code("globalreset"_n, mutable_global_wast);
    produce_blocks(1);
 
    signed_transaction trx;
    {
    action act;
-   act.account = N(globalreset);
+   act.account = "globalreset"_n;
    act.name = name(0ULL);
-   act.authorization = vector<permission_level>{{N(globalreset),config::active_name}};
+   act.authorization = vector<permission_level>{{"globalreset"_n,config::active_name}};
    trx.actions.push_back(act);
    }
    {
    action act;
-   act.account = N(globalreset);
+   act.account = "globalreset"_n;
    act.name = name(1ULL);
-   act.authorization = vector<permission_level>{{N(globalreset),config::active_name}};
+   act.authorization = vector<permission_level>{{"globalreset"_n,config::active_name}};
    trx.actions.push_back(act);
    }
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(globalreset), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "globalreset"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
    BOOST_REQUIRE_EQUAL(true, chain_has_transaction(trx.id()));
@@ -673,24 +673,24 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, big_memory, bdata::make({false, true}),
    produce_blocks(2);
 
 
-   create_accounts( {N(bigmem)} );
+   create_accounts( {"bigmem"_n} );
    produce_block();
 
    string biggest_memory_wast_f = fc::format_string(biggest_memory_wast, fc::mutable_variant_object(
                                           "MAX_WASM_PAGES", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024)));
 
-   set_code(N(bigmem), biggest_memory_wast_f.c_str());
+   set_code("bigmem"_n, biggest_memory_wast_f.c_str());
    produce_blocks(1);
 
    signed_transaction trx;
    action act;
-   act.account = N(bigmem);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(bigmem),config::active_name}};
+   act.account = "bigmem"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"bigmem"_n,config::active_name}};
    trx.actions.push_back(act);
 
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(bigmem), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "bigmem"_n, "active" ), control->get_chain_id());
    //but should not be able to grow beyond largest page
    push_transaction(trx);
 
@@ -698,7 +698,7 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, big_memory, bdata::make({false, true}),
 
    string too_big_memory_wast_f = fc::format_string(too_big_memory_wast, fc::mutable_variant_object(
                                           "MAX_WASM_PAGES_PLUS_ONE", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024)+1));
-   BOOST_CHECK_THROW(set_code(N(bigmem), too_big_memory_wast_f.c_str()), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(set_code("bigmem"_n, too_big_memory_wast_f.c_str()), eosio::chain::wasm_exception);
 
 } FC_LOG_AND_RETHROW()
 
@@ -707,51 +707,51 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, table_init_tests, bdata::make({false, t
       preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
    produce_blocks(2);
 
-   create_accounts( {N(tableinit)} );
+   create_accounts( {"tableinit"_n} );
    produce_block();
 
-   set_code(N(tableinit), valid_sparse_table);
+   set_code("tableinit"_n, valid_sparse_table);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(tableinit), too_big_table), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(set_code("tableinit"_n, too_big_table), eosio::chain::wasm_exception);
 
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( table_init_oob, TESTER ) try {
-   create_accounts( {N(tableinitoob)} );
+   create_accounts( {"tableinitoob"_n} );
    produce_block();
 
    signed_transaction trx;
-   trx.actions.emplace_back(vector<permission_level>{{N(tableinitoob),config::active_name}}, N(tableinitoob), N(), bytes{});
-   trx.actions[0].authorization = vector<permission_level>{{N(tableinitoob),config::active_name}};
+   trx.actions.emplace_back(vector<permission_level>{{"tableinitoob"_n,config::active_name}}, "tableinitoob"_n, ""_n, bytes{});
+   trx.actions[0].authorization = vector<permission_level>{{"tableinitoob"_n,config::active_name}};
 
     auto pushit_and_expect_fail = [&]() {
       produce_block();
       trx.signatures.clear();
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(tableinitoob), "active"), control->get_chain_id());
-      
+      trx.sign(get_private_key("tableinitoob"_n, "active"), control->get_chain_id());
+
       //the unspecified_exception_code comes from WAVM, which manages to throw a WAVM specific exception
       // up to where exec_one captures it and doesn't understand it
       BOOST_CHECK_THROW(push_transaction(trx), eosio::chain::wasm_exception);
    };
 
-   set_code(N(tableinitoob), table_init_oob_wast);
+   set_code("tableinitoob"_n, table_init_oob_wast);
    produce_block();
 
    pushit_and_expect_fail();
    //make sure doing it again didn't lodge something funky in to a cache
    pushit_and_expect_fail();
 
-   set_code(N(tableinitoob), table_init_oob_smaller_wast);
+   set_code("tableinitoob"_n, table_init_oob_smaller_wast);
    produce_block();
    pushit_and_expect_fail();
    pushit_and_expect_fail();
 
    //an elem w/o a table is a setcode fail though
-   BOOST_CHECK_THROW(set_code(N(tableinitoob), table_init_oob_no_table_wast), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(set_code("tableinitoob"_n, table_init_oob_no_table_wast), eosio::chain::wasm_exception);
 
-   set_code(N(tableinitoob), table_init_oob_empty_wast);
+   set_code("tableinitoob"_n, table_init_oob_empty_wast);
    produce_block();
    pushit_and_expect_fail();
    pushit_and_expect_fail();
@@ -761,14 +761,14 @@ BOOST_FIXTURE_TEST_CASE( table_init_oob, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( memory_init_border, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(memoryborder)} );
+   create_accounts( {"memoryborder"_n} );
    produce_block();
 
-   set_code(N(memoryborder), memory_init_borderline);
+   set_code("memoryborder"_n, memory_init_borderline);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(memoryborder), memory_init_toolong), eosio::chain::wasm_exception);
-   BOOST_CHECK_THROW(set_code(N(memoryborder), memory_init_negative), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(set_code("memoryborder"_n, memory_init_toolong), eosio::chain::wasm_exception);
+   BOOST_CHECK_THROW(set_code("memoryborder"_n, memory_init_negative), eosio::chain::wasm_exception);
 
 } FC_LOG_AND_RETHROW()
 
@@ -776,12 +776,12 @@ BOOST_FIXTURE_TEST_CASE( imports, TESTER ) try {
    try {
       produce_blocks(2);
 
-      create_accounts( {N(imports)} );
+      create_accounts( {"imports"_n} );
       produce_block();
 
       //this will fail to link but that's okay; mainly looking to make sure that the constraint
       // system doesn't choke when memories and tables exist only as imports
-      BOOST_CHECK_THROW(set_code(N(imports), memory_table_import), fc::exception);
+      BOOST_CHECK_THROW(set_code("imports"_n, memory_table_import), fc::exception);
    } catch ( const fc::exception& e ) {
 
         edump((e.to_detail_string()));
@@ -793,7 +793,7 @@ BOOST_FIXTURE_TEST_CASE( imports, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(nested)} );
+   create_accounts( {"nested"_n} );
    produce_block();
 
    // nested loops
@@ -805,7 +805,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 1023; ++i)
          ss << ")";
       ss << "))";
-      set_code(N(nested), ss.str().c_str());
+      set_code("nested"_n, ss.str().c_str());
    }
    {
       std::stringstream ss;
@@ -815,7 +815,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 1024; ++i)
          ss << ")";
       ss << "))";
-      BOOST_CHECK_THROW(set_code(N(nested), ss.str().c_str()), eosio::chain::wasm_exception);
+      BOOST_CHECK_THROW(set_code("nested"_n, ss.str().c_str()), eosio::chain::wasm_exception);
    }
 
    // nested blocks
@@ -827,7 +827,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 1023; ++i)
          ss << ")";
       ss << "))";
-      set_code(N(nested), ss.str().c_str());
+      set_code("nested"_n, ss.str().c_str());
    }
    {
       std::stringstream ss;
@@ -837,7 +837,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 1024; ++i)
          ss << ")";
       ss << "))";
-      BOOST_CHECK_THROW(set_code(N(nested), ss.str().c_str()), eosio::chain::wasm_exception);
+      BOOST_CHECK_THROW(set_code("nested"_n, ss.str().c_str()), eosio::chain::wasm_exception);
    }
    // nested ifs
    {
@@ -848,7 +848,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 1023; ++i)
          ss << "))";
       ss << "))";
-      set_code(N(nested), ss.str().c_str());
+      set_code("nested"_n, ss.str().c_str());
    }
    {
       std::stringstream ss;
@@ -858,7 +858,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 1024; ++i)
          ss << "))";
       ss << "))";
-      BOOST_CHECK_THROW(set_code(N(nested), ss.str().c_str()), eosio::chain::wasm_exception);
+      BOOST_CHECK_THROW(set_code("nested"_n, ss.str().c_str()), eosio::chain::wasm_exception);
    }
    // mixed nested
    {
@@ -875,7 +875,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 223; ++i)
          ss << "))";
       ss << "))";
-      set_code(N(nested), ss.str().c_str());
+      set_code("nested"_n, ss.str().c_str());
    }
    {
       std::stringstream ss;
@@ -891,7 +891,7 @@ BOOST_FIXTURE_TEST_CASE( nested_limit_test, TESTER ) try {
       for(unsigned int i = 0; i < 224; ++i)
          ss << "))";
       ss << "))";
-      BOOST_CHECK_THROW(set_code(N(nested), ss.str().c_str()), eosio::chain::wasm_exception);
+      BOOST_CHECK_THROW(set_code("nested"_n, ss.str().c_str()), eosio::chain::wasm_exception);
    }
 
 } FC_LOG_AND_RETHROW()
@@ -903,7 +903,7 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, lotso_globals, bdata::make({false, true
 
    produce_blocks(2);
 
-   create_accounts( {N(globals)} );
+   create_accounts( {"globals"_n} );
    produce_block();
 
    std::stringstream ss;
@@ -915,15 +915,15 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, lotso_globals, bdata::make({false, true
    for(unsigned int i = 0; i < 10; ++i)
       ss << "(global $g" << i+200 << " i32 (i32.const 0))";
 
-   set_code(N(globals),
+   set_code("globals"_n,
       string(ss.str() + ")")
    .c_str());
    //1024 should pass
-   set_code(N(globals),
+   set_code("globals"_n,
       string(ss.str() + "(global $z (mut i32) (i32.const -12)))")
    .c_str());
    //1028 should fail
-   BOOST_CHECK_THROW(set_code(N(globals),
+   BOOST_CHECK_THROW(set_code("globals"_n,
       string(ss.str() + "(global $z (mut i64) (i64.const -12)))")
    .c_str()), eosio::chain::wasm_exception);
 } FC_LOG_AND_RETHROW()
@@ -931,7 +931,7 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, lotso_globals, bdata::make({false, true
 BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
    produce_blocks(2);
 
-   create_accounts( {N(offsets)} );
+   create_accounts( {"offsets"_n} );
    produce_block();
 
    vector<string> loadops = {
@@ -957,7 +957,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(drop (" << s << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory-2 << " (i32.const 0)))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      set_code(N(offsets), ss.str().c_str());
+      set_code("offsets"_n, ss.str().c_str());
       produce_block();
    }
    for(const vector<string>& o : storeops) {
@@ -966,7 +966,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(" << o[0] << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory-2 << " (i32.const 0) (" << o[1] << ".const 0))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      set_code(N(offsets), ss.str().c_str());
+      set_code("offsets"_n, ss.str().c_str());
       produce_block();
    }
 
@@ -976,7 +976,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(drop (" << s << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory+4 << " (i32.const 0)))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      BOOST_CHECK_THROW(set_code(N(offsets), ss.str().c_str()), eosio::chain::wasm_exception);
+      BOOST_CHECK_THROW(set_code("offsets"_n, ss.str().c_str()), eosio::chain::wasm_exception);
       produce_block();
    }
    for(const vector<string>& o : storeops) {
@@ -985,7 +985,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
       ss << "(" << o[0] << " offset=" << eosio::chain::wasm_constraints::maximum_linear_memory+4 << " (i32.const 0) (" << o[1] << ".const 0))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      BOOST_CHECK_THROW(set_code(N(offsets), ss.str().c_str()), eosio::chain::wasm_exception);
+      BOOST_CHECK_THROW(set_code("offsets"_n, ss.str().c_str()), eosio::chain::wasm_exception);
       produce_block();
    }
 
@@ -994,7 +994,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check_old, old_wasm_tester ) try {
 BOOST_FIXTURE_TEST_CASE( offset_check, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(offsets)} );
+   create_accounts( {"offsets"_n} );
    produce_block();
 
    vector<string> loadops = {
@@ -1020,7 +1020,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check, TESTER ) try {
       ss << "(drop (" << s << " offset=" << 0xFFFFFFFFu << " (i32.const 0)))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      set_code(N(offsets), ss.str().c_str());
+      set_code("offsets"_n, ss.str().c_str());
       produce_block();
    }
    for(const vector<string>& o : storeops) {
@@ -1029,7 +1029,7 @@ BOOST_FIXTURE_TEST_CASE( offset_check, TESTER ) try {
       ss << "(" << o[0] << " offset=" << 0xFFFFFFFFu << " (i32.const 0) (" << o[1] << ".const 0))";
       ss << ") (export \"apply\" (func $apply)) )";
 
-      set_code(N(offsets), ss.str().c_str());
+      set_code("offsets"_n, ss.str().c_str());
       produce_block();
    }
 
@@ -1038,13 +1038,13 @@ BOOST_FIXTURE_TEST_CASE( offset_check, TESTER ) try {
 
 BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
    produce_blocks(2);
-   create_accounts( {N(noop), N(alice)} );
+   create_accounts( {"noop"_n, "alice"_n} );
    produce_block();
 
-   set_code(N(noop), contracts::noop_wasm());
+   set_code("noop"_n, contracts::noop_wasm());
 
-   set_abi(N(noop), contracts::noop_abi().data());
-   const auto& accnt  = control->db().get<account_object,by_name>(N(noop));
+   set_abi("noop"_n, contracts::noop_abi().data());
+   const auto& accnt  = control->db().get<account_object,by_name>("noop"_n);
    abi_def abi;
    BOOST_REQUIRE_EQUAL(abi_serializer::to_abi(accnt.abi, abi), true);
    abi_serializer abi_ser(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
@@ -1053,9 +1053,9 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
       produce_blocks(5);
       signed_transaction trx;
       action act;
-      act.account = N(noop);
-      act.name = N(anyaction);
-      act.authorization = vector<permission_level>{{N(noop), config::active_name}};
+      act.account = "noop"_n;
+      act.name = "anyaction"_n;
+      act.authorization = vector<permission_level>{{"noop"_n, config::active_name}};
 
       act.data = abi_ser.variant_to_binary("anyaction", mutable_variant_object()
                                            ("from", "noop")
@@ -1067,7 +1067,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
       trx.actions.emplace_back(std::move(act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(noop), "active"), control->get_chain_id());
+      trx.sign(get_private_key("noop"_n, "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
 
@@ -1078,9 +1078,9 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
       produce_blocks(5);
       signed_transaction trx;
       action act;
-      act.account = N(noop);
-      act.name = N(anyaction);
-      act.authorization = vector<permission_level>{{N(alice), config::active_name}};
+      act.account = "noop"_n;
+      act.name = "anyaction"_n;
+      act.authorization = vector<permission_level>{{"alice"_n, config::active_name}};
 
       act.data = abi_ser.variant_to_binary("anyaction", mutable_variant_object()
                                            ("from", "alice")
@@ -1092,7 +1092,7 @@ BOOST_FIXTURE_TEST_CASE(noop, TESTER) try {
       trx.actions.emplace_back(std::move(act));
 
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(alice), "active"), control->get_chain_id());
+      trx.sign(get_private_key("alice"_n, "active"), control->get_chain_id());
       push_transaction(trx);
       produce_block();
 
@@ -1113,7 +1113,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
    abi_serializer abi_ser(abi, abi_serializer::create_yield_function( abi_serializer_max_time ));
 
    signed_transaction trx;
-   name a = N(alice);
+   name a = "alice"_n;
    authority owner_auth =  authority( get_public_key( a, "owner" ) );
    trx.actions.emplace_back( vector<permission_level>{{config::system_account_name,config::active_name}},
                              newaccount{
@@ -1138,7 +1138,7 @@ BOOST_FIXTURE_TEST_CASE(eosio_abi, TESTER) try {
 
 BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
    produce_blocks(2);
-   create_accounts( {N(cbd)} );
+   create_accounts( {"cbd"_n} );
    produce_block();
 
    std::stringstream ss;
@@ -1149,7 +1149,7 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (func " << "$AA_" << i << ")";
    ss << ")";
 
-   set_code(N(cbd), ss.str().c_str());
+   set_code("cbd"_n, ss.str().c_str());
    produce_blocks(1);
 
    produce_blocks(1);
@@ -1162,7 +1162,7 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (func " << "$AA_" << i << ")";
    ss << ")";
 
-   BOOST_CHECK_THROW(set_code(N(cbd), ss.str().c_str()), wasm_serialization_error);
+   BOOST_CHECK_THROW(set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
    produce_blocks(1);
 
    ss.str("");
@@ -1174,7 +1174,7 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (drop (i32.const 3))";
    ss << "))";
 
-   BOOST_CHECK_THROW(set_code(N(cbd), ss.str().c_str()), fc::assert_exception); // this is caught first by MAX_SIZE_OF_ARRAYS check
+   BOOST_CHECK_THROW(set_code("cbd"_n, ss.str().c_str()), fc::assert_exception); // this is caught first by MAX_SIZE_OF_ARRAYS check
    produce_blocks(1);
 
    ss.str("");
@@ -1190,7 +1190,7 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (drop (i32.const 3))";
    ss << "))";
 
-   set_code(N(cbd), ss.str().c_str());
+   set_code("cbd"_n, ss.str().c_str());
    produce_blocks(1);
 
    ss.str("");
@@ -1206,7 +1206,7 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
       ss << "  (drop (i32.const 3))";
    ss << "))";
 
-   BOOST_CHECK_THROW(set_code(N(cbd), ss.str().c_str()), wasm_serialization_error);
+   BOOST_CHECK_THROW(set_code("cbd"_n, ss.str().c_str()), wasm_serialization_error);
    produce_blocks(1);
 
 } FC_LOG_AND_RETHROW()
@@ -1214,20 +1214,20 @@ BOOST_FIXTURE_TEST_CASE( check_big_deserialization, old_wasm_tester ) try {
 
 BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(tbl)} );
+   create_accounts( {"tbl"_n} );
    produce_block();
 
-   set_code(N(tbl), table_checker_wast);
+   set_code("tbl"_n, table_checker_wast);
    produce_blocks(1);
    {
    signed_transaction trx;
    action act;
    act.name = name(555ULL<<32 | 0ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1237,11 +1237,11 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    signed_transaction trx;
    action act;
    act.name = name(555ULL<<32 | 1022ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1251,11 +1251,11 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    signed_transaction trx;
    action act;
    act.name = name(7777ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1265,11 +1265,11 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    signed_transaction trx;
    action act;
    act.name = name(7778ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
 
    //should fail, a check to make sure assert() in wasm is being evaluated correctly
    BOOST_CHECK_THROW(push_transaction(trx), eosio_assert_message_exception);
@@ -1281,11 +1281,11 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    signed_transaction trx;
    action act;
    act.name = name(133ULL<<32 | 5ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
 
    //should fail, this element index (5) does not exist
    BOOST_CHECK_THROW(push_transaction(trx), eosio::chain::wasm_execution_error);
@@ -1297,11 +1297,11 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    signed_transaction trx;
    action act;
    act.name = name(eosio::chain::wasm_constraints::maximum_table_elements+54334);
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
 
    //should fail, this element index is out of range
    BOOST_CHECK_THROW(push_transaction(trx), eosio::chain::wasm_execution_error);
@@ -1310,18 +1310,18 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    produce_blocks(1);
 
    //run a few tests with new, proper syntax, call_indirect
-   set_code(N(tbl), table_checker_proper_syntax_wast);
+   set_code("tbl"_n, table_checker_proper_syntax_wast);
    produce_blocks(1);
 
    {
    signed_transaction trx;
    action act;
    act.name = name(555ULL<<32 | 1022ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
       set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    }
 
@@ -1330,25 +1330,25 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
    signed_transaction trx;
    action act;
    act.name = name(7777ULL<<32 | 1023ULL);       //top 32 is what we assert against, bottom 32 is indirect call index
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    }
-   set_code(N(tbl), table_checker_small_wast);
+   set_code("tbl"_n, table_checker_small_wast);
    produce_blocks(1);
 
    {
    signed_transaction trx;
    action act;
    act.name = name(888ULL);
-   act.account = N(tbl);
-   act.authorization = vector<permission_level>{{N(tbl),config::active_name}};
+   act.account = "tbl"_n;
+   act.authorization = vector<permission_level>{{"tbl"_n,config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(tbl), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "tbl"_n, "active" ), control->get_chain_id());
 
    //an element that is out of range and has no mmap access permission either (should be a trapped segv)
    BOOST_CHECK_EXCEPTION(push_transaction(trx), eosio::chain::wasm_execution_error, [](const eosio::chain::wasm_execution_error &e) {return true;});
@@ -1358,53 +1358,53 @@ BOOST_FIXTURE_TEST_CASE( check_table_maximum, TESTER ) try {
 BOOST_FIXTURE_TEST_CASE( protected_globals, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(gob)} );
+   create_accounts( {"gob"_n} );
    produce_block();
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_none_get_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_none_get_wast), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_get_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_some_get_wast), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_none_set_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_none_set_wast), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_set_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_some_set_wast), fc::exception);
    produce_blocks(1);
 
    //sanity to make sure I got general binary construction okay
-   set_code(N(gob), global_protection_okay_get_wasm);
+   set_code("gob"_n, global_protection_okay_get_wasm);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_none_get_wasm), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_none_get_wasm), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_get_wasm), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_some_get_wasm), fc::exception);
    produce_blocks(1);
 
-   set_code(N(gob), global_protection_okay_set_wasm);
+   set_code("gob"_n, global_protection_okay_set_wasm);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(gob), global_protection_some_set_wasm), fc::exception);
+   BOOST_CHECK_THROW(set_code("gob"_n, global_protection_some_set_wasm), fc::exception);
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( apply_export_and_signature, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(bbb)} );
+   create_accounts( {"bbb"_n} );
    produce_block();
 
-   BOOST_CHECK_THROW(set_code(N(bbb), no_apply_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("bbb"_n, no_apply_wast), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(bbb), no_apply_2_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("bbb"_n, no_apply_2_wast), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(bbb), no_apply_3_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("bbb"_n, no_apply_3_wast), fc::exception);
    produce_blocks(1);
 
-   BOOST_CHECK_THROW(set_code(N(bbb), apply_wrong_signature_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("bbb"_n, apply_wrong_signature_wast), fc::exception);
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
@@ -1424,61 +1424,61 @@ BOOST_FIXTURE_TEST_CASE( trigger_serialization_errors, TESTER) try {
                                             0x01, 0x0a, 0x0c, 0x01, 0x0a, 0x00, 0x41, 0x04, 0x41, 0x05, 0x41, 0x10, 0x10, 0x00, 0x0b, 0x0b,
                                             0x0b, 0x01, 0x00, 0x41, 0x04, 0x0b, 0x05, 0x68, 0x65, 0x6c, 0x6c, 0x6f };
 
-   create_accounts( {N(bbb)} );
+   create_accounts( {"bbb"_n} );
    produce_block();
 
-   set_code(N(bbb), proper_wasm);
-   BOOST_CHECK_THROW(set_code(N(bbb), malformed_wasm), wasm_serialization_error);
+   set_code("bbb"_n, proper_wasm);
+   BOOST_CHECK_THROW(set_code("bbb"_n, malformed_wasm), wasm_serialization_error);
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( protect_injected, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(inj)} );
+   create_accounts( {"inj"_n} );
    produce_block();
 
-   BOOST_CHECK_THROW(set_code(N(inj), import_injected_wast), fc::exception);
+   BOOST_CHECK_THROW(set_code("inj"_n, import_injected_wast), fc::exception);
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( import_signature, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(imp)} );
+   create_accounts( {"imp"_n} );
    produce_block();
 
-   BOOST_CHECK_THROW(set_code(N(imp), import_wrong_signature_wast), wasm_exception);
+   BOOST_CHECK_THROW(set_code("imp"_n, import_wrong_signature_wast), wasm_exception);
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( mem_growth_memset, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(grower)} );
+   create_accounts( {"grower"_n} );
    produce_block();
 
    action act;
-   act.account = N(grower);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(grower),config::active_name}};
+   act.account = "grower"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"grower"_n,config::active_name}};
 
-   set_code(N(grower), memory_growth_memset_store);
+   set_code("grower"_n, memory_growth_memset_store);
    {
       signed_transaction trx;
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(grower), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "grower"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
    }
 
    produce_blocks(1);
-   set_code(N(grower), memory_growth_memset_test);
+   set_code("grower"_n, memory_growth_memset_test);
    {
       signed_transaction trx;
       trx.actions.push_back(act);
       set_transaction_headers(trx);
-      trx.sign(get_private_key( N(grower), "active" ), control->get_chain_id());
+      trx.sign(get_private_key( "grower"_n, "active" ), control->get_chain_id());
       push_transaction(trx);
    }
 } FC_LOG_AND_RETHROW()
@@ -1522,76 +1522,76 @@ INCBIN(80k_deep_loop_with_void, "80k_deep_loop_with_void.wasm");
 BOOST_FIXTURE_TEST_CASE( fuzz, TESTER ) try {
    produce_blocks(2);
 
-   create_accounts( {N(fuzzy)} );
+   create_accounts( {"fuzzy"_n} );
    produce_block();
 
    {
       vector<uint8_t> wasm(gfuzz1Data, gfuzz1Data + gfuzz1Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz2Data, gfuzz2Data + gfuzz2Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz3Data, gfuzz3Data + gfuzz3Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz4Data, gfuzz4Data + gfuzz4Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz5Data, gfuzz5Data + gfuzz5Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz6Data, gfuzz6Data + gfuzz6Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz7Data, gfuzz7Data + gfuzz7Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz8Data, gfuzz8Data + gfuzz8Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz9Data, gfuzz9Data + gfuzz9Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz10Data, gfuzz10Data + gfuzz10Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz11Data, gfuzz11Data + gfuzz11Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz12Data, gfuzz12Data + gfuzz12Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz13Data, gfuzz13Data + gfuzz13Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    {
       vector<uint8_t> wasm(gfuzz14Data, gfuzz14Data + gfuzz14Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
       {
       vector<uint8_t> wasm(gfuzz15Data, gfuzz15Data + gfuzz15Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
    }
    /*  TODO: update wasm to have apply(...) then call, claim is that this
     *  takes 1.6 seconds under wavm...
    {
       auto start = fc::time_point::now();
       vector<uint8_t> wasm(gfuzz13Data, gfuzz13Data + gfuzz13Size);
-      set_code(N(fuzzy), wasm);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), fc::exception);
+      set_code("fuzzy"_n, wasm);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), fc::exception);
       auto end = fc::time_point::now();
       edump((end-start));
    }
@@ -1599,71 +1599,71 @@ BOOST_FIXTURE_TEST_CASE( fuzz, TESTER ) try {
 
    {
       vector<uint8_t> wasm(gbig_allocationData, gbig_allocationData + gbig_allocationSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gcrash_section_size_too_bigData, gcrash_section_size_too_bigData + gcrash_section_size_too_bigSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_no_destructorData, gleak_no_destructorData + gleak_no_destructorSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_readExportsData, gleak_readExportsData + gleak_readExportsSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_readFunctionsData, gleak_readFunctionsData + gleak_readFunctionsSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_readFunctions_2Data, gleak_readFunctions_2Data + gleak_readFunctions_2Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_readFunctions_3Data, gleak_readFunctions_3Data + gleak_readFunctions_3Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_readGlobalsData, gleak_readGlobalsData + gleak_readGlobalsSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_readImportsData, gleak_readImportsData + gleak_readImportsSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gleak_wasm_binary_cpp_L1249Data, gleak_wasm_binary_cpp_L1249Data + gleak_wasm_binary_cpp_L1249Size);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(greadFunctions_slowness_out_of_memoryData, greadFunctions_slowness_out_of_memoryData + greadFunctions_slowness_out_of_memorySize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(glocals_ycData, glocals_ycData + glocals_ycSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(glocals_sData, glocals_sData + glocals_sSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gslowwasm_localsetsData, gslowwasm_localsetsData + gslowwasm_localsetsSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_serialization_error);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_serialization_error);
    }
    {
       vector<uint8_t> wasm(gdeep_loops_ext_reportData, gdeep_loops_ext_reportData + gdeep_loops_ext_reportSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_exception);
    }
    {
       vector<uint8_t> wasm(g80k_deep_loop_with_retData, g80k_deep_loop_with_retData + g80k_deep_loop_with_retSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_exception);
    }
    {
       vector<uint8_t> wasm(g80k_deep_loop_with_voidData, g80k_deep_loop_with_voidData + g80k_deep_loop_with_voidSize);
-      BOOST_CHECK_THROW(set_code(N(fuzzy), wasm), wasm_exception);
+      BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_exception);
    }
 
    produce_blocks(1);
@@ -1678,24 +1678,24 @@ BOOST_FIXTURE_TEST_CASE( getcode_checks, TESTER ) try {
 
 BOOST_FIXTURE_TEST_CASE( big_maligned_host_ptr, TESTER ) try {
    produce_blocks(2);
-   create_accounts( {N(bigmaligned)} );
+   create_accounts( {"bigmaligned"_n} );
    produce_block();
 
    string large_maligned_host_ptr_wast_f = fc::format_string(large_maligned_host_ptr, fc::mutable_variant_object()
                                               ("MAX_WASM_PAGES", eosio::chain::wasm_constraints::maximum_linear_memory/(64*1024))
                                               ("MAX_NAME_ARRAY", (eosio::chain::wasm_constraints::maximum_linear_memory-1)/sizeof(chain::account_name)));
 
-   set_code(N(bigmaligned), large_maligned_host_ptr_wast_f.c_str());
+   set_code("bigmaligned"_n, large_maligned_host_ptr_wast_f.c_str());
    produce_blocks(1);
 
    signed_transaction trx;
    action act;
-   act.account = N(bigmaligned);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(bigmaligned),config::active_name}};
+   act.account = "bigmaligned"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"bigmaligned"_n,config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(bigmaligned), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "bigmaligned"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_blocks(1);
 } FC_LOG_AND_RETHROW()
@@ -1705,52 +1705,52 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, depth_tests, bdata::make({false, true})
       preactivate_builtin_protocol_features({builtin_protocol_feature_t::configurable_wasm_limits});
 
    produce_block();
-   create_accounts( {N(depth)} );
+   create_accounts( {"depth"_n} );
    produce_block();
 
    signed_transaction trx;
-   trx.actions.emplace_back(vector<permission_level>{{N(depth),config::active_name}}, N(depth), N(), bytes{});
-   trx.actions[0].authorization = vector<permission_level>{{N(depth),config::active_name}};
+   trx.actions.emplace_back(vector<permission_level>{{"depth"_n,config::active_name}}, "depth"_n, ""_n, bytes{});
+   trx.actions[0].authorization = vector<permission_level>{{"depth"_n,config::active_name}};
 
     auto pushit = [&]() {
       produce_block();
       trx.signatures.clear();
       set_transaction_headers(trx);
-      trx.sign(get_private_key(N(depth), "active"), control->get_chain_id());
+      trx.sign(get_private_key("depth"_n, "active"), control->get_chain_id());
       push_transaction(trx);
    };
 
    //strictly wasm recursion to maximum_call_depth & maximum_call_depth+1
    string wasm_depth_okay = fc::format_string(depth_assert_wasm, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
-   set_code(N(depth), wasm_depth_okay.c_str());
+   set_code("depth"_n, wasm_depth_okay.c_str());
    pushit();
 
    string wasm_depth_one_over = fc::format_string(depth_assert_wasm, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
-   set_code(N(depth), wasm_depth_one_over.c_str());
+   set_code("depth"_n, wasm_depth_one_over.c_str());
    BOOST_CHECK_THROW(pushit(), wasm_execution_error);
 
    //wasm recursion but call an intrinsic as the last function instead
    string intrinsic_depth_okay = fc::format_string(depth_assert_intrinsic, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
-   set_code(N(depth), intrinsic_depth_okay.c_str());
+   set_code("depth"_n, intrinsic_depth_okay.c_str());
    pushit();
 
    string intrinsic_depth_one_over = fc::format_string(depth_assert_intrinsic, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
-   set_code(N(depth), intrinsic_depth_one_over.c_str());
+   set_code("depth"_n, intrinsic_depth_one_over.c_str());
    BOOST_CHECK_THROW(pushit(), wasm_execution_error);
 
    //add a float operation in the mix to ensure any injected softfloat call doesn't count against limit
    string wasm_float_depth_okay = fc::format_string(depth_assert_wasm_float, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth));
-   set_code(N(depth), wasm_float_depth_okay.c_str());
+   set_code("depth"_n, wasm_float_depth_okay.c_str());
    pushit();
 
    string wasm_float_depth_one_over = fc::format_string(depth_assert_wasm_float, fc::mutable_variant_object()
                                               ("MAX_DEPTH", eosio::chain::wasm_constraints::maximum_call_depth+1));
-   set_code(N(depth), wasm_float_depth_one_over.c_str());
+   set_code("depth"_n, wasm_float_depth_one_over.c_str());
    BOOST_CHECK_THROW(pushit(), wasm_execution_error);
 
 } FC_LOG_AND_RETHROW()
@@ -1758,21 +1758,21 @@ BOOST_DATA_TEST_CASE_F( old_wasm_tester, depth_tests, bdata::make({false, true})
 BOOST_FIXTURE_TEST_CASE( varuint_memory_flags_tests, old_wasm_tester ) try {
    produce_block();
 
-   create_accounts( {N(memflags)} );
+   create_accounts( {"memflags"_n} );
    produce_block();
 
-   set_code(N(memflags), varuint_memory_flags);
+   set_code("memflags"_n, varuint_memory_flags);
    produce_block();
 
    {
    signed_transaction trx;
    action act;
-   act.account = N(memflags);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(memflags),config::active_name}};
+   act.account = "memflags"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"memflags"_n,config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(memflags), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "memflags"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_block();
    }
@@ -1785,18 +1785,18 @@ BOOST_FIXTURE_TEST_CASE( varuint_memory_flags_tests, old_wasm_tester ) try {
    {
    signed_transaction trx;
    action act;
-   act.account = N(memflags);
-   act.name = N();
-   act.authorization = vector<permission_level>{{N(memflags),config::active_name}};
+   act.account = "memflags"_n;
+   act.name = ""_n;
+   act.authorization = vector<permission_level>{{"memflags"_n,config::active_name}};
    trx.actions.push_back(act);
    set_transaction_headers(trx);
-   trx.sign(get_private_key( N(memflags), "active" ), control->get_chain_id());
+   trx.sign(get_private_key( "memflags"_n, "active" ), control->get_chain_id());
    push_transaction(trx);
    produce_block();
    }
 
-   set_code(N(memflags), std::vector<uint8_t>{});
-   BOOST_REQUIRE_THROW(set_code(N(memflags), varuint_memory_flags), wasm_exception);
+   set_code("memflags"_n, std::vector<uint8_t>{});
+   BOOST_REQUIRE_THROW(set_code("memflags"_n, varuint_memory_flags), wasm_exception);
 } FC_LOG_AND_RETHROW()
 
 static char reset_memory_fail1_wast[] = R"======(
@@ -1862,7 +1862,7 @@ BOOST_AUTO_TEST_CASE( code_size )  try {
    };
 
    std::vector<U8> code_end = { 0x0b };
- 
+
    std::vector<U8> code_function_body;
    code_function_body.insert(code_function_body.end(), wasm_constraints::maximum_code_size + 4, 0x01);
 
@@ -1885,8 +1885,8 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
 
    const resource_limits_manager& mgr = chain.control->get_resource_limits_manager();
 
-   account_name acc = N( asserter );
-   account_name user = N( user );
+   account_name acc = "asserter"_n;
+   account_name user = "user"_n;
    chain.create_accounts( {acc, user} );
    chain.produce_block();
 
@@ -1916,13 +1916,13 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    push_trx( ptrx, fc::time_point::maximum(), 0, false, 0 ); // non-explicit billing
 
    // setup account acc with large limits
-   chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+   chain.push_action( config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
          ("account", user)
          ("ram_bytes", -1)
          ("net_weight", 19'999'999)
          ("cpu_weight", 19'999'999)
    );
-   chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+   chain.push_action( config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
          ("account", acc)
          ("ram_bytes", -1)
          ("net_weight", 9'999)
@@ -1979,7 +1979,7 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
    BOOST_CHECK_EXCEPTION( push_trx( ptrx, fc::time_point::maximum(), min_cpu_time_us - 1, true, 0 ), transaction_exception,
                           fc_exception_message_starts_with("cannot bill CPU time less than the minimum") );
 
-   chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+   chain.push_action( config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
          ("account", acc)
          ("ram_bytes", -1)
          ("net_weight", 75)
@@ -2049,7 +2049,7 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
                          fc_exception_message_starts_with("estimated") );
 
    // Test when cpu limit is 0
-   chain.push_action( config::system_account_name, N(setalimits), config::system_account_name, fc::mutable_variant_object()
+   chain.push_action( config::system_account_name, "setalimits"_n, config::system_account_name, fc::mutable_variant_object()
            ("account", acc)
            ("ram_bytes", -1)
            ("net_weight", 75)
@@ -2075,7 +2075,7 @@ BOOST_AUTO_TEST_CASE( billed_cpu_test ) try {
 BOOST_FIXTURE_TEST_CASE(net_usage_tests, tester ) try {
    int count = 0;
    auto check = [&](int coderepeat, int max_net_usage)-> bool {
-      account_name account = N(f_tests) + (count++) * 16;
+      account_name account = "f_tests"_n + (count++) * 16;
       create_accounts({account});
 
       std::string code = R"=====(
@@ -2124,8 +2124,8 @@ BOOST_FIXTURE_TEST_CASE(net_usage_tests, tester ) try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(weighted_net_usage_tests, tester ) try {
-   account_name account = N(f_tests);
-   account_name acc2 = N(acc2);
+   account_name account = "f_tests"_n;
+   account_name acc2 = "acc2"_n;
    create_accounts({account, acc2});
    int ver = 0;
    auto check = [&](int coderepeat)-> bool {


### PR DESCRIPTION
Cherry picked from c5674d4c166639875f19cb7a2059941481ad9a66
with additional fixes.

Because the N macro did not have a project-specific prefix, it clashed
with its namesakes from third-party projects like LLVM. This commit
introduces a namespace-scoped operator ""_n and replaces all invocations
of the N macro with that operator.