### PR TITLE
Add get_transaction_status to chain_plugin

### DIFF
--- a/docs/02_cleos/03_command-reference/get/transaction-status.md
+++ b/docs/02_cleos/03_command-reference/get/transaction-status.md
@@ -19,17 +19,17 @@ This command simply returns the current chain status and transaction status info
 
 ```json
 {
-    "state": "UNKNOWN",
-    "block_number": 0,
-    "block_id": "0000000000000000000000000000000000000000000000000000000000000000",
-    "block_timestamp": "2000-01-01T00:00:00.000",
-    "expiration": "2000-01-01T00:00:00.000",
-    "head_number": 0,
-    "head_id": "0000000000000000000000000000000000000000000000000000000000000000",
-    "head_timestamp": "2000-01-01T00:00:00.000",
-    "irreversible_number": 0,
-    "irreversible_id": "0000000000000000000000000000000000000000000000000000000000000000",
-    "irreversible_timestamp": "2000-01-01T00:00:00.000",
-    "last_tracked_block_id": "0000000000000000000000000000000000000000000000000000000000000000"
+    "state": "IN_BLOCK",
+    "block_number": 90,
+    "block_id": "0000005accfd59ba80a05380f60d51687406337b2aedd28b7daa33fdb8c16b5a",
+    "block_timestamp": "2022-04-27T16:11:26.500",
+    "expiration": "2022-04-27T16:11:56.000",
+    "head_number": 186,
+    "head_id": "000000bab27da51f76f483bb629b532510c22e2eb1acc632f5b37b421adecf63",
+    "head_timestamp": "2022-04-27T16:12:14.500",
+    "irreversible_number": 25,
+    "irreversible_id": "0000001922118216bc16bf2c60d950598d80af3beca820eab751f7beecdb29e4",
+    "irreversible_timestamp": "2022-04-27T16:10:54.000",
+    "last_tracked_block_id": "000000129cee97f3e27312f0184d52d006a470f0e620553dfb4c5b4f3c856ab2"
 }
 ```

--- a/docs/02_cleos/03_command-reference/get/transaction-status.md
+++ b/docs/02_cleos/03_command-reference/get/transaction-status.md
@@ -1,0 +1,35 @@
+## Description
+
+Gets current blockchain state and, if available, transaction information given the transaction id
+
+## Position Parameters
+
+- `id` _TEXT_ - The string ID of the transaction to retrieve status about (required)
+
+## Options
+- `-h` - --help                   Print this help message and exit
+## Example
+
+
+```sh
+cleos get transaction-status 6438df82216dfaf46978f703fb818b49110dbfc5d9b521b5d08c342277438b29
+```
+
+This command simply returns the current chain status and transaction status information (if available). 
+
+```json
+{
+    "state": "UNKNOWN",
+    "block_number": 0,
+    "block_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "block_timestamp": "2000-01-01T00:00:00.000",
+    "expiration": "2000-01-01T00:00:00.000",
+    "head_number": 0,
+    "head_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "head_timestamp": "2000-01-01T00:00:00.000",
+    "irreversible_number": 0,
+    "irreversible_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "irreversible_timestamp": "2000-01-01T00:00:00.000",
+    "last_tracked_block_id": "0000000000000000000000000000000000000000000000000000000000000000"
+}
+```

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -161,6 +161,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
+      CHAIN_RO_CALL(get_transaction_status, 200),
       CHAIN_RO_CALL_ASYNC_WITH_400(compute_transaction, chain_apis::read_only::compute_transaction_results, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -161,7 +161,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
-      CHAIN_RO_CALL(get_transaction_status, 200),
+      CHAIN_RO_CALL_WITH_400(get_transaction_status, 200),
       CHAIN_RO_CALL_ASYNC_WITH_400(compute_transaction, chain_apis::read_only::compute_transaction_results, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -794,9 +794,15 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
          my->_trx_signals_processor.emplace();
          if (my->_trx_finality_status_processing) {
             my->_trx_signals_processor->register_callbacks(
-               []( const chain::signals_processor::trx_deque& trxs, const chain::block_state_ptr& blk ) {},
-               []( const chain::block_state_ptr& blk ) {},
-               []( uint32_t block_num ) {}
+               [this]( const chain::signals_processor::trx_deque& trxs, const chain::block_state_ptr& blk ) {
+                  my->_trx_finality_status_processing->signal_applied_transactions(trxs, blk);
+               },
+               [this]( const chain::block_state_ptr& blk ) {
+                  my->_trx_finality_status_processing->signal_irreversible_block(blk);
+               },
+               [this]( uint32_t block_num ) {
+                  my->_trx_finality_status_processing->signal_block_start(block_num);
+               }
             );
          }
       }         

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1694,7 +1694,7 @@ read_only::get_transaction_status_results read_only::get_transaction_status(cons
    }
    EOS_RETHROW_EXCEPTIONS(transaction_id_type_exception, "Invalid transaction ID: ${transaction_id}", ("transaction_id", param.id))
 
-   EOS_ASSERT(!trx_finality_status_proc, unsupported_feature, "Transaction Status Interface not enabled.  To enable, configure nodeos with '--transaction-finality-status-max-storage-size-gb'.");
+   EOS_ASSERT(trx_finality_status_proc, unsupported_feature, "Transaction Status Interface not enabled.  To enable, configure nodeos with '--transaction-finality-status-max-storage-size-gb'.");
 
    trx_finality_status_processing::chain_state ch_state = trx_finality_status_proc->get_chain_state();
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1700,7 +1700,7 @@ read_only::get_transaction_status_results read_only::get_transaction_status(cons
    }
    EOS_RETHROW_EXCEPTIONS(transaction_id_type_exception, "Invalid transaction ID: ${transaction_id}", ("transaction_id", param.id))
 
-   EOS_ASSERT(trx_finality_status_proc, unsupported_feature, "Transaction Status Interface not enabled.  To enable, configure nodeos with '--transaction-finality-status-max-storage-size-gb'.");
+   EOS_ASSERT(trx_finality_status_proc, unsupported_feature, "Transaction Status Interface not enabled.  To enable, configure nodeos with '--transaction-finality-status-max-storage-size-gb <size>'.");
 
    trx_finality_status_processing::chain_state ch_state = trx_finality_status_proc->get_chain_state();
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -129,7 +129,7 @@ public:
    get_info_results get_info(const get_info_params&) const;
 
    struct get_transaction_status_params {
-      string                       id;
+      string                               id;
    };
 
    struct get_transaction_status_results {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -18,6 +18,7 @@
 
 #include <eosio/chain_plugin/account_query_db.hpp>
 #include <eosio/chain_plugin/trx_retry_db.hpp>
+#include <eosio/chain_plugin/trx_finality_status_processing.hpp>
 
 #include <fc/static_variant.hpp>
 
@@ -86,12 +87,13 @@ class read_only {
    const fc::microseconds abi_serializer_max_time;
    bool  shorten_abi_errors = true;
    const producer_plugin* producer_plug;
+   const trx_finality_status_processing* trx_finality_status_proc;
 
 public:
    static const string KEYi64;
 
-   read_only(const controller& db, const std::optional<account_query_db>& aqdb, const fc::microseconds& abi_serializer_max_time, const producer_plugin* producer_plug)
-      : db(db), aqdb(aqdb), abi_serializer_max_time(abi_serializer_max_time), producer_plug(producer_plug) {
+   read_only(const controller& db, const std::optional<account_query_db>& aqdb, const fc::microseconds& abi_serializer_max_time, const producer_plugin* producer_plug, const trx_finality_status_processing* trx_finality_status_proc)
+      : db(db), aqdb(aqdb), abi_serializer_max_time(abi_serializer_max_time), producer_plug(producer_plug), trx_finality_status_proc(trx_finality_status_proc) {
    }
 
    void validate() const {}
@@ -125,6 +127,27 @@ public:
       std::optional<uint64_t>              total_net_weight;
    };
    get_info_results get_info(const get_info_params&) const;
+
+   struct get_transaction_status_params {
+      string                       id;
+   };
+
+   struct get_transaction_status_results {
+      string                               state;
+      std::optional<uint32_t>              block_number;
+      std::optional<chain::block_id_type>  block_id;
+      std::optional<fc::time_point>        block_timestamp;
+      std::optional<fc::time_point>        expiration;
+      uint32_t                             head_number;
+      chain::block_id_type                 head_id;
+      fc::time_point                       head_timestamp;
+      uint32_t                             irreversible_number;
+      chain::block_id_type                 irreversible_id;
+      fc::time_point                       irreversible_timestamp;
+      chain::block_id_type                 last_tracked_block_id;
+   };
+   get_transaction_status_results get_transaction_status(const get_transaction_status_params& params) const;
+
 
    struct get_activated_protocol_features_params {
       std::optional<uint32_t>  lower_bound;
@@ -790,6 +813,9 @@ FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (head_block_id)(head_block_time)(head_block_producer)
            (virtual_block_cpu_limit)(virtual_block_net_limit)(block_cpu_limit)(block_net_limit)
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)(total_cpu_weight)(total_net_weight) )
+FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_params, (id) )
+FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_results, (state)(block_number)(block_id)(block_timestamp)(expiration)(head_number)(head_id)
+           (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(last_tracked_block_id) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -138,10 +138,10 @@ public:
       std::optional<chain::block_id_type>  block_id;
       std::optional<fc::time_point>        block_timestamp;
       std::optional<fc::time_point>        expiration;
-      uint32_t                             head_number;
+      uint32_t                             head_number = 0;
       chain::block_id_type                 head_id;
       fc::time_point                       head_timestamp;
-      uint32_t                             irreversible_number;
+      uint32_t                             irreversible_number = 0;
       chain::block_id_type                 irreversible_id;
       fc::time_point                       irreversible_timestamp;
       chain::block_id_type                 last_tracked_block_id;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
@@ -18,15 +18,18 @@ namespace eosio::chain_apis {
    public:
 
       struct chain_state {
-         chain::block_id_type head_id;
-         chain::block_id_type irr_id;
-         chain::block_id_type last_tracked_block_id;
+         chain::block_id_type          head_id;
+         chain::block_timestamp_type   head_block_timestamp;
+         chain::block_id_type          irr_id;
+         chain::block_timestamp_type   irr_block_timestamp;
+         chain::block_id_type          last_tracked_block_id;
       };
 
       struct trx_state {
          chain::block_id_type block_id;
          fc::time_point       block_timestamp;
          fc::time_point       received;
+         fc::time_point       expiration;
          std::string          status;
       };
 

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -255,6 +255,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_REQUIRE(ts);
    BOOST_CHECK(ts->block_id == bs_20->id);
    BOOST_CHECK(ts->block_timestamp == bs_20->block->timestamp);
+   BOOST_CHECK(fc::time_point_sec(ts->expiration) == (std::get<1>(trx_pairs_20[1])->expiration()));
    BOOST_CHECK_EQUAL(std::string(ts->received), pre_block_20_time);
    BOOST_CHECK_EQUAL(ts->status, "IN_BLOCK");
 
@@ -1004,7 +1005,9 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_storage_reduction) { try {
 
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == b_12.bs->id);
+   BOOST_CHECK(cs.head_block_timestamp == b_12.bs->block->timestamp);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
+   BOOST_CHECK(cs.irr_block_timestamp == eosio::chain::block_timestamp_type{});
    BOOST_CHECK(cs.last_tracked_block_id == b_03.bs->id);
 
 

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -707,6 +707,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_19_alt->id);
    BOOST_CHECK(cs.irr_id == bs_19_alt->id);
+   BOOST_CHECK(cs.irr_block_timestamp == bs_19_alt->block->timestamp);
    BOOST_CHECK(cs.last_tracked_block_id == bs_19_alt->id);
 
 

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -80,6 +80,7 @@ namespace eosio { namespace client { namespace http {
 
    const string chain_func_base = "/v1/chain";
    const string get_info_func = chain_func_base + "/get_info";
+   const string get_transaction_status_func = chain_func_base + "/get_transaction_status";
    const string send_txn_func = chain_func_base + "/send_transaction";
    const string push_txn_func = chain_func_base + "/push_transaction";
    const string send2_txn_func = chain_func_base + "/send_transaction2";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2625,6 +2625,15 @@ int main( int argc, char** argv ) {
       std::cout << fc::json::to_pretty_string(get_info()) << std::endl;
    });
 
+   // get transaction status
+   string status_transaction_id_str;
+   auto getTransactionStatus = get->add_subcommand("transaction-status", localized("Get transaction status information"));
+   getTransactionStatus->add_option("id", status_transaction_id_str, localized("ID of the transaction to retrieve"))->required();
+   getTransactionStatus->callback([&status_transaction_id_str] {
+      auto arg= fc::mutable_variant_object( "id", status_transaction_id_str);
+      std::cout << fc::json::to_pretty_string(call(get_transaction_status_func, arg)) << std::endl;
+   });
+
    // get block
    string blockArg;
    bool get_bhs = false;

--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_block_with_invalid_abi, TESTER ) try {
    char headnumstr[20];
    sprintf(headnumstr, "%d", headnum);
    chain_apis::read_only::get_block_params param{headnumstr};
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {}, {});
 
    // block should be decoded successfully
    std::string block_str = json::to_pretty_string(plugin.get_block(param));

--- a/tests/get_table_tests.cpp
+++ b/tests/get_table_tests.cpp
@@ -89,7 +89,7 @@ BOOST_FIXTURE_TEST_CASE( get_scope_test, TESTER ) try {
    produce_blocks(1);
 
    // iterate over scope
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {}, {});
    eosio::chain_apis::read_only::get_table_by_scope_params param{"eosio.token"_n, "accounts"_n, "inita", "", 10};
    eosio::chain_apis::read_only::get_table_by_scope_result result = plugin.read_only::get_table_by_scope(param);
 
@@ -194,7 +194,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {}, {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio.token"_n;
    p.scope = "inita";
@@ -363,7 +363,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_by_seckey_test, TESTER ) try {
    produce_blocks(1);
 
    // get table: normal case
-   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
+   eosio::chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {}, {});
    eosio::chain_apis::read_only::get_table_rows_params p;
    p.code = "eosio"_n;
    p.scope = "eosio";
@@ -515,7 +515,7 @@ BOOST_FIXTURE_TEST_CASE( get_table_next_key_test, TESTER ) try {
    // }
 
 
-   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {});
+   chain_apis::read_only plugin(*(this->control), {}, fc::microseconds::maximum(), {}, {});
    chain_apis::read_only::get_table_rows_params params{
       .json=true,
       .code="test"_n,

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -68,7 +68,8 @@ try:
         cluster.killall(allInstances=killAll)
         cluster.cleanup()
         Print("Stand up cluster")
-        if cluster.launch(prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap) is False:
+        extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 "
+        if cluster.launch(prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap, extraNodeosArgs=extraNodeosArgs) is False:
             cmdError("launcher")
             errorExit("Failed to stand up eos cluster.")
     else:

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -68,8 +68,7 @@ try:
         cluster.killall(allInstances=killAll)
         cluster.cleanup()
         Print("Stand up cluster")
-        extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 "
-        if cluster.launch(prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap, extraNodeosArgs=extraNodeosArgs) is False:
+        if cluster.launch(prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap) is False:
             cmdError("launcher")
             errorExit("Failed to stand up eos cluster.")
     else:


### PR DESCRIPTION
Adding a feature that allows querying the status of a transaction on the chain.

Support for the feature added in cleos via subcommand: `get transaction-status <transaction_id>`

Feature takes a transaction_id as input and outputs chain status and, if available, transaction status in the following format:

`{
  "state": "IN_BLOCK",
  "block_number": 90,
  "block_id": "0000005accfd59ba80a05380f60d51687406337b2aedd28b7daa33fdb8c16b5a",
  "block_timestamp": "2022-04-27T16:11:26.500",
  "expiration": "2022-04-27T16:11:56.000",
  "head_number": 186,
  "head_id": "000000bab27da51f76f483bb629b532510c22e2eb1acc632f5b37b421adecf63",
  "head_timestamp": "2022-04-27T16:12:14.500",
  "irreversible_number": 25,
  "irreversible_id": "0000001922118216bc16bf2c60d950598d80af3beca820eab751f7beecdb29e4",
  "irreversible_timestamp": "2022-04-27T16:10:54.000",
  "last_tracked_block_id": "000000129cee97f3e27312f0184d52d006a470f0e620553dfb4c5b4f3c856ab2"
}`

**Transaction Status:**

- If the transaction is unknown, failed (expired), in a block, rolled back, finalized, or limited in block (this would be for unknown trans ids that the controller knows about). This will be reported as `state` with values of: `UNKNOWN`, `FAILED`, `FORKED_OUT`, `LOCALLY_APPLIED`, `IN_BLOCK`, `IRREVERSIBLE`.
- The transaction’s block number, id, and timestamp, if they are applicable, will be reported as `block_number`, `block_id`, and `block_timestamp`. The transaction’s expiration date as `expiration`

**Chain Status:**

- The current head block number, id, and timestamp will be reported as `head_number`, `head_id`, and `head_timestamp`.
- The irreversible block number, id, and timestamp will be reported as `irreversible_number`, `irreversible_id`, and `irreversible_timestamp`.
- The _last_tracked_block_id, from the chain state object as `last_tracked_block_id`