### PR TITLE
Don't apply subjective billing to read-only transactions

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2813,7 +2813,7 @@ void read_only::compute_transaction(const fc::variant_object& params, next_funct
             abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
         } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
-        app().get_method<incoming::methods::transaction_async>()(pretty_input, true, true,
+        app().get_method<incoming::methods::transaction_async>()(pretty_input, false, true,
              [this, next](const std::variant<fc::exception_ptr, transaction_trace_ptr>& result) -> void {
                  if (std::holds_alternative<fc::exception_ptr>(result)) {
                      next(std::get<fc::exception_ptr>(result));

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -585,7 +585,7 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                   }
                   exhausted = block_is_exhausted();
                } else {
-                   if (!trx->read_only)
+                   if (!disable_subjective_billing)
                       _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
 
                   auto e_ptr = trace->except->dynamic_copy_exception();
@@ -599,7 +599,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                   _unapplied_transactions.add_persisted( trx );
                } else {
                   // if db_read_mode SPECULATIVE then trx is in the pending block and not immediately reverted
-                  _subjective_billing.subjective_bill( trx->id(), expire, first_auth, trace->elapsed,
+                  if (!disable_subjective_billing)
+                     _subjective_billing.subjective_bill( trx->id(), expire, first_auth, trace->elapsed,
                                                        chain.get_read_mode() == chain::db_read_mode::SPECULATIVE );
                }
                send_response( trace );

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -561,7 +561,8 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
 
             bool disable_subjective_billing = ( _pending_block_mode == pending_block_mode::producing )
                                               || ( persist_until_expired && _disable_subjective_api_billing )
-                                              || ( !persist_until_expired && _disable_subjective_p2p_billing );
+                                              || ( !persist_until_expired && _disable_subjective_p2p_billing )
+                                              || trx->read_only;
 
             auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
             uint32_t sub_bill = 0;
@@ -584,7 +585,9 @@ class producer_plugin_impl : public std::enable_shared_from_this<producer_plugin
                   }
                   exhausted = block_is_exhausted();
                } else {
-                  _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
+                   if (!trx->read_only)
+                      _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
+
                   auto e_ptr = trace->except->dynamic_copy_exception();
                   send_response( e_ptr );
                }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -83,7 +83,7 @@ add_test(NAME producer-preactivate-feature-test COMMAND tests/prod_preactivation
 set_property(TEST producer-preactivate-feature-test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME nodeos_protocol_feature_test COMMAND tests/nodeos_protocol_feature_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_protocol_feature_test PROPERTY LABELS nonparallelizable_tests)
-add_test(NAME compute_transaction_test COMMAND tests/compute_transaction_test.py -v -p 2 --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+add_test(NAME compute_transaction_test COMMAND tests/compute_transaction_test.py -v -p 2 -n 3 --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST compute_transaction_test PROPERTY LABELS nonparallelizable_tests)
 
 add_test(NAME distributed-transactions-test COMMAND tests/distributed-transactions-test.py -d 2 -p 4 -n 6 -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -851,7 +851,7 @@ class Node(object):
 
         return balances
 
-    # Gets accounts mapped to key. Returns json object
+    # Gets subjective bill info for an account
     def getAccountSubjectiveInfo(self, account):
         acct = self.getEosAccount(account)
         return acct["subjective_cpu_bill_limit"]

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -852,6 +852,11 @@ class Node(object):
         return balances
 
     # Gets accounts mapped to key. Returns json object
+    def getAccountSubjectiveInfo(self, account):
+        acct = self.getEosAccount(account)
+        return acct["subjective_cpu_bill_limit"]
+
+    # Gets accounts mapped to key. Returns json object
     def getAccountsByKey(self, key, exitOnError=False):
         cmdDesc = "get accounts"
         cmd="%s %s" % (cmdDesc, key)

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -168,6 +168,17 @@ try:
     acct2 = npnode.getAccountSubjectiveInfo("account2")
     assert(acct2["used"] > 0)
 
+    # Test that irrelavent signature doesn't break read-only txn
+    trx3 = {
+
+        "actions": [{"account": "eosio.token","name": "transfer",
+                     "authorization": [{"actor": "account1","permission": "active"},{"actor": "account2","permission": "active"}],
+                     "data": {"from": "account1","to": "account2","quantity": "10.0001 SYS","memo": memo},
+                     "compression": "none"}]
+    }
+    results = npnode.pushTransaction(trx3, opts="--read-only")
+    assert(results[0])
+
     testSuccessful = True
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -73,7 +73,7 @@ try:
     Print ("producing nodes: %s, non-producing nodes: %d, topology: %s, delay between nodes launch(seconds): %d" % (pnodes, total_nodes-pnodes, topo, delay))
 
     Print("Stand up cluster")
-    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay,extraNodeosArgs=" --http-max-response-time-ms 990000 --disable-subjective-api-billing false --subjective-cpu-leeway-us 0" ) is False:
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, topo=topo, delay=delay,extraNodeosArgs=" --http-max-response-time-ms 990000 --disable-subjective-api-billing false" ) is False:
        errorExit("Failed to stand up eos cluster.")
 
     Print ("Wait for Cluster stabilization")


### PR DESCRIPTION
This PR turns off subjective billing for read-only transactions.

*** Warning ***
An effect of this change is that compute_transaction becomes a potential DOS attack vector for any node that has enabled the compute_transaction end point.  Any exposed node should implement some form of throttling to prevent this sort of attack.