### PR TITLE
Increment codegen_version 

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/eos-vm-oc.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/eos-vm-oc.hpp
@@ -50,6 +50,8 @@ enum eosvmoc_exitcode : int {
    EOSVMOC_EXIT_EXCEPTION
 };
 
+static constexpr uint8_t current_codegen_version = 1;
+
 }}}
 
 FC_REFLECT(eosio::chain::eosvmoc::no_offset, );

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/code_cache.cpp
@@ -262,7 +262,7 @@ code_cache_base::code_cache_base(const boost::filesystem::path data_dir, const e
       for(unsigned i = 0; i < number_entries; ++i) {
          code_descriptor cd;
          fc::raw::unpack(ds, cd);
-         if(cd.codegen_version != 0) {
+         if(cd.codegen_version != current_codegen_version) {
             allocator->deallocate(code_mapping + cd.code_begin);
             allocator->deallocate(code_mapping + cd.initdata_begin);
             continue;

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_monitor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_monitor.cpp
@@ -140,7 +140,7 @@ struct compile_monitor_session {
                   reply.result = code_descriptor {
                      code.code_id,
                      code.vm_version,
-                     0,
+                     current_codegen_version,
                      (uintptr_t)code_ptr - (uintptr_t)_code_mapping,
                      result.start,
                      result.apply_offset,


### PR DESCRIPTION
We're incompatible with 2.1 due to a different host function table (see intrisic_mapping.hpp).