### PR TITLE
remove gettext/libintl dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,6 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
-if (UNIX AND APPLE)
-   list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/gettext")
-endif()
-
 include( GNUInstallDirs )
 include( InstallDirectoryPermissions )
 include( MASSigning )

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -10,8 +10,6 @@ if( GPERFTOOLS_FOUND )
     list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
-find_package(Intl REQUIRED)
-
 set(LOCALEDIR ${CMAKE_INSTALL_PREFIX}/share/locale)
 set(LOCALEDOMAIN ${CLI_CLIENT_EXECUTABLE_NAME})
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -14,10 +14,10 @@ set(LOCALEDIR ${CMAKE_INSTALL_PREFIX}/share/locale)
 set(LOCALEDOMAIN ${CLI_CLIENT_EXECUTABLE_NAME})
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 
-target_include_directories(${CLI_CLIENT_EXECUTABLE_NAME} PUBLIC ${Intl_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(${CLI_CLIENT_EXECUTABLE_NAME} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_link_libraries( ${CLI_CLIENT_EXECUTABLE_NAME}
-                       PRIVATE appbase version chain_api_plugin producer_plugin chain_plugin http_plugin eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} ${Intl_LIBRARIES} )
+                       PRIVATE appbase version chain_api_plugin producer_plugin chain_plugin http_plugin eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 
 copy_bin( ${CLI_CLIENT_EXECUTABLE_NAME} )

--- a/programs/cleos/localize.hpp
+++ b/programs/cleos/localize.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <libintl.h>
 #include <fc/variant.hpp>
 
 namespace eosio { namespace client { namespace localize {
@@ -13,7 +12,7 @@ namespace eosio { namespace client { namespace localize {
    inline auto localized_with_variant( const char* raw_fmt, const fc::variant_object& args) {
       if (raw_fmt != nullptr) {
          try {
-            return fc::format_string(::gettext(raw_fmt), args);
+            return fc::format_string(raw_fmt, args);
          } catch (...) {
          }
          return std::string(raw_fmt);

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2423,9 +2423,6 @@ CLI::callback_t header_opt_callback = [](CLI::results_t res) {
 };
 
 int main( int argc, char** argv ) {
-   setlocale(LC_ALL, "");
-   bindtextdomain(locale_domain, locale_path);
-   textdomain(locale_domain);
    fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
    context = eosio::client::http::create_http_context();
    wallet_url = default_wallet_url;

--- a/scripts/eosio_build.sh
+++ b/scripts/eosio_build.sh
@@ -180,9 +180,7 @@ if [[ $ARCH == "Linux" ]]; then
 fi
 
 if [ "$ARCH" == "Darwin" ]; then
-   # opt/gettext: cleos requires Intl, which requires gettext; it's keg only though and we don't want to force linking: https://github.com/EOSIO/eos/issues/2240#issuecomment-396309884
    # EOSIO_INSTALL_DIR/lib/cmake: mongo_db_plugin.cpp:25:10: fatal error: 'bsoncxx/builder/basic/kvp.hpp' file not found
-   CMAKE_PREFIX_PATHS="/usr/local/opt/gettext;${EOSIO_INSTALL_DIR}"
    FILE="${SCRIPT_DIR}/eosio_build_darwin.sh"
    export CMAKE=${CMAKE}
 fi

--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -45,7 +45,6 @@ echo "class Eosio < Formula
    option :universal
 
    depends_on \"gmp\"
-   depends_on \"gettext\"
    depends_on \"openssl@1.1\"
    depends_on \"libusb\"
    depends_on macos: :mojave


### PR DESCRIPTION
gettext is only used for cleos localization support. But, cleos has not had any effort to translate it thus far. Remove this unused dependency for now as it's an LGPL dep and may cause some grief depending on future platform support. When we get back around to localizing cleos we can reevaluate this need; it's possible something like boost::locale would be a better fit.

Port of EOSIO/eos#8118 & EOSIO/eos#10326