### PR TITLE
compute_transaction & send_transaction2 cleanup

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -94,10 +94,37 @@ namespace {
    }\
 }
 
+#define CALL_ASYNC_WITH_400(api_name, api_handle, api_namespace, call_name, call_result, http_response_code) \
+{std::string("/v1/" #api_name "/" #call_name), \
+   [api_handle](string, string body, url_response_callback cb) mutable { \
+      api_handle.validate(); \
+      try { \
+         auto params = parse_params<api_namespace::call_name ## _params>(body);\
+         api_handle.call_name( std::move(params),\
+            [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
+               if (std::holds_alternative<fc::exception_ptr>(result)) {\
+                  try {\
+                     std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\
+                  } catch (...) {\
+                     http_plugin::handle_exception(#api_name, #call_name, body, cb);\
+                  }\
+               } else {\
+                  cb(http_response_code, std::visit(async_result_visitor(), result));\
+               }\
+            });\
+      } catch (...) { \
+         http_plugin::handle_exception(#api_name, #call_name, body, cb); \
+      } \
+   }\
+}
+
 #define CHAIN_RO_CALL(call_name, http_response_code) CALL(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
 #define CHAIN_RW_CALL(call_name, http_response_code) CALL(chain, rw_api, chain_apis::read_write, call_name, http_response_code)
 #define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
 #define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
+
+#define CHAIN_RO_CALL_ASYNC_WITH_400(call_name, call_result, http_response_code) CALL_ASYNC_WITH_400(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
+#define CHAIN_RW_CALL_ASYNC_WITH_400(call_name, call_result, http_response_code) CALL_ASYNC_WITH_400(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
 
 #define CHAIN_RO_CALL_WITH_400(call_name, http_response_code) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
 
@@ -134,12 +161,12 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
-      CHAIN_RO_CALL_ASYNC(compute_transaction, chain_apis::read_only::compute_transaction_results, 200),
+      CHAIN_RO_CALL_ASYNC_WITH_400(compute_transaction, chain_apis::read_only::compute_transaction_results, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202),
-      CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202)
+      CHAIN_RW_CALL_ASYNC_WITH_400(send_transaction2, chain_apis::read_write::send_transaction_results, 202)
    });
 
    if (chain.account_queries_enabled()) {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -640,7 +640,7 @@ public:
    void send_transaction(const send_transaction_params& params, chain::plugin_interface::next_function<send_transaction_results> next);
 
    struct send_transaction2_params {
-      bool return_failure_traces = false; ///< Ignored. Will be enabled in future versions.
+      bool return_failure_trace = true; ///< Ignored. Will be enabled in future versions.
       bool retry_trx = false; ///< request transaction retry on validated transaction
       std::optional<uint16_t> retry_trx_num_blocks{}; ///< if retry_trx, report trace at specified blocks from executed or lib if not specified
       fc::variant transaction;
@@ -796,7 +796,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))
 FC_REFLECT(eosio::chain_apis::read_only::get_block_header_state_params, (block_num_or_id))
 
 FC_REFLECT( eosio::chain_apis::read_write::push_transaction_results, (transaction_id)(processed) )
-FC_REFLECT( eosio::chain_apis::read_write::send_transaction2_params, (return_failure_traces)(retry_trx)(retry_trx_num_blocks)(transaction) )
+FC_REFLECT( eosio::chain_apis::read_write::send_transaction2_params, (return_failure_trace)(retry_trx)(retry_trx_num_blocks)(transaction) )
 
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_params, (json)(code)(scope)(table)(table_key)(lower_bound)(upper_bound)(limit)(key_type)(index_position)(encode_type)(reverse)(show_payer) )
 FC_REFLECT( eosio::chain_apis::read_only::get_table_rows_result, (rows)(more)(next_key) );

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -381,7 +381,7 @@ fc::variant push_transaction( signed_transaction& trx, packed_transaction::compr
             try {
                bool retry = tx_retry_lib || tx_retry_num_blocks > 0;
                auto args = fc::mutable_variant_object()
-                     ( "return_failure_traces", tx_rtn_failure_trace )
+                     ( "return_failure_trace", tx_rtn_failure_trace )
                      ( "retry_trx", retry );
                if( tx_retry_num_blocks > 0 ) args( "retry_trx_num_blocks", tx_retry_num_blocks );
                args( "transaction", packed_transaction( trx, compression ) );


### PR DESCRIPTION
- Changed `compute_transaction` & `send_transaction2` to generate 400 http code on invalid input to match newer scheme for http errors. See https://github.com/EOSIO/eos/pull/9033 which will likely be backported to Mandel. For now this only applies the #9033 approach to `compute_transaction` & `send_transaction2`.
- Renamed `return_failure_traces` to `return_failure_trace`.
- Changed to default of `return_failure_trace` to `true`
  -  Currently ignored: feature not implemented yet.