### PR TITLE
replace old libsecp256k1 fork with upstream & remove GMP dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ configure_file(${CMAKE_SOURCE_DIR}/libraries/softfloat/COPYING.txt
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.softfloat COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/libraries/wasm-jit/LICENSE
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.wavm COPYONLY)
-configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/secp256k1/upstream/COPYING
+configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/secp256k1/secp256k1/COPYING
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.secp256k1 COPYONLY)
 configure_file(${CMAKE_SOURCE_DIR}/libraries/fc/include/fc/crypto/webauthn_json/license.txt
                ${CMAKE_BINARY_DIR}/licenses/eosio/LICENSE.rapidjson COPYONLY)
@@ -224,7 +224,7 @@ configure_file(${CMAKE_SOURCE_DIR}/libraries/eos-vm/LICENSE
 install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ COMPONENT base)
 install(FILES libraries/softfloat/COPYING.txt DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.softfloat COMPONENT base)
 install(FILES libraries/wasm-jit/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.wavm COMPONENT base)
-install(FILES libraries/fc/secp256k1/upstream/COPYING DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.secp256k1 COMPONENT base)
+install(FILES libraries/fc/secp256k1/secp256k1/COPYING DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.secp256k1 COMPONENT base)
 install(FILES libraries/fc/include/fc/crypto/webauthn_json/license.txt DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.rapidjson COMPONENT base)
 install(FILES libraries/fc/src/network/LICENSE.go DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ COMPONENT base)
 install(FILES libraries/yubihsm/LICENSE DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/licenses/eosio/ RENAME LICENSE.yubihsm COMPONENT base)

--- a/CMakeModules/EosioTester.cmake.in
+++ b/CMakeModules/EosioTester.cmake.in
@@ -102,7 +102,6 @@ macro(add_eosio_test_executable test_name)
        ${libchainbase}
        ${libbuiltins}
        ${libsecp256k1}
-       @GMP_LIBRARIES@
 
        ${Boost_FILESYSTEM_LIBRARY}
        ${Boost_SYSTEM_LIBRARY}

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -100,7 +100,6 @@ macro(add_eosio_test_executable test_name)
        ${libchainbase}
        ${libbuiltins}
        ${libsecp256k1}
-       @GMP_LIBRARIES@
 
        ${Boost_FILESYSTEM_LIBRARY}
        ${Boost_SYSTEM_LIBRARY}

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ apt-get update && apt-get install   \
         jq                          \
         libboost-all-dev            \
         libcurl4-openssl-dev        \
-        libgmp-dev                  \
         libssl-dev                  \
         libtinfo5                   \
         libusb-1.0-0-dev            \

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -72,9 +72,6 @@ namespace eosio { namespace chain {
    using                               fc::flat_multimap;
    using                               fc::flat_set;
    using                               std::variant;
-   using                               fc::ecc::range_proof_type;
-   using                               fc::ecc::range_proof_info;
-   using                               fc::ecc::commitment_type;
 
    using public_key_type  = fc::crypto::public_key;
    using private_key_type = fc::crypto::private_key;


### PR DESCRIPTION
Replace the old libsecp256k1 fork with upstream. The initial motivation for this change was performance: upstream libsecp256k1 can make use of now expired patented optimizations that significantly reduce the amount of time to perform key recovery.

There are two other significant benefits though. The previous fork in use was many many years old and some users have voiced concern about usage of such stale forks (EOSIO/eos#8984). It's certainly desirable to get back on track with the upstream repository. Plus, this latest version of libsecp256k1 no longer needs GMP to perform at optimal speed -- they've even completely removed that code path from the library. GMP is an LGPL library and removing it as a dependency opens up the possibility for future positive changes to binary releases. Besides, removing dependencies always make me smile these days. :wink: 

My measurements of the performance improvement for K1 key recovery:
CPU | Previous | New
--- | --- | ---
Intel 9600k | 50µs | 33µs
AMD 5950X | 51µs | 35µs

(exact performance numbers will vary based on hardware and many other factors; these numbers we gathered with only a single core loaded)

Much of the changes are over in eosnetworkfoundation/mandel-fc#19

Yes, this PR isn't touching the cicd or build scripts. I'm going to continue to ignore those with the hope something good can come along before 3.1 release :smiling_imp: 

This ports over EOSIO/eos#9885 (and EOSIO/fc#180) but then adds on top of it: an even newer version of libsecp256k1 is used vs that late 2020 change which both slightly boosts performance more and allows removal of GMP. I've also wired in libsecp256k1's unit tests.