### PR TITLE
eliminate prolific gperftools copy paste

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,17 @@ endif()
 
 message( STATUS "Using '${EOSIO_ROOT_KEY}' as public key for 'eosio' account" )
 
+find_package( Gperftools QUIET )
+if( GPERFTOOLS_FOUND )
+    message( STATUS "Found gperftools; compiling EOSIO with TCMalloc")
+    #if doing this by the book, simply link_libraries( ${GPERFTOOLS_TCMALLOC} ) here. That will
+    #give the performance benefits of tcmalloc but since it won't be linked last
+    #the heap profiler & checker may not be accurate. This here is rather undocumented behavior
+    #to stuff a library toward the end of the link list
+    set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} ${GPERFTOOLS_TCMALLOC}")
+    set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} ${GPERFTOOLS_TCMALLOC}")
+endif()
+
 add_subdirectory( libraries )
 add_subdirectory( plugins )
 add_subdirectory( programs )

--- a/programs/cleos/CMakeLists.txt
+++ b/programs/cleos/CMakeLists.txt
@@ -5,14 +5,6 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
-find_package(Intl REQUIRED)
-
 set(LOCALEDIR ${CMAKE_INSTALL_PREFIX}/share/locale)
 set(LOCALEDOMAIN ${CLI_CLIENT_EXECUTABLE_NAME})
 

--- a/programs/eosio-blocklog/CMakeLists.txt
+++ b/programs/eosio-blocklog/CMakeLists.txt
@@ -4,12 +4,6 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling eosio-blocklog with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 target_include_directories(eosio-blocklog PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries( eosio-blocklog

--- a/programs/eosio-launcher/CMakeLists.txt
+++ b/programs/eosio-launcher/CMakeLists.txt
@@ -3,12 +3,6 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
   find_package(Git)
   if(GIT_FOUND)

--- a/programs/keosd/CMakeLists.txt
+++ b/programs/keosd/CMakeLists.txt
@@ -3,12 +3,6 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling ${KEY_STORE_EXECUTABLE_NAME} with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
 
 target_link_libraries( ${KEY_STORE_EXECUTABLE_NAME}

--- a/programs/nodeos/CMakeLists.txt
+++ b/programs/nodeos/CMakeLists.txt
@@ -4,12 +4,6 @@ if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling ${NODE_EXECUTABLE_NAME} with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../../.git)
   find_package(Git)
   if(GIT_FOUND)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,5 @@
 find_program( NODE_FOUND node )
 
-find_package( Gperftools QUIET )
-if( GPERFTOOLS_FOUND )
-    message( STATUS "Found gperftools; compiling tests with TCMalloc")
-    list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
-endif()
-
 include_directories( "${CMAKE_SOURCE_DIR}/plugins/wallet_plugin/include" )
 
 file(GLOB UNIT_TESTS "*.cpp")

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_package( Gperftools QUIET )
-
 ### Build contracts with cdt if available ###
 include(ExternalProject)
 
@@ -22,11 +20,6 @@ if( EOSIO_COMPILE_TEST_CONTRACTS )
 else()
   message( STATUS "Not building contracts in directory `eos/unittests/test-contracts/`" )
   add_subdirectory(test-contracts)
-endif()
-
-if( GPERFTOOLS_FOUND )
-   message( STATUS "Found gperftools; compiling tests with TCMalloc" )
-   list( APPEND PLATFORM_SPECIFIC_LIBS tcmalloc )
 endif()
 
 add_subdirectory(contracts)


### PR DESCRIPTION
Eliminate the massive amount of gperftools copy paste. See comment in CMakeLists.txt about how this change technically is doing undocumented behavior. We can back out the undocumented behavior piece if anyone is particularly concerned.

Ports over EOSIO/eos#8208

Interestingly, the wasm spec tests change is already present in mandel's fork. That repo must have been forked from master.