### PR TITLE
remove BOOST_ASIO_HAS_LOCAL_SOCKETS ifdefs

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -1,7 +1,5 @@
 #include <eosio/http_plugin/http_plugin.hpp>
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
 #include <eosio/http_plugin/local_endpoint.hpp>
-#endif
 #include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/thread_utils.hpp>
 
@@ -94,7 +92,6 @@ namespace eosio {
           static const long timeout_open_handshake = 0;
       };
 
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
       struct asio_local_with_stub_log : public websocketpp::config::asio {
           typedef asio_local_with_stub_log type;
           typedef asio base;
@@ -126,7 +123,7 @@ namespace eosio {
 
           static const long timeout_open_handshake = 0;
       };
-#endif
+
       /**
        * virtualized wrapper for the various underlying connection functions needed in req/resp processng
        */
@@ -172,9 +169,7 @@ namespace eosio {
    }
 
    using websocket_server_type = websocketpp::server<detail::asio_with_stub_log<websocketpp::transport::asio::basic_socket::endpoint>>;
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
    using websocket_local_server_type = websocketpp::server<detail::asio_local_with_stub_log>;
-#endif
    using websocket_server_tls_type =  websocketpp::server<detail::asio_with_stub_log<websocketpp::transport::asio::tls_socket::endpoint>>;
    using ssl_context_ptr =  websocketpp::lib::shared_ptr<websocketpp::lib::asio::ssl::context>;
    using http_plugin_impl_ptr = std::shared_ptr<class http_plugin_impl>;
@@ -215,10 +210,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
 
          websocket_server_tls_type https_server;
 
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
          std::optional<asio::local::stream_protocol::endpoint> unix_endpoint;
          websocket_local_server_type unix_server;
-#endif
 
          bool                     validate_host = true;
          set<string>              valid_hosts;
@@ -631,12 +624,10 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          }
    };
 
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
    template<>
    bool http_plugin_impl::allow_host<detail::asio_local_with_stub_log>(const detail::asio_local_with_stub_log::request_type& req, websocketpp::server<detail::asio_local_with_stub_log>::connection_ptr con) {
       return true;
    }
-#endif
 
    http_plugin::http_plugin():my(new http_plugin_impl()){
       app().register_config_type<https_ecdh_curve_t>();
@@ -644,7 +635,6 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
    http_plugin::~http_plugin(){}
 
    void http_plugin::set_program_options(options_description&, options_description& cfg) {
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
       if(current_http_plugin_defaults.default_unix_socket_path.length())
          cfg.add_options()
             ("unix-socket-path", bpo::value<string>()->default_value(current_http_plugin_defaults.default_unix_socket_path),
@@ -653,7 +643,6 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          cfg.add_options()
             ("unix-socket-path", bpo::value<string>(),
              "The filename (relative to data-dir) to create a unix socket for HTTP RPC; set blank to disable.");
-#endif
 
       if(current_http_plugin_defaults.default_http_port)
          cfg.add_options()
@@ -761,14 +750,12 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
             }
          }
 
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
          if( options.count( "unix-socket-path" ) && !options.at( "unix-socket-path" ).as<string>().empty()) {
             boost::filesystem::path sock_path = options.at("unix-socket-path").as<string>();
             if (sock_path.is_relative())
                sock_path = app().data_dir() / sock_path;
             my->unix_endpoint = asio::local::stream_protocol::endpoint(sock_path.string());
          }
-#endif
 
          if( options.count( "https-server-address" ) && options.at( "https-server-address" ).as<string>().length()) {
             if( !options.count( "https-certificate-chain-file" ) ||
@@ -833,7 +820,6 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
                }
             }
 
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
             if(my->unix_endpoint) {
                try {
                   my->unix_server.clear_access_channels(websocketpp::log::alevel::all);
@@ -856,7 +842,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
                   throw;
                }
             }
-#endif
+
             if(my->https_listen_endpoint) {
                try {
                   my->create_server_for_endpoint(*my->https_listen_endpoint, my->https_server);
@@ -907,10 +893,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          my->server.stop_listening();
       if(my->https_server.is_listening())
          my->https_server.stop_listening();
-#ifdef BOOST_ASIO_HAS_LOCAL_SOCKETS
       if(my->unix_server.is_listening())
          my->unix_server.stop_listening();
-#endif
 
       if( my->thread_pool ) {
          my->thread_pool->stop();


### PR DESCRIPTION
BOOST_ASIO_HAS_LOCAL_SOCKETS was sprinkled about to ensure future compatibility with Windows. But, Windows 10 supports unix sockets natively (i.e. outside of WSL). Boost 1.75 adds support for those. If we ever support native Win32 builds it seems reasonable to simply require Win10 & boost 1.75+. So, remove this ifdef spam.

Needs changes in a submodule: eosnetworkfoundation/mandel-fc#14

Ports EOSIO/eos#10040