### PR TITLE
Allow minority/majority producers permission to be removed

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -2297,13 +2297,17 @@ struct controller_impl {
                                                        config::active_name}),
                          calculate_threshold( 2, 3 ) /* more than two-thirds */                      );
 
-      update_permission( authorization.get_permission({config::producers_account_name,
-                                                       config::majority_producers_permission_name}),
-                         calculate_threshold( 1, 2 ) /* more than one-half */                        );
+      const permission_object* major_perm = authorization.find_permission({config::producers_account_name,
+                                                                           config::majority_producers_permission_name});
+      if( major_perm ) {
+         update_permission( *major_perm, calculate_threshold( 1, 2 ) /* more than one-half */ );
+      }
 
-      update_permission( authorization.get_permission({config::producers_account_name,
-                                                       config::minority_producers_permission_name}),
-                         calculate_threshold( 1, 3 ) /* more than one-third */                       );
+      const permission_object* minor_perm = authorization.find_permission({config::producers_account_name,
+                                                                           config::minority_producers_permission_name});
+      if( minor_perm ) {
+         update_permission( *minor_perm, calculate_threshold( 1, 3 ) /* more than one-third */ );
+      }
 
       //TODO: Add tests
    }

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -1,4 +1,5 @@
 #include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/authorization_manager.hpp>
 #include <eosio/testing/tester.hpp>
 
 #include <boost/test/unit_test.hpp>
@@ -228,6 +229,13 @@ BOOST_FIXTURE_TEST_CASE( producer_schedule_promotion_test, TESTER ) try {
    BOOST_CHECK_EQUAL( control->active_producers().version, 1u );
    BOOST_CHECK_EQUAL( true, compare_schedules( sch1, control->active_producers() ) );
    produce_blocks(6);
+
+   // verify prod.minor and prod.major permissions can be removed
+   auto& authorization = control->get_mutable_authorization_manager();
+   const auto& minor_permission = authorization.get_permission({config::producers_account_name, config::minority_producers_permission_name});
+   authorization.remove_permission( minor_permission );
+   const auto& majority_permission = authorization.get_permission({config::producers_account_name, config::majority_producers_permission_name});
+   authorization.remove_permission( majority_permission );
 
    res = set_producers( {"alice"_n,"bob"_n,"carol"_n} );
    vector<producer_authority> sch2 = {


### PR DESCRIPTION
- Nothing prevents `eosio.prods` `prod.major` or `prod.minor` permissions from being deleted.
  - `cleos set account permission eosio.prods prod.minor NULL`
  - `cleos set account permission eosio.prods prod.major NULL`
- Verify permissions exist before attempting to update them in `update_producers_authority` to prevent chain from stopping.