### PR TITLE
Update memory_size() calculation for tracked_transaction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ configure_file(${CMAKE_SOURCE_DIR}/libraries/softfloat/COPYING.txt
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.softfloat COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/libraries/wasm-jit/LICENSE
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.wavm COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/secp256k1/upstream/COPYING
+configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/secp256k1/secp256k1/COPYING
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.secp256k1 COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/include/fc/crypto/webauthn_json/license.txt
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.rapidjson COPYONLY)
@@ -224,7 +224,7 @@ configure_file(${CMAKE_SOURCE_DIR}/libraries/eos-vm/LICENSE
 install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ COMPONENT base)
 install(FILES libraries/softfloat/COPYING.txt DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.softfloat COMPONENT base)
 install(FILES libraries/wasm-jit/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.wavm COMPONENT base)
-install(FILES libraries/fc/secp256k1/upstream/COPYING DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.secp256k1 COMPONENT base)
+install(FILES libraries/fc/secp256k1/secp256k1/COPYING DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.secp256k1 COMPONENT base)
 install(FILES libraries/fc/include/fc/crypto/webauthn_json/license.txt DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.rapidjson COMPONENT base)
 install(FILES libraries/fc/src/network/LICENSE.go DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ COMPONENT base)
 install(FILES libraries/yubihsm/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.yubihsm COMPONENT base)

--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -102,7 +102,6 @@ macro(add_eosio_test_executable test_name)
        ${libchainbase}
        ${libbuiltins}
        ${libsecp256k1}
-       @GMP_LIBRARIES@
 
        ${Boost_FILESYSTEM_LIBRARY}
        ${Boost_SYSTEM_LIBRARY}

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -100,7 +100,6 @@ macro(add_eosio_test_executable test_name)
        ${libchainbase}
        ${libbuiltins}
        ${libsecp256k1}
-       @GMP_LIBRARIES@
 
        ${Boost_FILESYSTEM_LIBRARY}
        ${Boost_SYSTEM_LIBRARY}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ apt-get update && apt-get install   \
         jq                          \
         libboost-all-dev            \
         libcurl4-openssl-dev        \
-        libgmp-dev                  \
         libssl-dev                  \
         libtinfo5                   \
         libusb-1.0-0-dev            \

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -72,9 +72,6 @@ namespace eosio { namespace chain {
    using                               fc::flat_multimap;
    using                               fc::flat_set;
    using                               std::variant;
-   using                               fc::ecc::range_proof_type;
-   using                               fc::ecc::range_proof_info;
-   using                               fc::ecc::commitment_type;
 
    using public_key_type  = fc::crypto::public_key;
    using private_key_type = fc::crypto::private_key;

--- a/plugins/chain_plugin/trx_retry_db.cpp
+++ b/plugins/chain_plugin/trx_retry_db.cpp
@@ -51,10 +51,7 @@ struct tracked_transaction {
       return block_num != 0;
    }
 
-   // for fc::tracked_storage, rough guess for now until get_estimated_size() is implemented for variant
-   // Size of packed_transaction + (2 * packed_transaction size as rough guess for variant size)
-   // todo: add get_estimated_size to fc::variant for use here
-   size_t memory_size()const { return ptrx->get_estimated_size() * 3 + sizeof(*this); }
+   size_t memory_size()const { return ptrx->get_estimated_size() + trx_trace_v.estimated_size() + sizeof(*this); }
 
    tracked_transaction(const tracked_transaction&) = delete;
    tracked_transaction() = delete;


### PR DESCRIPTION
### tracked_transaction now uses the new fc::variant::estimated size function to more accurately estimate the size

This PR also ticks up the git commit for the fc submodule.

Some additional test changes may be needed.