### PR TITLE
Split wasm spec tests into two jobs so they run quicker.

### DIFF
--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -174,7 +174,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions.*|f32.*|memory.*|f64.*|unreachable.*|const.*"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions.*|f32.*|f64.*|unreachable.*|const.*"'
   ubuntu-2004-wasm-test-2:
     name: Ubuntu 20.04 | WASM Spec Test 2
     runs-on: ubuntu-latest
@@ -195,7 +195,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions.*|f32.*|memory.*|f64.*|unreachable.*|const.*"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions.*|f32.*|f64.*|unreachable.*|const.*"'
   ubuntu-2004-serial-test:
     name: Ubuntu 20.04 | Serial Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -174,7 +174,28 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions_0_check_throw_unit_test.*|f32_0_pass_unit_test.*|memory_trap_1_check_throw_unit_test.*"'
+  ubuntu-2004-wasm-test-2:
+    name: Ubuntu 20.04 | WASM Spec Test 2
+    runs-on: ubuntu-latest
+    needs: ubuntu-2004-build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+      - name: Download build
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-2004-build
+      - name: WASM Spec Test
+        run: |
+          set -e
+          tar -xzf ubuntu-2004-build/build.tar.gz
+          export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
+          docker pull ${UBUNTU_2004_IMAGE}
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions_0_check_throw_unit_test.*|f32_0_pass_unit_test.*|memory_trap_1_check_throw_unit_test.*"'
   ubuntu-2004-serial-test:
     name: Ubuntu 20.04 | Serial Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -174,7 +174,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions.*|f32.*|memory.*|f64.*|unreachable.*"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions.*|f32.*|memory.*|f64.*|unreachable.*|const.*"'
   ubuntu-2004-wasm-test-2:
     name: Ubuntu 20.04 | WASM Spec Test 2
     runs-on: ubuntu-latest
@@ -195,7 +195,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions.*|f32.*|memory.*|f64.*|unreachable.*"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions.*|f32.*|memory.*|f64.*|unreachable.*|const.*"'
   ubuntu-2004-serial-test:
     name: Ubuntu 20.04 | Serial Test
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu-2004.yml
+++ b/.github/workflows/ubuntu-2004.yml
@@ -174,7 +174,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions_0_check_throw_unit_test.*|f32_0_pass_unit_test.*|memory_trap_1_check_throw_unit_test.*"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -E "conversions.*|f32.*|memory.*|f64.*|unreachable.*"'
   ubuntu-2004-wasm-test-2:
     name: Ubuntu 20.04 | WASM Spec Test 2
     runs-on: ubuntu-latest
@@ -195,7 +195,7 @@ jobs:
           tar -xzf ubuntu-2004-build/build.tar.gz
           export DOCKER="docker run --rm -v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE} -w ${GITHUB_WORKSPACE} ${UBUNTU_2004_IMAGE}"
           docker pull ${UBUNTU_2004_IMAGE}
-          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions_0_check_throw_unit_test.*|f32_0_pass_unit_test.*|memory_trap_1_check_throw_unit_test.*"'
+          ${DOCKER} bash -c 'cd build && ctest --output-on-failure -j $(nproc) -L "wasm_spec_tests" -R "conversions.*|f32.*|memory.*|f64.*|unreachable.*"'
   ubuntu-2004-serial-test:
     name: Ubuntu 20.04 | Serial Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Wasm Spec Tests are the longest running tests. Split into two jobs so they can run in parallel. 