### PR TITLE
increase HTTP server's default maximum POST size to 2MB

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -193,7 +193,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          string                         access_control_allow_headers;
          string                         access_control_max_age;
          bool                           access_control_allow_credentials = false;
-         size_t                         max_body_size{1024*1024};
+         size_t                         max_body_size{2*1024*1024};
 
          websocket_server_type    server;
 
@@ -695,7 +695,7 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
                 if( v ) fc_ilog( logger, "configured http with Access-Control-Allow-Credentials: true" );
              })->default_value(false),
              "Specify if Access-Control-Allow-Credentials: true should be returned on each request.")
-            ("max-body-size", bpo::value<uint32_t>()->default_value(1024*1024),
+            ("max-body-size", bpo::value<uint32_t>()->default_value(my->max_body_size),
              "The maximum body size in bytes allowed for incoming RPC requests")
             ("http-max-bytes-in-flight-mb", bpo::value<uint32_t>()->default_value(500),
              "Maximum size in megabytes http_plugin should use for processing http requests. 503 error response when exceeded." )


### PR DESCRIPTION
I'd say at least once a month I see a user ensnared by the HTTP server's default maximum POST size when trying to set a "large" (512KB-1MB) contract on their account. There's even a recent open issue in b1's repo with someone who fell victim to this trap (EOSIO/eos#11085)

The reason this problem creeps up is because the WASM in the request sent to the HTTP server in keosd is encoded as a hex byte array, effectively doubling its size in the POST payload.

#153 improves the error message in this situation. But I really can't see any downside to just increasing the default limit to 2MB. This allows users to set contracts up to just under 1MB in size -- the maximum size cleos can set contract code to as-is anyways. A 2MB instead of 1MB limit would even seem unlikely to impact a nodeos RPC node exposed publicly with no proxy protection in front of it.