### PR TITLE
Added classes for processing controller trx and block signals

### DIFF
--- a/plugins/chain_interface/include/eosio/chain/block_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/block_interface.hpp
@@ -1,0 +1,35 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/trace.hpp>
+#include <optional>
+
+namespace eosio::chain {
+
+class block_interface {
+public:
+   block_interface() = default;
+
+   /// connect to chain controller irreversible_block signal
+   virtual void signal_irreversible_block( const chain::block_state_ptr& bsp ) = 0;
+
+   /// connect to chain controller block_start signal
+   virtual void signal_block_start( uint32_t block_num ) {
+      _block_num = block_num;
+   }
+
+   /// connect to chain controller accepted_block signal
+   virtual void signal_accepted_block( const chain::block_state_ptr& ) {
+      _block_num.reset();
+   }
+
+   std::optional<uint32_t> block_num() const {
+      return _block_num;
+   }
+private:
+   std::optional<uint32_t> _block_num;
+};
+
+using block_interface_ptr = std::shared_ptr<block_interface>;
+
+} // eosio::chain

--- a/plugins/chain_interface/include/eosio/chain/signals_processor.hpp
+++ b/plugins/chain_interface/include/eosio/chain/signals_processor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/block_state.hpp>
+#include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/block_interface.hpp>
 #include <eosio/chain/trx_interface.hpp>
@@ -22,6 +23,10 @@ public:
      _speculative_block_trx_processor(speculative_block_trx_processor),
      _local_trx_processor(local_trx_processor),
      _trx_processor(_local_trx_processor) {
+      EOS_ASSERT( _block_processor, plugin_config_exception, "signals_processor must be provided a block_processor" );
+      EOS_ASSERT( _in_block_trx_processor, plugin_config_exception, "signals_processor must be provided a in_block_trx_processor" );
+      EOS_ASSERT( _speculative_block_trx_processor, plugin_config_exception, "signals_processor must be provided a speculative_block_trx_processor" );
+      EOS_ASSERT( _local_trx_processor, plugin_config_exception, "signals_processor must be provided a local_trx_processor" );
    }
 
    /// connect to chain controller applied_transaction signal

--- a/plugins/chain_interface/include/eosio/chain/signals_processor.hpp
+++ b/plugins/chain_interface/include/eosio/chain/signals_processor.hpp
@@ -1,0 +1,63 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/trace.hpp>
+#include <eosio/chain/block_interface.hpp>
+#include <eosio/chain/trx_interface.hpp>
+
+namespace eosio::chain {
+
+class signals_processor {
+public:
+   /**
+    * Class for tracking transactions and which block they belong to.
+    * @param block_processor backend processor of block related signals
+    * @param in_block_trx_processor backend processor of transactions in speculative blocks
+    * @param speculative_block_trx_processor backend processor of transactions in speculative blocks
+    * @param local_trx_processor backend processor of transactions applied locally
+    */
+   signals_processor( block_interface_ptr block_processor,  trx_interface_ptr in_block_trx_processor, trx_interface_ptr speculative_block_trx_processor, trx_interface_ptr local_trx_processor)
+   : _block_processor(block_processor),
+     _in_block_trx_processor(in_block_trx_processor),
+     _speculative_block_trx_processor(speculative_block_trx_processor),
+     _local_trx_processor(local_trx_processor),
+     _trx_processor(_local_trx_processor) {
+   }
+
+   /// connect to chain controller applied_transaction signal
+   void signal_applied_transaction( const chain::transaction_trace_ptr& trace, const chain::signed_transaction& strx ) {
+      if (!_trx_processor) {
+         _trx_processor = trace->producer_block_id ? _in_block_trx_processor : _speculative_block_trx_processor;
+      }
+      _trx_processor->signal_applied_transaction(trace, strx);
+   }
+
+   /// connect to chain controller accepted_block signal
+   void signal_accepted_block( const chain::block_state_ptr& bsp ) {
+      _block_processor->signal_accepted_block(bsp);
+      _trx_processor = _local_trx_processor;
+   }
+
+   /// connect to chain controller irreversible_block signal
+   void signal_irreversible_block( const chain::block_state_ptr& bsp ) {
+      _block_processor->signal_irreversible_block(bsp);
+   }
+
+
+   /// connect to chain controller block_start signal
+   void signal_block_start( uint32_t block_num ) {
+      _block_processor->signal_block_start(block_num);
+      // either it is a speculative block or real block. need to determine when we get a transaction
+      _trx_processor.reset();
+   }
+
+private:
+   const block_interface_ptr _block_processor;
+   const trx_interface_ptr _in_block_trx_processor;
+   const trx_interface_ptr _speculative_block_trx_processor;
+   const trx_interface_ptr _local_trx_processor;
+
+   trx_interface_ptr _trx_processor;
+};
+
+} // eosio::chain

--- a/plugins/chain_interface/include/eosio/chain/trx_interface.hpp
+++ b/plugins/chain_interface/include/eosio/chain/trx_interface.hpp
@@ -1,0 +1,25 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/trace.hpp>
+#include <memory>
+
+namespace eosio::chain {
+
+class trx_interface {
+public:
+   trx_interface() = default;
+
+   /// connect to chain controller applied_transaction signal
+   virtual void signal_applied_transaction( const chain::transaction_trace_ptr& trace, const chain::signed_transaction& strx ) = 0;
+};
+
+using trx_interface_ptr = std::shared_ptr<trx_interface>;
+
+class no_op_processor : public trx_interface {
+public:
+   no_op_processor() = default;
+
+   void signal_applied_transaction( const chain::transaction_trace_ptr& trace, const chain::signed_transaction& strx ) override {}
+};
+} // eosio::chain

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB HEADERS "include/eosio/chain_plugin/*.hpp")
 add_library( chain_plugin
              account_query_db.cpp
+             trx_finality_status_processing.cpp
              trx_retry_processing.cpp
              chain_plugin.cpp
              ${HEADERS} )

--- a/plugins/chain_plugin/CMakeLists.txt
+++ b/plugins/chain_plugin/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB HEADERS "include/eosio/chain_plugin/*.hpp")
 add_library( chain_plugin
              account_query_db.cpp
+             trx_retry_processing.cpp
              chain_plugin.cpp
              ${HEADERS} )
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/block_interface.hpp>
+#include <eosio/chain/trx_interface.hpp>
+#include <eosio/chain/trace.hpp>
+#include <memory>
+
+namespace eosio::chain_apis {
+   /**
+    * This class manages the processing related to the transaction finality status feature.
+    */
+   class trx_finality_status_processing {
+   public:
+
+      /**
+       * Instantiate a new transaction retry processor
+       * @param max_storage - the maximum storage allotted to this feature
+       */
+      trx_finality_status_processing( uint64_t max_storage );
+
+      chain::block_interface_ptr get_block_processor() const;
+
+      chain::trx_interface_ptr get_in_block_trx_processor() const;
+
+      chain::trx_interface_ptr get_speculative_trx_processor() const;
+
+      chain::trx_interface_ptr get_local_trx_processor() const;
+   };
+
+   using trx_finality_status_processing_ptr = std::shared_ptr<trx_finality_status_processing>;
+} // namespace eosio::chain_apis

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_processing.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_retry_processing.hpp
@@ -1,0 +1,32 @@
+#pragma once
+#include <eosio/chain/types.hpp>
+#include <eosio/chain/block_state.hpp>
+#include <eosio/chain/block_interface.hpp>
+#include <eosio/chain/trx_interface.hpp>
+#include <eosio/chain/trace.hpp>
+#include <memory>
+
+namespace eosio::chain_apis {
+   /**
+    * This class manages the processing related to the transaction retry feature.
+    */
+   class trx_retry_processing {
+   public:
+
+      /**
+       * Instantiate a new transaction retry processor
+       * @param max_storage - the maximum storage allotted to this feature
+       */
+      trx_retry_processing( uint64_t max_storage );
+
+      chain::block_interface_ptr get_block_processor() const;
+
+      chain::trx_interface_ptr get_in_block_trx_processor() const;
+
+      chain::trx_interface_ptr get_speculative_trx_processor() const;
+
+      chain::trx_interface_ptr get_local_trx_processor() const;
+   };
+
+   using trx_retry_processing_ptr = std::shared_ptr<trx_retry_processing>;
+} // namespace eosio::chain_apis

--- a/plugins/chain_plugin/test/CMakeLists.txt
+++ b/plugins/chain_plugin/test/CMakeLists.txt
@@ -3,3 +3,9 @@ add_executable( test_account_query_db test_account_query_db.cpp )
 target_link_libraries( test_account_query_db chain_plugin eosio_testing)
 
 add_test(NAME test_account_query_db COMMAND plugins/chain_plugin/test/test_account_query_db WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+add_executable( test_signals_processor test_signals_processor.cpp )
+
+target_link_libraries( test_signals_processor chain_plugin eosio_testing)
+
+add_test(NAME test_signals_processor COMMAND plugins/chain_plugin/test/test_signals_processor WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/chain_plugin/test/test_signals_processor.cpp
+++ b/plugins/chain_plugin/test/test_signals_processor.cpp
@@ -1,0 +1,235 @@
+#define BOOST_TEST_MODULE signals_processor
+#include <boost/test/included/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/chain/signals_processor.hpp>
+#include <eosio/chain/name.hpp>
+#include <eosio/chain/asset.hpp>
+#include <fc/bitutil.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+
+class trx_handler : public chain::trx_interface {
+public:
+   std::vector<chain::transaction_id_type> ids;
+   /// connect to chain controller applied_transaction signal
+   void signal_applied_transaction( const chain::transaction_trace_ptr& trace, const chain::signed_transaction& strx ) override {
+      ids.push_back(trace->id);
+   }
+};
+
+class block_handler : public chain::block_interface {
+public:
+   std::vector<chain::block_id_type> irr_ids;
+   /// connect to chain controller irreversible_block signal
+   void signal_irreversible_block( const chain::block_state_ptr& bsp ) override {
+      irr_ids.push_back(bsp->id);
+   }
+};
+
+namespace {
+   chain::transaction_trace_ptr make_transaction_trace( const chain::transaction_id_type& id, uint32_t block_number,
+         uint32_t slot, std::optional<chain::block_id_type> block_id, chain::transaction_receipt_header::status_enum status, std::vector<chain::action_trace>&& actions ) {
+      return std::make_shared<chain::transaction_trace>(chain::transaction_trace{
+         id,
+         block_number,
+         chain::block_timestamp_type(slot),
+         block_id,
+         chain::transaction_receipt_header{status},
+         fc::microseconds(0),
+         0,
+         false,
+         std::move(actions),
+         {},
+         {},
+         {},
+         {},
+         {}
+      });
+   }
+
+   chain::bytes make_transfer_data( chain::name from, chain::name to, chain::asset quantity, std::string&& memo) {
+      fc::datastream<size_t> ps;
+      fc::raw::pack(ps, from, to, quantity, memo);
+      chain::bytes result( ps.tellp());
+
+      if( result.size()) {
+         fc::datastream<char *> ds( result.data(), size_t( result.size()));
+         fc::raw::pack(ds, from, to, quantity, memo);
+      }
+      return result;
+   }
+
+   auto make_transfer_action( chain::name from, chain::name to, chain::asset quantity, std::string memo ) {
+      return chain::action( std::vector<chain::permission_level> {{from, chain::config::active_name}},
+                            "eosio.token"_n, "transfer"_n, make_transfer_data( from, to, quantity, std::move(memo) ) );
+   }
+
+   chain::action_trace make_action_trace( uint64_t global_sequence, chain::action act, chain::name receiver ) {
+      chain::action_trace result;
+      // don't think we need any information other than receiver and global sequence
+      result.receipt.emplace(chain::action_receipt{
+         receiver,
+         chain::digest_type::hash(act),
+         global_sequence,
+         0,
+         {},
+         0,
+         0
+      });
+      result.receiver = receiver;
+      result.act = std::move(act);
+      return result;
+   }
+
+   auto make_packed_trx( std::vector<chain::action> actions ) {
+      chain::signed_transaction trx;
+      trx.actions = std::move( actions );
+      return packed_transaction( trx );
+   }
+
+   chain::asset operator"" _t(const char* input, std::size_t) {
+      return chain::asset::from_string(input);
+   }
+
+
+   auto get_private_key( chain::name keyname, std::string role = "owner" ) {
+      auto secret = fc::sha256::hash( keyname.to_string() + role );
+      return chain::private_key_type::regenerate<fc::ecc::private_key_shim>( secret );
+   }
+
+   auto get_public_key( chain::name keyname, std::string role = "owner" ) {
+      return get_private_key( keyname, role ).get_public_key();
+   }
+
+   auto make_block_state( chain::block_id_type previous, uint32_t height, uint32_t slot, chain::name producer,
+                          std::vector<chain::packed_transaction> trxs ) {
+      chain::signed_block_ptr block = std::make_shared<chain::signed_block>();
+      for( auto& trx : trxs ) {
+         block->transactions.emplace_back( trx );
+      }
+      block->producer = producer;
+      block->timestamp = chain::block_timestamp_type(slot);
+      // make sure previous contains correct block # so block_header::block_num() returns correct value
+      if( previous == chain::block_id_type() ) {
+         previous._hash[0] &= 0xffffffff00000000;
+         previous._hash[0] += fc::endian_reverse_u32(height - 1);
+      }
+      block->previous = previous;
+
+      auto priv_key = get_private_key( block->producer, "active" );
+      auto pub_key = get_public_key( block->producer, "active" );
+
+      auto prev = std::make_shared<chain::block_state>();
+      auto header_bmroot = chain::digest_type::hash( std::make_pair( block->digest(), prev->blockroot_merkle.get_root()));
+      auto sig_digest = chain::digest_type::hash( std::make_pair( header_bmroot, prev->pending_schedule.schedule_hash ));
+      block->producer_signature = priv_key.sign( sig_digest );
+
+      std::vector<chain::private_key_type> signing_keys;
+      signing_keys.emplace_back( std::move( priv_key ));
+      auto signer = [&]( chain::digest_type d ) {
+         std::vector<chain::signature_type> result;
+         result.reserve( signing_keys.size());
+         for( const auto& k: signing_keys )
+            result.emplace_back( k.sign( d ));
+         return result;
+      };
+      chain::pending_block_header_state pbhs;
+      pbhs.producer = block->producer;
+      pbhs.timestamp = block->timestamp;
+      chain::producer_authority_schedule schedule = {0, {chain::producer_authority{block->producer,
+                                                                                   chain::block_signing_authority_v0{1, {{pub_key, 1}}}}}};
+      pbhs.active_schedule = schedule;
+      pbhs.valid_block_signing_authority = chain::block_signing_authority_v0{1, {{pub_key, 1}}};
+      auto bsp = std::make_shared<chain::block_state>(
+         std::move( pbhs ),
+         std::move( block ),
+         std::vector<chain::transaction_metadata_ptr>(),
+         chain::protocol_feature_set(),
+         []( chain::block_timestamp_type timestamp,
+             const fc::flat_set<chain::digest_type>& cur_features,
+             const std::vector<chain::digest_type>& new_features ) {},
+         signer
+      );
+      bsp->block_num = height;
+
+      return bsp;
+   }
+}
+
+BOOST_AUTO_TEST_SUITE(signals_processor_tests)
+
+BOOST_AUTO_TEST_CASE(signals_test) { try {
+   auto* blocks = new block_handler;
+   block_interface_ptr blocks_ptr{blocks};
+   auto* block_trxs = new trx_handler;
+   trx_interface_ptr block_trxs_ptr{block_trxs};
+   auto* speculative_trxs = new trx_handler;
+   trx_interface_ptr speculative_trxs_ptr{speculative_trxs};
+   auto* local_trxs = new trx_handler;
+   trx_interface_ptr local_trxs_ptr{local_trxs};
+   chain::signals_processor sig_proc{blocks_ptr, block_trxs_ptr, speculative_trxs_ptr, local_trxs_ptr};
+
+   auto act1 = make_transfer_action( "alice"_n, "bob"_n, "0.0001 SYS"_t, "Memo!" );
+   auto act2 = make_transfer_action( "alice"_n, "jen"_n, "0.0002 SYS"_t, "Memo!" );
+   auto actt1 = make_action_trace( 0, act1, "eosio.token"_n );
+   auto actt2 = make_action_trace( 1, act2, "alice"_n );
+   auto ptrx1 = make_packed_trx( { act1, act2 } );
+   auto tt1 = make_transaction_trace( ptrx1.id(), 1, 1, {}, chain::transaction_receipt_header::executed, { actt1, actt2 } );
+   sig_proc.signal_applied_transaction( tt1, ptrx1.get_signed_transaction() );
+
+   BOOST_CHECK_EQUAL(local_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(speculative_trxs->ids.size(), 0);
+   BOOST_CHECK_EQUAL(block_trxs->ids.size(), 0);
+   BOOST_CHECK_EQUAL(blocks->irr_ids.size(), 0);
+   BOOST_CHECK(!blocks->block_num());
+
+   sig_proc.signal_block_start(50);
+   BOOST_CHECK(blocks->block_num());
+   BOOST_CHECK_EQUAL(*blocks->block_num(), 50);
+   sig_proc.signal_applied_transaction( tt1, ptrx1.get_signed_transaction() );
+   BOOST_CHECK_EQUAL(local_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(speculative_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(block_trxs->ids.size(), 0);
+   BOOST_CHECK_EQUAL(blocks->irr_ids.size(), 0);
+   BOOST_CHECK(blocks->block_num());
+   BOOST_CHECK_EQUAL(*blocks->block_num(), 50);
+
+   auto tt2 = make_transaction_trace( ptrx1.id(), 1, 1, chain::block_id_type{}, chain::transaction_receipt_header::executed, { actt1, actt2 } );
+   sig_proc.signal_block_start(25);
+   BOOST_CHECK(blocks->block_num());
+   BOOST_CHECK_EQUAL(*blocks->block_num(), 25);
+   sig_proc.signal_applied_transaction( tt2, ptrx1.get_signed_transaction() );
+   BOOST_CHECK_EQUAL(local_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(speculative_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(block_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(blocks->irr_ids.size(), 0);
+   BOOST_CHECK(blocks->block_num());
+   BOOST_CHECK_EQUAL(*blocks->block_num(), 25);
+
+   auto bsp1 = make_block_state( chain::block_id_type(), 1, 1, "bp.one"_n, { chain::packed_transaction(ptrx1) } );
+   sig_proc.signal_accepted_block(bsp1);
+   BOOST_CHECK_EQUAL(local_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(speculative_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(block_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(blocks->irr_ids.size(), 0);
+   BOOST_CHECK(!blocks->block_num());
+
+   sig_proc.signal_applied_transaction( tt1, ptrx1.get_signed_transaction() );
+   BOOST_CHECK_EQUAL(local_trxs->ids.size(), 2);
+   BOOST_CHECK_EQUAL(speculative_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(block_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(blocks->irr_ids.size(), 0);
+   BOOST_CHECK(!blocks->block_num());
+
+   sig_proc.signal_irreversible_block(bsp1);
+   BOOST_CHECK_EQUAL(local_trxs->ids.size(), 2);
+   BOOST_CHECK_EQUAL(speculative_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(block_trxs->ids.size(), 1);
+   BOOST_CHECK_EQUAL(blocks->irr_ids.size(), 1);
+   BOOST_CHECK(!blocks->block_num());
+
+} FC_LOG_AND_RETHROW() }
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/plugins/chain_plugin/trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/trx_finality_status_processing.cpp
@@ -1,0 +1,31 @@
+#include <eosio/chain_plugin/trx_finality_status_processing.hpp>
+
+
+using namespace eosio;
+
+namespace eosio::chain_apis {
+
+   trx_finality_status_processing::trx_finality_status_processing( uint64_t max_storage )
+   {
+   }
+
+   chain::block_interface_ptr trx_finality_status_processing::get_block_processor() const {
+#warning TODO need to add real block_interface implementation
+      return chain::block_interface_ptr{};
+   }
+
+   chain::trx_interface_ptr trx_finality_status_processing::get_in_block_trx_processor() const {
+#warning TODO need to add real trx_interface implementation
+      return chain::trx_interface_ptr{};
+   }
+
+   chain::trx_interface_ptr trx_finality_status_processing::get_speculative_trx_processor() const {
+      // trx finality status does not care about speculative block transactions
+      return chain::trx_interface_ptr{new chain::no_op_processor};
+   }
+
+   chain::trx_interface_ptr trx_finality_status_processing::get_local_trx_processor() const {
+#warning TODO need to add real trx_interface implementation
+      return chain::trx_interface_ptr{};
+   }
+}

--- a/plugins/chain_plugin/trx_retry_processing.cpp
+++ b/plugins/chain_plugin/trx_retry_processing.cpp
@@ -1,0 +1,31 @@
+#include <eosio/chain_plugin/trx_retry_processing.hpp>
+
+
+using namespace eosio;
+
+namespace eosio::chain_apis {
+
+   trx_retry_processing::trx_retry_processing( uint64_t max_storage )
+   {
+   }
+
+   chain::block_interface_ptr trx_retry_processing::get_block_processor() const {
+#warning TODO need to add real block_interface implementation
+      return chain::block_interface_ptr{};
+   }
+
+   chain::trx_interface_ptr trx_retry_processing::get_in_block_trx_processor() const {
+#warning TODO need to add real trx_interface implementation
+      return chain::trx_interface_ptr{};
+   }
+
+   chain::trx_interface_ptr trx_retry_processing::get_speculative_trx_processor() const {
+      // trx retry does not care about speculative block transactions
+      return chain::trx_interface_ptr{new chain::no_op_processor};
+   }
+
+   chain::trx_interface_ptr trx_retry_processing::get_local_trx_processor() const {
+#warning TODO need to add real trx_interface implementation
+      return chain::trx_interface_ptr{};
+   }
+}


### PR DESCRIPTION
This is being used by Transaction Retry and Transaction Finality Status features.
Also hooks up signals_processor in chain_plugin and added configuration parameters to enable each feature.