### PR TITLE
port python changes from "test framework archiving"

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1555,22 +1555,6 @@ class Cluster(object):
                 except:
                     Utils.Print("No reportStatus")
 
-    def printBlockLogIfNeeded(self):
-        printBlockLog=False
-        if hasattr(self, "nodes") and self.nodes is not None:
-            for node in self.nodes:
-                if node.missingTransaction:
-                    printBlockLog=True
-                    break
-
-        if hasattr(self, "biosNode") and self.biosNode is not None and self.biosNode.missingTransaction:
-            printBlockLog=True
-
-        if not printBlockLog:
-            return
-
-        self.printBlockLog()
-
     def getBlockLog(self, nodeExtension, blockLogAction=BlockLogAction.return_blocks, outputFile=None, first=None, last=None, throwException=False, silentErrors=False, exitOnError=False):
         blockLogDir=Utils.getNodeDataDir(nodeExtension, "blocks")
         return Utils.getBlockLog(blockLogDir, blockLogAction=blockLogAction, outputFile=outputFile, first=first, last=last,  throwException=throwException, silentErrors=silentErrors, exitOnError=exitOnError)

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -1432,9 +1432,10 @@ class Cluster(object):
         if self.useBiosBootFile:
             Cluster.dumpErrorDetailImpl(Cluster.__bootlog)
 
-    def killall(self, silent=True, allInstances=False):
+    def killall(self, kill=True, silent=True, allInstances=False):
         """Kill cluster nodeos instances. allInstances will kill all nodeos instances running on the system."""
-        cmd="%s -k 9" % (Utils.EosLauncherPath)
+        signalNum=9 if kill else 15
+        cmd="%s -k %d" % (Utils.EosLauncherPath, signalNum)
         if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
         if 0 != subprocess.call(cmd.split(), stdout=Utils.FNull):
             if not silent: Utils.Print("Launcher failed to shut down eos cluster.")

--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -264,6 +264,7 @@ class Cluster(object):
                 Utils.Print("ERROR: Launcher failed to create shape file \"%s\"." % (shapeFile))
                 return False
 
+            Utils.Print("opening %s shape file: %s, current dir: %s" % (topo, shapeFile, os.getcwd()))
             f = open(shapeFile, "r")
             shapeFileJsonStr = f.read()
             f.close()

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -152,13 +152,6 @@ class TestHelper(object):
             psOut=Cluster.pgrepEosServers(timeout=60)
             Utils.Print("pgrep output:\n%s" % (psOut))
             Utils.Print("== Errors see above ==")
-            if len(Utils.CheckOutputDeque)>0:
-                Utils.Print("== cout/cerr pairs from last %d calls to Utils. ==" % len(Utils.CheckOutputDeque))
-                for out, err, cmd in reversed(Utils.CheckOutputDeque):
-                    Utils.Print("cmd={%s}" % (" ".join(cmd)))
-                    Utils.Print("cout={%s}" % (out))
-                    Utils.Print("cerr={%s}\n" % (err))
-                Utils.Print("== cmd/cout/cerr pairs done. ==")
 
         if killEosInstances:
             Utils.Print("Shut down the cluster.")

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -155,7 +155,7 @@ class TestHelper(object):
 
         if killEosInstances:
             Utils.Print("Shut down the cluster.")
-            cluster.killall(allInstances=cleanRun)
+            cluster.killall(allInstances=cleanRun, kill=testSuccessful)
             if testSuccessful and not keepLogs:
                 Utils.Print("Cleanup cluster data.")
                 cluster.cleanup()

--- a/tests/TestHelper.py
+++ b/tests/TestHelper.py
@@ -151,10 +151,6 @@ class TestHelper(object):
             Utils.Print(Utils.FileDivider)
             psOut=Cluster.pgrepEosServers(timeout=60)
             Utils.Print("pgrep output:\n%s" % (psOut))
-            cluster.dumpErrorDetails()
-            if walletMgr:
-                walletMgr.dumpErrorDetails()
-            cluster.printBlockLogIfNeeded()
             Utils.Print("== Errors see above ==")
             if len(Utils.CheckOutputDeque)>0:
                 Utils.Print("== cout/cerr pairs from last %d calls to Utils. ==" % len(Utils.CheckOutputDeque))

--- a/tests/ship_test.py
+++ b/tests/ship_test.py
@@ -210,14 +210,6 @@ finally:
 
         if testSuccessful and not keepLogs:
             shutil.rmtree(shipTempDir, ignore_errors=True)
-    if not testSuccessful and dumpErrorDetails:
-        Print(Utils.FileDivider)
-        Print("Compare Blocklog")
-        cluster.compareBlockLogs()
-        Print(Utils.FileDivider)
-        Print("Print Blocklog")
-        cluster.printBlockLog()
-        Print(Utils.FileDivider)
 
 errorCode = 0 if testSuccessful else 1
 exit(errorCode)

--- a/tests/ship_test.py
+++ b/tests/ship_test.py
@@ -208,7 +208,7 @@ finally:
                 # output file should have lots of output, but if user passes in a huge number of requests, these could go on forever
                 printTruncatedFile("%s%d.out" % (shipClientFilePrefix, i), maxLines=20000)
 
-        if not keepLogs:
+        if testSuccessful and not keepLogs:
             shutil.rmtree(shipTempDir, ignore_errors=True)
     if not testSuccessful and dumpErrorDetails:
         Print(Utils.FileDivider)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -72,7 +72,7 @@ class Utils:
     DataRoot="var"
     DataDir="%s/lib/" % (DataRoot)
     ConfigDir="etc/eosio/"
-    CheckOutputFilename="%s/subprocess_results.log"
+    CheckOutputFilename="%s/subprocess_results.log" % (DataRoot)
     CheckOutputFile=open(CheckOutputFilename,"w")
 
     TimeFmt='%Y-%m-%dT%H:%M:%S.%f'
@@ -181,8 +181,10 @@ class Utils:
         assert isinstance(popen, subprocess.Popen)
         assert isinstance(cmd, (str,list))
         (output,error)=popen.communicate()
-        checkOutputDict={ "cmd": cmd, "output": output, "error": error }
-        Utils.CheckOutputFile.write(json.dumps(checkOutputDict, indent=4, sort_keys=True))
+        Utils.CheckOutputFile.write(Utils.FileDivider + "\n")
+        Utils.CheckOutputFile.write("cmd={%s}\n" % (" ".join(cmd)))
+        Utils.CheckOutputFile.write("cout={%s}\n" % (output))
+        Utils.CheckOutputFile.write("cerr={%s}\n" % (error))
         if popen.returncode != 0 and not ignoreError:
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error)
         return output.decode("utf-8")

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -72,7 +72,6 @@ class Utils:
     DataRoot="var"
     DataDir="%s/lib/" % (DataRoot)
     ConfigDir="etc/eosio/"
-    CheckOutputFilename="%s/subprocess_results.log" % (DataRoot)
 
     TimeFmt='%Y-%m-%dT%H:%M:%S.%f'
 
@@ -84,8 +83,12 @@ class Utils:
     def checkOutputFileWrite(time, cmd, output, error):
         stop=Utils.timestamp()
         if not hasattr(Utils, "checkOutputFile"):
-            if Utils.Debug: Utils.Print("opening %s in dir: %s" % (Utils.CheckOutputFilename, os.getcwd()))
-            Utils.checkOutputFile=open(Utils.CheckOutputFilename,"w")
+            if not os.path.isdir(Utils.DataRoot):
+                if Utils.Debug: Utils.Print("creating dir %s in dir: %s" % (Utils.DataRoot, os.getcwd()))
+                os.mkdir(Utils.DataRoot)
+            filename="%s/subprocess_results.log" % (Utils.DataRoot)
+            if Utils.Debug: Utils.Print("opening %s in dir: %s" % (filename, os.getcwd()))
+            Utils.checkOutputFile=open(filename,"w")
 
         Utils.checkOutputFile.write(Utils.FileDivider + "\n")
         Utils.checkOutputFile.write("start={%s}\n" % (time))

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -65,13 +65,15 @@ class Utils:
 
     EosLauncherPath="programs/eosio-launcher/eosio-launcher"
     ShuttingDown=False
-    CheckOutputDeque=deque(maxlen=10)
 
     EosBlockLogPath="programs/eosio-blocklog/eosio-blocklog"
 
     FileDivider="================================================================="
-    DataDir="var/lib/"
+    DataRoot="var"
+    DataDir="%s/lib/" % (DataRoot)
     ConfigDir="etc/eosio/"
+    CheckOutputFilename="%s/subprocess_results.log"
+    CheckOutputFile=open(CheckOutputFilename,"w")
 
     TimeFmt='%Y-%m-%dT%H:%M:%S.%f'
 
@@ -179,7 +181,8 @@ class Utils:
         assert isinstance(popen, subprocess.Popen)
         assert isinstance(cmd, (str,list))
         (output,error)=popen.communicate()
-        Utils.CheckOutputDeque.append((output,error,cmd))
+        checkOutputDict={ "cmd": cmd, "output": output, "error": error }
+        Utils.CheckOutputFile.write(json.dumps(checkOutputDict, indent=4, sort_keys=True))
         if popen.returncode != 0 and not ignoreError:
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error)
         return output.decode("utf-8")

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -73,15 +73,32 @@ class Utils:
     DataDir="%s/lib/" % (DataRoot)
     ConfigDir="etc/eosio/"
     CheckOutputFilename="%s/subprocess_results.log" % (DataRoot)
-    CheckOutputFile=open(CheckOutputFilename,"w")
 
     TimeFmt='%Y-%m-%dT%H:%M:%S.%f'
+
+    @staticmethod
+    def timestamp():
+        return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")
+
+    @staticmethod
+    def checkOutputFileWrite(time, cmd, output, error):
+        stop=Utils.timestamp()
+        if not hasattr(Utils, "checkOutputFile"):
+            if Utils.Debug: Utils.Print("opening %s in dir: %s" % (Utils.CheckOutputFilename, os.getcwd()))
+            Utils.checkOutputFile=open(Utils.CheckOutputFilename,"w")
+
+        Utils.checkOutputFile.write(Utils.FileDivider + "\n")
+        Utils.checkOutputFile.write("start={%s}\n" % (time))
+        Utils.checkOutputFile.write("cmd={%s}\n" % (" ".join(cmd)))
+        Utils.checkOutputFile.write("cout={%s}\n" % (output))
+        Utils.checkOutputFile.write("cerr={%s}\n" % (error))
+        Utils.checkOutputFile.write("stop={%s}\n" % (stop))
 
     @staticmethod
     def Print(*args, **kwargs):
         stackDepth=len(inspect.stack())-2
         s=' '*stackDepth
-        stdout.write(datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f "))
+        stdout.write(Utils.timestamp() + " ")
         stdout.write(s)
         print(*args, **kwargs)
 
@@ -180,11 +197,9 @@ class Utils:
     def checkDelayedOutput(popen, cmd, ignoreError=False):
         assert isinstance(popen, subprocess.Popen)
         assert isinstance(cmd, (str,list))
+        start=Utils.timestamp()
         (output,error)=popen.communicate()
-        Utils.CheckOutputFile.write(Utils.FileDivider + "\n")
-        Utils.CheckOutputFile.write("cmd={%s}\n" % (" ".join(cmd)))
-        Utils.CheckOutputFile.write("cout={%s}\n" % (output))
-        Utils.CheckOutputFile.write("cerr={%s}\n" % (error))
+        Utils.checkOutputFileWrite(start, cmd, output, error)
         if popen.returncode != 0 and not ignoreError:
             raise subprocess.CalledProcessError(returncode=popen.returncode, cmd=cmd, output=error)
         return output.decode("utf-8")


### PR DESCRIPTION
This ports the python test harness changes from EOSIO/eos#9134.

The original PR's purpose to to ensure that all log files output from tests are bundled in to B1's CICD artifact storage. Those changes (to the `.cicd` files) are dropped, as while it makes sense to store the log output, there is no real equivalent in the current CI design. I've added #139 to address that we should be packaging up all that output in the future.

Bringing over the python changes reduces merge conflicts for future ports.