### PR TITLE
Add new transaction retry integration test

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -219,7 +219,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -L "long_running_tests" -E "nodeos_short_fork_take_over_lr_test|nodeos_under_min_avail_ram_lr_test|nodeos_startup_catchup_lr_test|nodeos_producer_watermark_lr_test|nodeos_irreversible_mode_lr_test|nodeos_forked_chain_lr_test|nodeos_voting_lr_test|nodeos_high_transaction_lr_test"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -L "long_running_tests" -E "nodeos_short_fork_take_over_lr_test|nodeos_under_min_avail_ram_lr_test|nodeos_startup_catchup_lr_test|nodeos_producer_watermark_lr_test|nodeos_irreversible_mode_lr_test|nodeos_forked_chain_lr_test|nodeos_voting_lr_test|nodeos_high_transaction_lr_test|nodeos_retry_transaction_lr_test"'
   nodeos_short_fork_take_over_lr_test:
     name: Ubuntu 20.04 | nodeos_short_fork_take_over_lr_test
     runs-on: ubuntu-latest
@@ -388,3 +388,24 @@ jobs:
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
           ${DOCKER} bash -c 'cd build && ctest --output-on-failure -R nodeos_high_transaction_lr_test'
+  nodeos_retry_transaction_lr_test:
+    name: Ubuntu 20.04 | nodeos_retry_transaction_lr_test
+    runs-on: ubuntu-latest
+    needs: ubuntu-2004-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-2004-build
+      - name: nodeos_retry_transaction_lr_test
+        run: |
+          set -e
+          tar -xzf ubuntu-2004-build/build.tar.gz
+          export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
+          docker pull ${UBUNTU_2004_IMAGE}
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -R nodeos_retry_transaction_lr_test'

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2486,7 +2486,7 @@ void read_write::send_transaction2(const read_write::send_transaction2_params& p
       std::optional<uint16_t> retry_num_blocks = params.retry_trx_num_blocks;
 
       EOS_ASSERT( !retry || trx_retry.has_value(), unsupported_feature, "Transaction retry not enabled on node" );
-      EOS_ASSERT( !retry || (ptrx->expiration() < trx_retry->get_max_expiration_time()), tx_exp_too_far_exception,
+      EOS_ASSERT( !retry || (ptrx->expiration() <= trx_retry->get_max_expiration_time()), tx_exp_too_far_exception,
                   "retry transaction expiration ${e} larger than allowed ${m}",
                   ("e", ptrx->expiration())("m", trx_retry->get_max_expiration_time()) );
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/large-lib-test.py ${CMAKE_CURRENT_BIN
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/http_plugin_test.py ${CMAKE_CURRENT_BINARY_DIR}/http_plugin_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/p2p_high_latency_test.py ${CMAKE_CURRENT_BINARY_DIR}/p2p_high_latency_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_high_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_high_transaction_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_retry_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_retry_transaction_test.py COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -161,6 +162,9 @@ set_property(TEST nodeos_producer_watermark_lr_test PROPERTY LABELS long_running
 
 add_test(NAME nodeos_high_transaction_lr_test COMMAND tests/nodeos_high_transaction_test.py -v --clean-run --dump-error-detail -p 4 -n 8 --num-transactions 10000 --max-transactions-per-second 500 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_high_transaction_lr_test PROPERTY LABELS long_running_tests)
+
+add_test(NAME nodeos_retry_transaction_lr_test COMMAND tests/nodeos_retry_transaction_test.py -v --clean-run --dump-error-detail --num-transactions 10000 --max-transactions-per-second 500 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_retry_transaction_lr_test PROPERTY LABELS long_running_tests)
 
 
 add_test(NAME cli_test COMMAND tests/cli_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,7 +163,7 @@ set_property(TEST nodeos_producer_watermark_lr_test PROPERTY LABELS long_running
 add_test(NAME nodeos_high_transaction_lr_test COMMAND tests/nodeos_high_transaction_test.py -v --clean-run --dump-error-detail -p 4 -n 8 --num-transactions 10000 --max-transactions-per-second 500 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_high_transaction_lr_test PROPERTY LABELS long_running_tests)
 
-add_test(NAME nodeos_retry_transaction_lr_test COMMAND tests/nodeos_retry_transaction_test.py -v --clean-run --dump-error-detail --num-transactions 10000 --max-transactions-per-second 500 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME nodeos_retry_transaction_lr_test COMMAND tests/nodeos_retry_transaction_test.py -v --clean-run --dump-error-detail --num-transactions 100 --max-transactions-per-second 10 --total-accounts 5 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_retry_transaction_lr_test PROPERTY LABELS long_running_tests)
 
 

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -776,7 +776,7 @@ class Node(object):
             else:
                 cmdRetry = "--retry-num-blocks %s" % retry
 
-        cmd="%s %s -v transfer %s -j %s %s" % (
+        cmd="%s %s -v transfer --expiration 90 %s -j %s %s" % (
             Utils.EosClientPath, self.eosClientArgs(), cmdRetry, source.name, destination.name)
         cmdArr=cmd.split()
         cmdArr.append(amountStr)

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -712,24 +712,15 @@ class Node(object):
     def waitForIrreversibleBlock(self, blockNum, timeout=None, blockType=BlockType.head):
         return self.waitForBlock(blockNum, timeout=timeout, blockType=blockType)
 
-    # Trasfer funds. Returns "transfer" json return object
-    def transferFunds(self, source, destination, amountStr, memo="memo", force=False, waitForTransBlock=False, exitOnError=True, reportStatus=True, retry=None):
+    def __transferFundsCmdArr(self, source, destination, amountStr, memo, force, retry):
         assert isinstance(amountStr, str)
         assert(source)
         assert(isinstance(source, Account))
         assert(destination)
         assert(isinstance(destination, Account))
-        assert retry is None or isinstance(retry, int) or (isinstance(retry, str) and retry == "lib"), "Invalid retry passed"
 
-        cmdRetry = ""
-        if retry is not None:
-            if retry == "lib":
-                cmdRetry = "--retry-irreversible"
-            else:
-                cmdRetry = "--retry-num-blocks %s" % retry
-
-        cmd="%s %s -v transfer %s -j %s %s" % (
-            Utils.EosClientPath, self.eosClientArgs(), cmdRetry, source.name, destination.name)
+        cmd="%s %s -v transfer --expiration 90 %s -j %s %s" % (
+            Utils.EosClientPath, self.eosClientArgs(), self.getRetryCmdArg(retry), source.name, destination.name)
         cmdArr=cmd.split()
         cmdArr.append(amountStr)
         cmdArr.append(memo)
@@ -737,6 +728,11 @@ class Node(object):
             cmdArr.append("-f")
         s=" ".join(cmdArr)
         if Utils.Debug: Utils.Print("cmd: %s" % (s))
+        return cmdArr
+
+    # Trasfer funds. Returns "transfer" json return object
+    def transferFunds(self, source, destination, amountStr, memo="memo", force=False, waitForTransBlock=False, exitOnError=True, reportStatus=True, retry=None):
+        cmdArr = self.__transferFundsCmdArr(source, destination, amountStr, memo, force, retry)
         trans=None
         start=time.perf_counter()
         try:
@@ -762,29 +758,7 @@ class Node(object):
 
     # Trasfer funds. Returns (popen, cmdArr) for checkDelayedOutput
     def transferFundsAsync(self, source, destination, amountStr, memo="memo", force=False, exitOnError=True, retry=None):
-        assert isinstance(amountStr, str)
-        assert(source)
-        assert(isinstance(source, Account))
-        assert(destination)
-        assert(isinstance(destination, Account))
-        assert retry is None or isinstance(retry, int) or (isinstance(retry, str) and retry == "lib"), "Invalid retry passed"
-
-        cmdRetry = ""
-        if retry is not None:
-            if retry == "lib":
-                cmdRetry = "--retry-irreversible"
-            else:
-                cmdRetry = "--retry-num-blocks %s" % retry
-
-        cmd="%s %s -v transfer --expiration 90 %s -j %s %s" % (
-            Utils.EosClientPath, self.eosClientArgs(), cmdRetry, source.name, destination.name)
-        cmdArr=cmd.split()
-        cmdArr.append(amountStr)
-        cmdArr.append(memo)
-        if force:
-            cmdArr.append("-f")
-        s=" ".join(cmdArr)
-        if Utils.Debug: Utils.Print("cmd: %s" % (s))
+        cmdArr = self.__transferFundsCmdArr(source, destination, amountStr, memo, force, retry)
         start=time.perf_counter()
         try:
             popen=Utils.delayedCheckOutput(cmdArr)
@@ -794,13 +768,25 @@ class Node(object):
         except subprocess.CalledProcessError as ex:
             end=time.perf_counter()
             msg=ex.output.decode("utf-8")
-            Utils.Print("ERROR: Exception during funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
+            Utils.Print("ERROR: Exception during spawn of funds transfer.  cmd Duration: %.3f sec.  %s" % (end-start, msg))
             if exitOnError:
                 Utils.cmdError("could not transfer \"%s\" from %s to %s" % (amountStr, source, destination))
                 Utils.errorExit("Failed to transfer \"%s\" from %s to %s" % (amountStr, source, destination))
-            return None
+            return None, None
 
         return popen, cmdArr
+
+    @staticmethod
+    def getRetryCmdArg(retry):
+        """Returns the cleos cmd arg for retry"""
+        assert retry is None or isinstance(retry, int) or (isinstance(retry, str) and retry == "lib"), "Invalid retry passed"
+        cmdRetry = ""
+        if retry is not None:
+            if retry == "lib":
+                cmdRetry = "--retry-irreversible"
+            else:
+                cmdRetry = "--retry-num-blocks %s" % retry
+        return cmdRetry
 
     @staticmethod
     def currencyStrToInt(balanceStr):

--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+
+from testUtils import Utils
+import time
+import signal
+from Cluster import Cluster
+from Cluster import NamedAccounts
+from core_symbol import CORE_SYMBOL
+from WalletMgr import WalletMgr
+from Node import Node
+from TestHelper import TestHelper
+from TestHelper import AppArgs
+
+import json
+
+###############################################################
+# nodeos_retry_transaction_test
+# 
+# This test sets up 3 producing nodes and 4
+#   non-producing node(s). The non-producing node will be sent
+#   many transfers.  When it is complete it verifies that all
+#   of the transactions made it into blocks.
+#
+# During processing two of the relay nodes are killed so that
+# one of the api nodes is isolated and its transactions will
+# be lost. The api node retry logic should allow it to resend
+# those transactions once connectivity is restored.
+#
+###############################################################
+
+Print=Utils.Print
+
+appArgs = AppArgs()
+minTotalAccounts = 10
+extraArgs = appArgs.add(flag="--transaction-time-delta", type=int, help="How many seconds seconds behind an earlier sent transaction should be received after a later one", default=5)
+extraArgs = appArgs.add(flag="--num-transactions", type=int, help="How many total transactions should be sent", default=10000)
+extraArgs = appArgs.add(flag="--max-transactions-per-second", type=int, help="How many transactions per second should be sent", default=500)
+extraArgs = appArgs.add(flag="--total-accounts", type=int, help="How many accounts should be involved in sending transfers.  Must be greater than %d" % (minTotalAccounts), default=100)
+args = TestHelper.parse_args({"--dump-error-details","--keep-logs","-v","--leave-running","--clean-run"}, applicationSpecificArgs=appArgs)
+
+Utils.Debug=args.v
+totalProducerNodes=3
+totalNodes=7
+totalNonProducerNodes=totalNodes-totalProducerNodes
+maxActiveProducers=totalProducerNodes
+totalProducers=totalProducerNodes
+cluster=Cluster(walletd=True)
+dumpErrorDetails=args.dump_error_details
+keepLogs=args.keep_logs
+dontKill=args.leave_running
+killAll=args.clean_run
+walletPort=TestHelper.DEFAULT_WALLET_PORT
+blocksPerSec=2
+transBlocksBehind=args.transaction_time_delta * blocksPerSec
+numTransactions = args.num_transactions
+maxTransactionsPerSecond = args.max_transactions_per_second
+assert args.total_accounts >= minTotalAccounts, Print("ERROR: Only %d was selected for --total-accounts, must have at least %d" % (args.total_accounts, minTotalAccounts))
+if numTransactions % args.total_accounts > 0:
+    oldNumTransactions = numTransactions
+    numTransactions = int((oldNumTransactions + args.total_accounts - 1)/args.total_accounts) * args.total_accounts
+    Print("NOTE: --num-transactions passed as %d, but rounding to %d so each of the %d accounts gets the same number of transactions" %
+          (oldNumTransactions, numTransactions, args.total_accounts))
+numRounds = int(numTransactions / args.total_accounts)
+
+
+walletMgr=WalletMgr(True, port=walletPort)
+testSuccessful=False
+killEosInstances=not dontKill
+killWallet=not dontKill
+
+WalletdName=Utils.EosWalletName
+ClientName="cleos"
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setWalletMgr(walletMgr)
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+    Print("Stand up cluster")
+
+    specificExtraNodeosArgs={
+        3:"--transaction-retry-max-storage-size-gb 5 --disable-api-persisted-trx", # api node
+        4:"--disable-api-persisted-trx",                                           # relay only, will be killed
+        5:"--transaction-retry-max-storage-size-gb 5 --disable-api-persisted-trx", # api node, will be isolated
+        6:"--disable-api-persisted-trx"                                            # relay only, will be killed
+    }
+
+    # topo=ring all nodes are connected in a ring but also to the bios node
+    if cluster.launch(pnodes=totalProducerNodes, totalNodes=totalNodes, totalProducers=totalProducers,
+                      topo="ring",
+                      specificExtraNodeosArgs=specificExtraNodeosArgs,
+                      useBiosBootFile=False) is False:
+        Utils.cmdError("launcher")
+        Utils.errorExit("Failed to stand up eos cluster.")
+
+    cluster.waitOnClusterSync(blockAdvancing=5)
+    Utils.Print("Cluster in Sync")
+    cluster.biosNode.kill(signal.SIGTERM)
+    Utils.Print("Bios node killed")
+    # need bios to pass along blocks so api node can continue without its other peer, but drop trx which is the point of this test
+    Utils.Print("Restart bios in drop transactions mode")
+    cluster.biosNode.relaunch("bios", cachePopen=True, addSwapFlags={"--p2p-accept-transactions": "false"})
+
+# ***   create accounts to vote in desired producers   ***
+
+    Print("creating %d accounts" % (args.total_accounts))
+    namedAccounts=NamedAccounts(cluster,args.total_accounts)
+    accounts=namedAccounts.accounts
+
+    accountsToCreate = [cluster.eosioAccount]
+    for account in accounts:
+        accountsToCreate.append(account)
+
+    testWalletName="test"
+
+    Print("Creating wallet \"%s\"." % (testWalletName))
+    testWallet=walletMgr.create(testWalletName, accountsToCreate)
+
+    for _, account in cluster.defProducerAccounts.items():
+        walletMgr.importKey(account, testWallet, ignoreDupKeyWarning=True)
+
+    Print("Wallet \"%s\" password=%s." % (testWalletName, testWallet.password.encode("utf-8")))
+
+    for account in accounts:
+        walletMgr.importKey(account, testWallet)
+
+    # ***   identify each node (producers and non-producing nodes)   ***
+
+    prodNodes=[]
+    prodNodes.append( cluster.getNode(0) )
+    prodNodes.append( cluster.getNode(1) )
+    prodNodes.append( cluster.getNode(2) )
+    apiNodes=[]
+    apiNodes.append( cluster.getNode(3) )
+    apiNodes.append( cluster.getNode(5) )
+    relayNodes=[]
+    relayNodes.append( cluster.getNode(4) )
+    relayNodes.append( cluster.getNode(6) )
+
+    apiNodeCount = len(apiNodes)
+
+    # ***   delegate bandwidth to accounts   ***
+
+    node=apiNodes[0]
+    checkTransIds = []
+    startTime = time.perf_counter()
+    Print("Create new accounts via %s" % (cluster.eosioAccount.name))
+    # create accounts via eosio as otherwise a bid is needed
+    for account in accounts:
+        trans = node.createInitializeAccount(account, cluster.eosioAccount, stakedDeposit=0, waitForTransBlock=False, stakeNet=1000, stakeCPU=1000, buyRAM=1000, exitOnError=True)
+        checkTransIds.append(Node.getTransId(trans))
+
+    nextTime = time.perf_counter()
+    Print("Create new accounts took %s sec" % (nextTime - startTime))
+    startTime = nextTime
+
+    Print("Transfer funds to new accounts via %s" % (cluster.eosioAccount.name))
+    for account in accounts:
+        transferAmount="1000.0000 {0}".format(CORE_SYMBOL)
+        Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
+        trans = node.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer", waitForTransBlock=False, reportStatus=False)
+        checkTransIds.append(Node.getTransId(trans))
+
+    nextTime = time.perf_counter()
+    Print("Transfer funds took %s sec" % (nextTime - startTime))
+    startTime = nextTime
+
+    Print("Delegate Bandwidth to new accounts")
+    for account in accounts:
+        trans=node.delegatebw(account, 200.0000, 200.0000, waitForTransBlock=False, exitOnError=True, reportStatus=False)
+        checkTransIds.append(Node.getTransId(trans))
+
+    nextTime = time.perf_counter()
+    Print("Delegate Bandwidth took %s sec" % (nextTime - startTime))
+    startTime = nextTime
+    lastIrreversibleBlockNum = None
+
+    def cacheTransIdInBlock(transId, transToBlock, node):
+        global lastIrreversibleBlockNum
+        lastPassLIB = None
+        blockWaitTimeout = 60
+        transTimeDelayed = False
+        while True:
+            trans = node.getTransaction(transId, delayedRetry=False)
+            if trans is None:
+                if transTimeDelayed:
+                    return (None, None)
+                else:
+                    if Utils.Debug:
+                        Print("Transaction not found for trans id: %s. Will wait %d seconds to see if it arrives in a block." %
+                              (transId, args.transaction_time_delta))
+                    transTimeDelayed = True
+                    node.waitForTransInBlock(transId, timeout = args.transaction_time_delta)
+                    continue
+
+            lastIrreversibleBlockNum = trans["last_irreversible_block"]
+            blockNum = Node.getTransBlockNum(trans)
+            assert blockNum is not None, Print("ERROR: could not retrieve block num from transId: %s, trans: %s" % (transId, json.dumps(trans, indent=2)))
+            block = node.getBlock(blockNum)
+            if block is not None:
+                transactions = block["transactions"]
+                for trans_receipt in transactions:
+                    btrans = trans_receipt["trx"]
+                    assert btrans is not None, Print("ERROR: could not retrieve \"trx\" from transaction_receipt: %s, from transId: %s that led to block: %s" % (json.dumps(trans_receipt, indent=2), transId, json.dumps(block, indent=2)))
+                    btransId = btrans["id"]
+                    assert btransId is not None, Print("ERROR: could not retrieve \"id\" from \"trx\": %s, from transId: %s that led to block: %s" % (json.dumps(btrans, indent=2), transId, json.dumps(block, indent=2)))
+                    transToBlock[btransId] = block
+
+                break
+
+            if lastPassLIB is not None and lastPassLIB >= lastIrreversibleBlockNum:
+                Print("ERROR: could not find block number: %d from transId: %s, waited %d seconds for LIB to advance but it did not. trans: %s" % (blockNum, transId, blockWaitTimeout, json.dumps(trans, indent=2)))
+                return (trans, None)
+            if Utils.Debug:
+                extra = "" if lastPassLIB is None else " and since it progressed from %d in our last pass" % (lastPassLIB)
+                Print("Transaction returned for trans id: %s indicated it was in block num: %d, but that block could not be found.  LIB is %d%s, we will wait to see if the block arrives." %
+                      (transId, blockNum, lastIrreversibleBlockNum, extra))
+            lastPassLIB = lastIrreversibleBlockNum
+            node.waitForBlock(blockNum, timeout = blockWaitTimeout)
+
+        return (block, trans)
+
+    def findTransInBlock(transId, transToBlock, node):
+        if transId in transToBlock:
+            return
+        (block, trans) = cacheTransIdInBlock(transId, transToBlock, node)
+        assert trans is not None, Print("ERROR: could not find transaction for transId: %s" % (transId))
+        assert block is not None, Print("ERROR: could not retrieve block with block num: %d, from transId: %s, trans: %s" % (blockNum, transId, json.dumps(trans, indent=2)))
+
+    transToBlock = {}
+    for transId in checkTransIds:
+        findTransInBlock(transId, transToBlock, node)
+
+    nextTime = time.perf_counter()
+    Print("Verifying transactions took %s sec" % (nextTime - startTime))
+    startTransferTime = nextTime
+
+    #verify nodes are in sync and advancing
+    cluster.waitOnClusterSync(blockAdvancing=5)
+
+    Print("Sending %d transfers" % (numTransactions))
+    delayAfterRounds = int(maxTransactionsPerSecond / args.total_accounts)
+    history = []
+    startTime = time.perf_counter()
+    startRound = time.perf_counter()
+    for round in range(0, numRounds):
+        # ensure we are not sending too fast
+        startRound = time.perf_counter()
+        timeDiff = startRound - startTime
+        expectedTransactions = maxTransactionsPerSecond * timeDiff
+        sentTransactions = round * args.total_accounts
+        if sentTransactions > expectedTransactions:
+            excess = sentTransactions - expectedTransactions
+            # round up to a second
+            delayTime = int((excess + maxTransactionsPerSecond - 1) / maxTransactionsPerSecond)
+            Utils.Print("Delay %d seconds to keep max transactions under %d per second" % (delayTime, maxTransactionsPerSecond))
+            time.sleep(delayTime)
+
+        if round % 5 == 0:
+            killTime = time.perf_counter()
+            cluster.getNode(4).kill(signal.SIGTERM)
+            cluster.getNode(6).kill(signal.SIGTERM)
+            startRound = startRound - ( time.perf_counter() - killTime )
+            startTime = startTime - ( time.perf_counter() - killTime )
+
+        trackedTransPopens = []
+
+        transferAmount = Node.currencyIntToStr(round + 1, CORE_SYMBOL)
+        Print("Sending round %d, transfer: %s" % (round, transferAmount))
+        for accountIndex in range(0, args.total_accounts):
+            fromAccount = accounts[accountIndex]
+            toAccountIndex = accountIndex + 1 if accountIndex + 1 < args.total_accounts else 0
+            toAccount = accounts[toAccountIndex]
+            node = apiNodes[accountIndex % apiNodeCount]
+            popen, cmd = node.transferFundsAsync(fromAccount, toAccount, transferAmount, "transfer round %d" % (round), exitOnError=False, retry=2)
+            trackedTransPopens.append((popen, cmd))
+
+        if round % 5 == 0:
+            relaunchTime = time.perf_counter()
+            cluster.getNode(4).relaunch(4, cachePopen=True)
+            cluster.getNode(6).relaunch(6, cachePopen=True)
+            startRound = startRound - ( time.perf_counter() - relaunchTime )
+            startTime = startTime - ( time.perf_counter() - relaunchTime )
+
+        # store off the transaction id, which we can use with the node.transCache
+        for i in range(0, len(trackedTransPopens)):
+            Utils.Print("checking output ", i, " ", trackedTransPopens[i][0], " ", trackedTransPopens[i][1])
+            history.append( Utils.toJson( Utils.checkDelayedOutput(trackedTransPopens[i][0], trackedTransPopens[i][1]) ) )
+
+
+    nextTime = time.perf_counter()
+    Print("Sending transfers took %s sec" % (nextTime - startTransferTime))
+    startTranferValidationTime = nextTime
+
+    blocks = {}
+    transToBlock = {}
+    missingTransactions = []
+    transBlockOrderWeird = []
+    newestBlockNum = None
+    newestBlockNumTransId = None
+    newestBlockNumTransOrder = None
+    lastBlockNum = None
+    lastTransId = None
+    transOrder = 0
+    lastPassLIB = None
+    for transId in history:
+        blockNum = None
+        block = None
+        transDesc = None
+        if transId not in transToBlock:
+            (block, trans) = cacheTransIdInBlock(transId, transToBlock, node)
+            if trans is None or block is None:
+                missingTransactions.append({
+                    "newer_trans_id" : transId,
+                    "newer_trans_index" : transOrder,
+                    "newer_bnum" : None,
+                    "last_trans_id" : lastTransId,
+                    "last_trans_index" : transOrder - 1,
+                    "last_bnum" : lastBlockNum,
+                })
+                if newestBlockNum > lastBlockNum:
+                    missingTransactions[-1]["highest_block_seen"] = newestBlockNum
+            blockNum = Node.getTransBlockNum(trans)
+            assert blockNum is not None, Print("ERROR: could not retrieve block num from transId: %s, trans: %s" % (transId, json.dumps(trans, indent=2)))
+        else:
+            block = transToBlock[transId]
+            blockNum = block["block_num"]
+            assert blockNum is not None, Print("ERROR: could not retrieve block num for block retrieved for transId: %s, block: %s" % (transId, json.dumps(block, indent=2)))
+
+        if lastBlockNum is not None:
+            if blockNum > lastBlockNum + transBlocksBehind or blockNum + transBlocksBehind < lastBlockNum:
+                transBlockOrderWeird.append({
+                    "newer_trans_id" : transId,
+                    "newer_trans_index" : transOrder,
+                    "newer_bnum" : blockNum,
+                    "last_trans_id" : lastTransId,
+                    "last_trans_index" : transOrder - 1,
+                    "last_bnum" : lastBlockNum
+                })
+                if newestBlockNum > lastBlockNum:
+                    last = transBlockOrderWeird[-1]
+                    last["older_trans_id"] = newestBlockNumTransId
+                    last["older_trans_index"] = newestBlockNumTransOrder
+                    last["older_bnum"] = newestBlockNum
+
+        if newestBlockNum is None:
+            newestBlockNum = blockNum
+            newestBlockNumTransId = transId
+            newestBlockNumTransOrder = transOrder
+        elif blockNum > newestBlockNum:
+            newestBlockNum = blockNum
+            newestBlockNumTransId = transId
+            newestBlockNumTransOrder = transOrder
+
+        lastTransId = transId
+        transOrder += 1
+        lastBlockNum = blockNum
+
+    nextTime = time.perf_counter()
+    Print("Validating transfers took %s sec" % (nextTime - startTranferValidationTime))
+
+    delayedReportError = False
+    if len(missingTransactions) > 0:
+        verboseOutput = "Missing transaction information: [" if Utils.Debug else "Missing transaction ids: ["
+        verboseOutput = ", ".join([missingTrans if Utils.Debug else missingTrans["newer_trans_id"] for missingTrans in missingTransactions])
+        verboseOutput += "]"
+        Utils.Print("ERROR: There are %d missing transactions.  %s" % (len(missingTransactions), verboseOutput))
+        delayedReportError = True
+
+    if len(transBlockOrderWeird) > 0:
+        verboseOutput = "Delayed transaction information: [" if Utils.Debug else "Delayed transaction ids: ["
+        verboseOutput = ", ".join([json.dumps(trans, indent=2) if Utils.Debug else trans["newer_trans_id"] for trans in transBlockOrderWeird])
+        verboseOutput += "]"
+        Utils.Print("ERROR: There are %d transactions delayed more than %d seconds.  %s" % (len(transBlockOrderWeird), args.transaction_time_delta, verboseOutput))
+        delayedReportError = True
+
+    testSuccessful = not delayedReportError
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
+    if not testSuccessful:
+        Print(Utils.FileDivider)
+        #Print("Compare Blocklog")
+        #cluster.compareBlockLogs()
+        Print(Utils.FileDivider)
+        #Print("Print Blocklog")
+        #cluster.printBlockLog()
+        Print(Utils.FileDivider)
+
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -182,6 +182,7 @@ class Utils:
         (output,error)=popen.communicate()
         Utils.CheckOutputDeque.append((output,error,cmd))
         if popen.returncode != 0 and not ignoreError:
+            Utils.Print("ERROR: %s" % error)
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error)
         return output.decode("utf-8")
 

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -256,8 +256,7 @@ class Utils:
         return retStr
 
     @staticmethod
-    def runCmdArrReturnJson(cmdArr, trace=False, silentErrors=True):
-        retStr=Utils.checkOutput(cmdArr)
+    def toJson(retStr, trace=False, silentErrors=True):
         jStr=Utils.filterJsonObjectOrArray(retStr)
         if trace: Utils.Print ("RAW > %s" % (retStr))
         if trace: Utils.Print ("JSON> %s" % (jStr))
@@ -276,6 +275,11 @@ class Utils:
             Utils.Print ("RAW > %s" % retStr)
             Utils.Print ("JSON> %s" % jStr)
             raise
+
+    @staticmethod
+    def runCmdArrReturnJson(cmdArr, trace=False, silentErrors=True):
+        retStr=Utils.checkOutput(cmdArr)
+        return Utils.toJson(retStr)
 
     @staticmethod
     def runCmdReturnStr(cmd, trace=False):


### PR DESCRIPTION
- Includes a fix for transaction retry expiration comparison.
- New integration test for transaction retry feature

```
# This test sets up 3 producing nodes and 4 non-producing
#   nodes; 2 API nodes and 2 relay nodes. The API nodes will be
#   sent many transfers.  When it is complete it verifies that
#   all of the transactions made it into blocks.
#
# During processing the two relay nodes are killed so that
# one of the api nodes is isolated and its transactions will
# be lost. The api node retry logic should allow it to resend
# those transactions once connectivity is restored.
```
