### PR TITLE
Remove requirement for disable-api-persisted-trx to be true

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1601,7 +1601,7 @@ struct controller_impl {
             emit(self.applied_transaction, std::tie(trace, trx->packed_trx()));
 
 
-            if ( read_mode != db_read_mode::SPECULATIVE && pending->_block_status == controller::block_status::incomplete || trx->read_only ) {
+            if ( (read_mode != db_read_mode::SPECULATIVE && pending->_block_status == controller::block_status::incomplete) || trx->read_only ) {
                //this may happen automatically in destructor, but I prefer make it more explicit
                trx_context.undo();
             } else {

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -149,7 +149,7 @@ namespace eosio { namespace chain {
 
          transaction_checktime_timer   transaction_timer;
 
-         bool                          is_read_only = false;
+         const bool                    is_read_only;
    private:
          bool                          is_initialized = false;
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -55,9 +55,9 @@ namespace eosio { namespace chain {
    ,trace(std::make_shared<transaction_trace>())
    ,start(s)
    ,transaction_timer(std::move(tmr))
+   ,is_read_only(read_only)
    ,net_usage(trace->net_usage)
    ,pseudo_start(s)
-   ,is_read_only(read_only)
    {
       if (!c.skip_db_sessions()) {
          undo_session.emplace(c.mutable_db().start_undo_session(true));

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1121,8 +1121,6 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
       my->chain.emplace( *my->chain_config, std::move(pfs), *chain_id );
 
       if( options.count( "transaction-retry-max-storage-size-gb" )) {
-         EOS_ASSERT( options.at( "disable-api-persisted-trx" ).as<bool>(), plugin_config_exception,
-                     "disable-api-persisted-trx must be set to true for transaction retry feature" );
          EOS_ASSERT( !options.count( "producer-name"), plugin_config_exception,
                      "Transaction retry not allowed on producer nodes." );
          const uint64_t max_storage_size = options.at( "transaction-retry-max-storage-size-gb" ).as<uint64_t>() * 1024 * 1024 * 1024;

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -93,24 +93,11 @@ chain::transaction_trace_ptr make_transaction_trace( const packed_transaction_pt
    });
 }
 
-uint64_t get_id( const transaction& trx ) {
-   testit t = trx.actions.at(0).data_as<testit>();
-   return t.id;
-}
-
-uint64_t get_id( const packed_transaction_ptr& ptr ) {
-   return get_id( ptr->get_transaction() );
-}
-
 chain::block_id_type make_block_id( uint32_t block_num ) {
    chain::block_id_type block_id;
    block_id._hash[0] &= 0xffffffff00000000;
    block_id._hash[0] += fc::endian_reverse_u32(block_num);
    return block_id;
-}
-
-uint32_t get_block_num( const chain::block_id_type& block_id ) {
-   return eosio::chain::block_header::num_from_id(block_id);
 }
 
 auto make_block_state( uint32_t block_num ) {

--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -83,7 +83,7 @@ try:
     specificExtraNodeosArgs={
         3:"--transaction-retry-max-storage-size-gb 5 --disable-api-persisted-trx", # api node
         4:"--disable-api-persisted-trx",                                           # relay only, will be killed
-        5:"--transaction-retry-max-storage-size-gb 5 --disable-api-persisted-trx", # api node, will be isolated
+        5:"--transaction-retry-max-storage-size-gb 5",                             # api node, will be isolated
         6:"--disable-api-persisted-trx"                                            # relay only, will be killed
     }
 


### PR DESCRIPTION
- Remove requirement for `disable-api-persisted-trx` to be `true` for transaction retry feature, as it is not required. Transaction retry will work with it enabled or disabled.
- Fix some compiler warnings.