### PR TITLE
refactor release-build-test to eliminate sole usage of jq

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ apt-get update && apt-get install   \
         cmake                       \
         curl                        \
         git                         \
-        jq                          \
         libboost-all-dev            \
         libcurl4-openssl-dev        \
         libssl-dev                  \

--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -10,49 +10,13 @@ echo 'asserts. This test checks that debug flag. Anyone intending to build and i
 echo 'nodeos from source should perform a "release build" which excludes asserts and'
 echo 'debugging symbols, and performs compiler optimizations.'
 echo ''
-# check for jq
-if ! $(jq --version 1>/dev/null); then
-    echo 'ERROR: Test requires jq, but jq was not found in your PATH!'
-    echo ''
-    exit 1
-fi
-# find nodeos
-[[ $(git --version) ]] && cd "$(git rev-parse --show-toplevel)/build/programs/nodeos" || cd "$(dirname "${BASH_SOURCE[0]}")/../programs/nodeos"
-if [[ ! -f nodeos ]]; then
-    echo 'ERROR: nodeos binary not found!'
-    echo ''
-    echo 'I looked here...'
-    echo "$ ls -la \"$(pwd)/programs/nodeos\""
-    ls -la "$(pwd)/programs/nodeos"
-    echo '...which I derived from one of these paths:'
-    echo '$ echo "$(git rev-parse --show-toplevel)/build"'
-    echo "$(git rev-parse --show-toplevel)/build"
-    echo '$ echo "$(dirname "${BASH_SOURCE[0]}")/.."'
-    echo "$(dirname "${BASH_SOURCE[0]}")/.."
-    echo 'Release build test not run.'
-    exit 1
-fi
-# run nodeos to generate state files
-./nodeos --extract-build-info build-info.json 1>/dev/null 2>/dev/null
-if [[ ! -f build-info.json ]]; then
-    echo 'ERROR: Build info JSON file not found!'
-    echo ''
-    echo 'Looked in the following places:'
-    echo "$ ls -la \"$(pwd)\""
-    ls -la "$(pwd)"
-    echo 'Release build test not run.'
-    exit 2
-fi
-# test state files for debug flag
-if [[ "$(cat build-info.json | jq .debug)" == 'false' ]]; then
+
+NODEOS_DEBUG=$(programs/nodeos/nodeos --extract-build-info >(python3 -c 'import json,sys; print(json.load(sys.stdin)["debug"]);') &> /dev/null)
+if [[ "${NODEOS_DEBUG,,}" == 'false' ]]; then
     echo 'PASS: Debug flag is not set.'
     echo ''
-    rm build-info.json
     exit 0
 fi
+
 echo 'FAIL: Debug flag is set!'
-echo ''
-echo '$ cat build-info.json | jq .'
-cat build-info.json | jq .
-rm build-info.json
 exit 3


### PR DESCRIPTION
Refactor out the sole usage of `jq`. Python is already a requirement to run tests so lean on that instead. Removes `jq` from being a requirement.