### PR TITLE
ENFS-43: Add Configured Whitelist to Ignore Number of Failures

### DIFF
--- a/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
@@ -114,7 +114,7 @@ public: // public for tests
 public:
    void disable() { _disabled = true; }
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
-   bool is_account_disabled(const account_name& a ) { return _disabled_accounts.count( a ); }
+   bool is_account_disabled(const account_name& a ) const { return _disabled_accounts.count( a ); }
 
    /// @param in_pending_block pass true if pt's bill time is accounted for in the pending block
    void subjective_bill( const transaction_id_type& id, const fc::time_point& expire, const account_name& first_auth,

--- a/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
@@ -114,6 +114,7 @@ public: // public for tests
 public:
    void disable() { _disabled = true; }
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
+   bool is_account_disabled(const account_name & a ) { _disabled_accounts.count( a ); }
 
    /// @param in_pending_block pass true if pt's bill time is accounted for in the pending block
    void subjective_bill( const transaction_id_type& id, const fc::time_point& expire, const account_name& first_auth,

--- a/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
@@ -114,7 +114,7 @@ public: // public for tests
 public:
    void disable() { _disabled = true; }
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
-   bool is_account_disabled(const account_name & a ) { _disabled_accounts.count( a ); }
+   bool is_account_disabled(const account_name& a ) { return _disabled_accounts.count( a ); }
 
    /// @param in_pending_block pass true if pt's bill time is accounted for in the pending block
    void subjective_bill( const transaction_id_type& id, const fc::time_point& expire, const account_name& first_auth,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1912,7 +1912,8 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
             auto trx_deadline = start + fc::milliseconds( _max_transaction_time_ms );
 
             auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
-            if( account_fails.failure_limit( first_auth ) ) {
+            auto max_fails_disabled = _subjective_billing.is_account_disabled( first_auth );
+            if( !max_fails_disabled && account_fails.failure_limit( first_auth ) ) {
                ++num_failed;
                itr = _unapplied_transactions.erase( itr );
                continue;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1808,6 +1808,7 @@ class account_failures {
 public:
    constexpr static uint32_t max_failures_per_account = 3;
 
+   //lifetime of sb must outlive account_failures
    explicit account_failures( const eosio::subjective_billing& sb ) : subjective_billing(sb) {}
 
    void add( const account_name& n, int64_t exception_code ) {
@@ -1885,7 +1886,7 @@ private:
    };
 
    std::map<account_name, account_failure> failed_accounts;
-   eosio::subjective_billing subjective_billing;
+   const eosio::subjective_billing& subjective_billing;
 };
 
 } // anonymous namespace

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1808,6 +1808,8 @@ class account_failures {
 public:
    constexpr static uint32_t max_failures_per_account = 3;
 
+   explicit account_failures( const eosio::subjective_billing& sb ) : subjective_billing(sb) {}
+
    void add( const account_name& n, int64_t exception_code ) {
       auto& fa = failed_accounts[n];
       ++fa.num_failures;
@@ -1817,7 +1819,8 @@ public:
    // return true if exceeds max_failures_per_account and should be dropped
    bool failure_limit( const account_name& n ) {
       auto fitr = failed_accounts.find( n );
-      if( fitr != failed_accounts.end() && fitr->second.num_failures >= max_failures_per_account ) {
+      bool is_whitelisted = subjective_billing.is_account_disabled( n );
+      if( !is_whitelisted && fitr != failed_accounts.end() && fitr->second.num_failures >= max_failures_per_account ) {
          ++fitr->second.num_failures;
          return true;
       }
@@ -1882,6 +1885,7 @@ private:
    };
 
    std::map<account_name, account_failure> failed_accounts;
+   eosio::subjective_billing subjective_billing;
 };
 
 } // anonymous namespace
@@ -1890,7 +1894,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
 {
    bool exhausted = false;
    if( !_unapplied_transactions.empty() ) {
-      account_failures account_fails;
+      account_failures account_fails( _subjective_billing );
       chain::controller& chain = chain_plug->chain();
       const auto& rl = chain.get_resource_limits_manager();
       int num_applied = 0, num_failed = 0, num_processed = 0;
@@ -1912,8 +1916,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
             auto trx_deadline = start + fc::milliseconds( _max_transaction_time_ms );
 
             auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
-            auto max_fails_disabled = _subjective_billing.is_account_disabled( first_auth );
-            if( !max_fails_disabled && account_fails.failure_limit( first_auth ) ) {
+            if( account_fails.failure_limit( first_auth ) ) {
                ++num_failed;
                itr = _unapplied_transactions.erase( itr );
                continue;


### PR DESCRIPTION
Do not apply the 3-strike rule to disable-subjective-account-billing accounts.