### PR TITLE
improve reliability of two forking unit tests

### DIFF
--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -423,7 +423,6 @@ try:
             nextProdChange=True
             Print("nextProdChange = True")
         elif nextProdChange and blockProducer1!=killAtProducer:
-            nextProdChange=False
             Print("nextProdChange = False")
             if blockProducer0!=blockProducer1:
                 Print("Divergence identified at block %s, node_00 producer: %s, node_01 producer: %s" % (blockNum, blockProducer0, blockProducer1))
@@ -432,7 +431,7 @@ try:
             else:
                 missedTransitionBlock=blockNum
                 transitionCount+=1
-                Print("missedTransitionBlock = {} transitionCount = ".format(missedTransitionBlock, transitionCount))
+                Print("missedTransitionBlock = {} transitionCount = {}".format(missedTransitionBlock, transitionCount))
                 # allow this to transition twice, in case the script was identifying an earlier transition than the bridge node received the kill command
                 if transitionCount>1:
                     Print("At block %d and have passed producer: %s %d times and we have not diverged, stopping looking and letting errors report" % (blockNum, killAtProducer, transitionCount))
@@ -500,16 +499,20 @@ try:
 
     #ensure that the nodes have enough time to get in concensus, so wait for 3 producers to produce their complete round
     time.sleep(inRowCountPerProducer * 3 / 2)
-    remainingChecks=20
+    remainingChecks=60
     match=False
     checkHead=False
+    checkMatchBlock=killBlockNum
+    forkResolved=False
     while remainingChecks>0:
-        checkMatchBlock=killBlockNum if not checkHead else prodNodes[0].getBlockNum()
+        if checkMatchBlock == killBlockNum and checkHead:
+            checkMatchBlock = prodNodes[0].getBlockNum()
         blockProducer0=prodNodes[0].getBlockProducerByNum(checkMatchBlock)
         blockProducer1=prodNodes[1].getBlockProducerByNum(checkMatchBlock)
         match=blockProducer0==blockProducer1
         if match:
             if checkHead:
+                forkResolved=True
                 break
             else:
                 checkHead=True
@@ -517,6 +520,12 @@ try:
         Print("Fork has not resolved yet, wait a little more. Block %s has producer %s for node_00 and %s for node_01.  Original divergence was at block %s. Wait time remaining: %d" % (checkMatchBlock, blockProducer0, blockProducer1, killBlockNum, remainingChecks))
         time.sleep(1)
         remainingChecks-=1
+    
+    assert forkResolved, "fork was not resolved in a reasonable time. node_00 lib {} head {} node_01 lib {} head {}".format(
+                                                                                  prodNodes[0].getIrreversibleBlockNum(), 
+                                                                                          prodNodes[0].getHeadBlockNum(), 
+                                                                                                          prodNodes[1].getIrreversibleBlockNum(), 
+                                                                                                                 prodNodes[1].getHeadBlockNum()) 
 
     for prodNode in prodNodes:
         info=prodNode.getInfo()

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -371,6 +371,7 @@ try:
     # block number to start expecting node killed after
     preKillBlockNum=nonProdNode.getBlockNum()
     preKillBlockProducer=nonProdNode.getBlockProducerByNum(preKillBlockNum)
+    Print("preKillBlockProducer = {}".format(preKillBlockProducer))
     # kill at last block before defproducerl, since the block it is killed on will get propagated
     killAtProducer="defproducerk"
     nonProdNode.killNodeOnProducer(producer=killAtProducer, whereInSequence=(inRowCountPerProducer-1))
@@ -400,8 +401,13 @@ try:
             (headBlockNum, libNumAroundDivergence)=getMinHeadAndLib(prodNodes)
 
         # track the block number and producer from each producing node
-        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum)
-        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum)
+        # we use timeout 70 here because of case when chain break, call to getBlockProducerByNum
+        # and call of producer_plugin::schedule_delayed_production_loop happens nearly immediately
+        # for 10 producers wait cycle is 10 * (12*0.5) = 60 seconds.
+        # for 11 producers wait cycle is 11 * (12*0.5) = 66 seconds.
+        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum, timeout=70)
+        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum, timeout=70)
+        Print("blockNum = {} blockProducer0 = {} blockProducer1 = {}".format(blockNum, blockProducer0, blockProducer1))
         blockProducers0.append({"blockNum":blockNum, "prod":blockProducer0})
         blockProducers1.append({"blockNum":blockNum, "prod":blockProducer1})
 
@@ -410,12 +416,15 @@ try:
         if not prodChanged:
             if preKillBlockProducer!=blockProducer0:
                 prodChanged=True
+                Print("prodChanged = True")
 
         #since it is killing for the last block of killAtProducer, we look for the next producer change
         if not nextProdChange and prodChanged and blockProducer1==killAtProducer:
             nextProdChange=True
+            Print("nextProdChange = True")
         elif nextProdChange and blockProducer1!=killAtProducer:
             nextProdChange=False
+            Print("nextProdChange = False")
             if blockProducer0!=blockProducer1:
                 Print("Divergence identified at block %s, node_00 producer: %s, node_01 producer: %s" % (blockNum, blockProducer0, blockProducer1))
                 actualLastBlockNum=blockNum
@@ -423,6 +432,7 @@ try:
             else:
                 missedTransitionBlock=blockNum
                 transitionCount+=1
+                Print("missedTransitionBlock = {} transitionCount = ".format(missedTransitionBlock, transitionCount))
                 # allow this to transition twice, in case the script was identifying an earlier transition than the bridge node received the kill command
                 if transitionCount>1:
                     Print("At block %d and have passed producer: %s %d times and we have not diverged, stopping looking and letting errors report" % (blockNum, killAtProducer, transitionCount))

--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -256,8 +256,13 @@ try:
             (headBlockNum, libNumAroundDivergence)=getMinHeadAndLib(prodNodes)
 
         # track the block number and producer from each producing node
-        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum)
-        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum)
+        # we use timeout 70 here because of case when chain break, call to getBlockProducerByNum
+        # and call of producer_plugin::schedule_delayed_production_loop happens nearly immediately
+        # for 10 producers wait cycle is 10 * (12*0.5) = 60 seconds.
+        # for 11 producers wait cycle is 11 * (12*0.5) = 66 seconds.
+        blockProducer0=prodNodes[0].getBlockProducerByNum(blockNum, timeout=70)
+        blockProducer1=prodNodes[1].getBlockProducerByNum(blockNum, timeout=70)
+        Print("blockNum = {} blockProducer0 = {} blockProducer1 = {}".format(blockNum, blockProducer0, blockProducer1))
         blockProducers0.append({"blockNum":blockNum, "prod":blockProducer0})
         blockProducers1.append({"blockNum":blockNum, "prod":blockProducer1})
 
@@ -266,12 +271,14 @@ try:
         if not prodChanged:
             if preKillBlockProducer!=blockProducer0:
                 prodChanged=True
+                Print("prodChanged = True")
 
         #since it is killing for the last block of killAtProducer, we look for the next producer change
         if not nextProdChange and prodChanged and blockProducer1==killAtProducer:
             nextProdChange=True
+            Print("nextProdChange = True")
         elif nextProdChange and blockProducer1!=killAtProducer:
-            nextProdChange=False
+            Print("nextProdChange = False")
             if blockProducer0!=blockProducer1:
                 Print("Divergence identified at block %s, node_00 producer: %s, node_01 producer: %s" % (blockNum, blockProducer0, blockProducer1))
                 actualLastBlockNum=blockNum
@@ -279,6 +286,7 @@ try:
             else:
                 missedTransitionBlock=blockNum
                 transitionCount+=1
+                Print("missedTransitionBlock = {} transitionCount = {}".format(missedTransitionBlock, transitionCount))
                 # allow this to transition twice, in case the script was identifying an earlier transition than the bridge node received the kill command
                 if transitionCount>1:
                     Print("At block %d and have passed producer: %s %d times and we have not diverged, stopping looking and letting errors report" % (blockNum, killAtProducer, transitionCount))
@@ -356,16 +364,20 @@ try:
 
     #ensure that the nodes have enough time to get in concensus, so wait for 3 producers to produce their complete round
     time.sleep(inRowCountPerProducer * 3 / 2)
-    remainingChecks=20
+    remainingChecks=60
     match=False
     checkHead=False
+    checkMatchBlock=killBlockNum
+    forkResolved=False
     while remainingChecks>0:
-        checkMatchBlock=killBlockNum if not checkHead else prodNodes[0].getBlockNum()
+        if checkMatchBlock == killBlockNum and checkHead:
+            checkMatchBlock = prodNodes[0].getBlockNum()
         blockProducer0=prodNodes[0].getBlockProducerByNum(checkMatchBlock)
         blockProducer1=prodNodes[1].getBlockProducerByNum(checkMatchBlock)
         match=blockProducer0==blockProducer1
         if match:
             if checkHead:
+                forkResolved=True
                 break
             else:
                 checkHead=True
@@ -373,6 +385,12 @@ try:
         Print("Fork has not resolved yet, wait a little more. Block %s has producer %s for node_00 and %s for node_01.  Original divergence was at block %s. Wait time remaining: %d" % (checkMatchBlock, blockProducer0, blockProducer1, killBlockNum, remainingChecks))
         time.sleep(1)
         remainingChecks-=1
+    
+    assert forkResolved, "fork was not resolved in a reasonable time. node_00 lib {} head {} node_01 lib {} head {}".format(
+                                                                                  prodNodes[0].getIrreversibleBlockNum(), 
+                                                                                          prodNodes[0].getHeadBlockNum(), 
+                                                                                                          prodNodes[1].getIrreversibleBlockNum(), 
+                                                                                                                 prodNodes[1].getHeadBlockNum()) 
 
     for prodNode in prodNodes:
         info=prodNode.getInfo()


### PR DESCRIPTION
This ports over EOSIO/eos#10356 & EOSIO/eos#10879. The original description from @dimas1185:

>This PR fixes 2 flaky parts in nodeos_forked_chain_lr_test and nodeos_short_fork_take_over_lr_test:
>
>1. if node_02 transfer extra block on shutdown, i.e. it was supposed to be killed on block x, but during shutdown it have got x+1 and populated it. For this to be handled correctly, line 434 was removed.
>Example of such failure: https://buildkite.com/EOSIO/eosio/builds/30786#854e0f8f-16e4-4385-81c6-c0d935b1c052
>2. need a bit more time to resolve the fork. See line 510. Example of failure: https://buildkite.com/EOSIO/eosio/builds/30805#d6a12c86-b3a9-4efc-b983-2baa24a03e1a
>3. Same code changes were added to nodeos_short_fork_take_over_lr_test. Example fail:
    https://buildkite.com/EOSIO/eosio-test-stability/builds/320#2c36f791-7af9-4c4a-ae01-ae75ca6d659f
