### PR TITLE
Updates to get_transaction_status handling.

### DIFF
--- a/docs/02_cleos/03_command-reference/get/transaction-status.md
+++ b/docs/02_cleos/03_command-reference/get/transaction-status.md
@@ -1,6 +1,10 @@
 ## Description
 
-Gets current blockchain state and, if available, transaction information given the transaction id
+Gets current blockchain state and, if available, transaction information given the transaction id.
+
+For query to work, the transaction finality status feature must be enabled by configuring
+the chain plugin with the config option "--transaction-finality-status-max-storage-size-gb <size>"
+in nodeos.
 
 ## Position Parameters
 

--- a/docs/02_cleos/03_command-reference/get/transaction-status.md
+++ b/docs/02_cleos/03_command-reference/get/transaction-status.md
@@ -8,7 +8,7 @@ in nodeos.
 
 ## Position Parameters
 
-- `id` _TEXT_ - The string ID of the transaction to retrieve status about (required)
+- `id` _TEXT_ - The transaction ID of the transaction to retrieve status about (required)
 
 ## Options
 - `-h` - --help                   Print this help message and exit

--- a/docs/02_cleos/03_command-reference/get/transaction-status.md
+++ b/docs/02_cleos/03_command-reference/get/transaction-status.md
@@ -30,6 +30,7 @@ This command simply returns the current chain status and transaction status info
     "irreversible_number": 25,
     "irreversible_id": "0000001922118216bc16bf2c60d950598d80af3beca820eab751f7beecdb29e4",
     "irreversible_timestamp": "2022-04-27T16:10:54.000",
-    "last_tracked_block_id": "000000129cee97f3e27312f0184d52d006a470f0e620553dfb4c5b4f3c856ab2"
+    "last_tracked_block_id": "000000129cee97f3e27312f0184d52d006a470f0e620553dfb4c5b4f3c856ab2",
+    "last_tracked_block_number": 18
 }
 ```

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -161,7 +161,6 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200),
       CHAIN_RO_CALL(get_required_keys, 200),
       CHAIN_RO_CALL(get_transaction_id, 200),
-      CHAIN_RO_CALL_WITH_400(get_transaction_status, 200),
       CHAIN_RO_CALL_ASYNC_WITH_400(compute_transaction, chain_apis::read_only::compute_transaction_results, 200),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),
@@ -173,6 +172,12 @@ void chain_api_plugin::plugin_startup() {
    if (chain.account_queries_enabled()) {
       _http_plugin.add_async_api({
          CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
+      });
+   }
+
+   if (chain.transaction_finality_status_enabled()) {
+      _http_plugin.add_async_api({
+         CHAIN_RO_CALL_WITH_400(get_transaction_status, 200),
       });
    }
 }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1693,21 +1693,11 @@ read_only::get_info_results read_only::get_info(const read_only::get_info_params
 }
 
 read_only::get_transaction_status_results read_only::get_transaction_status(const read_only::get_transaction_status_params& param) const {
-   transaction_id_type input_id;
-   auto input_id_length = param.id.size();
-   try
-   {
-      FC_ASSERT(input_id_length <= 64, "hex string is too long to represent an actual transaction id");
-      FC_ASSERT(input_id_length >= 8, "hex string representing transaction id should be at least 8 characters long to avoid excessive collisions");
-      input_id = transaction_id_type(param.id);
-   }
-   EOS_RETHROW_EXCEPTIONS(transaction_id_type_exception, "Invalid transaction ID: ${transaction_id}", ("transaction_id", param.id))
-
    EOS_ASSERT(trx_finality_status_proc, unsupported_feature, "Transaction Status Interface not enabled.  To enable, configure nodeos with '--transaction-finality-status-max-storage-size-gb <size>'.");
 
    trx_finality_status_processing::chain_state ch_state = trx_finality_status_proc->get_chain_state();
 
-   auto trx_st = trx_finality_status_proc->get_trx_state(input_id);
+   auto trx_st = trx_finality_status_proc->get_trx_state(param.id);
 
    return {
       trx_st ? trx_st->status : "UNKNOWN",

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1649,6 +1649,9 @@ bool chain_plugin::account_queries_enabled() const {
    return my->account_queries_enabled;
 }
 
+bool chain_plugin::transaction_finality_status_enabled() const {
+   return my->_trx_finality_status_processing.get();
+}
 
 namespace chain_apis {
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1718,7 +1718,8 @@ read_only::get_transaction_status_results read_only::get_transaction_status(cons
       chain::block_header::num_from_id(ch_state.irr_id),
       ch_state.irr_id,
       ch_state.irr_block_timestamp,
-      ch_state.last_tracked_block_id
+      ch_state.last_tracked_block_id,
+      chain::block_header::num_from_id(ch_state.last_tracked_block_id)
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -145,6 +145,7 @@ public:
       chain::block_id_type                 irreversible_id;
       fc::time_point                       irreversible_timestamp;
       chain::block_id_type                 last_tracked_block_id;
+      uint32_t                             last_tracked_block_number = 0;
    };
    get_transaction_status_results get_transaction_status(const get_transaction_status_params& params) const;
 
@@ -815,7 +816,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)(total_cpu_weight)(total_net_weight) )
 FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_params, (id) )
 FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_results, (state)(block_number)(block_id)(block_timestamp)(expiration)(head_number)(head_id)
-           (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(last_tracked_block_id) )
+           (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(last_tracked_block_id)(last_tracked_block_number) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -129,7 +129,7 @@ public:
    get_info_results get_info(const get_info_params&) const;
 
    struct get_transaction_status_params {
-      string                               id;
+      chain::transaction_id_type           id;
    };
 
    struct get_transaction_status_results {

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -799,6 +799,7 @@ public:
    static void handle_bad_alloc();
 
    bool account_queries_enabled() const;
+   bool transaction_finality_status_enabled() const;
 private:
    static void log_guard_exception(const chain::guard_exception& e);
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2634,11 +2634,17 @@ int main( int argc, char** argv ) {
    });
 
    // get transaction status
-   string status_transaction_id_str;
+   string status_transaction_id;
    auto getTransactionStatus = get->add_subcommand("transaction-status", localized("Get transaction status information"));
-   getTransactionStatus->add_option("id", status_transaction_id_str, localized("ID of the transaction to retrieve"))->required();
-   getTransactionStatus->callback([&status_transaction_id_str] {
-      auto arg= fc::mutable_variant_object( "id", status_transaction_id_str);
+   getTransactionStatus->add_option("id", status_transaction_id, localized("ID of the transaction to retrieve"))->required();
+   getTransactionStatus->callback([&status_transaction_id] {
+      try {
+         chain::transaction_id_type transaction_id(status_transaction_id);
+      } catch (...) {
+         std::cerr << "Unable to convert " << status_transaction_id << " to transaction id." << std::endl;
+         throw;
+      }
+      auto arg= fc::mutable_variant_object( "id", status_transaction_id);
       std::cout << fc::json::to_pretty_string(call(get_transaction_status_func, arg)) << std::endl;
    });
 


### PR DESCRIPTION
### This PR addresses issues raised around _transaction finality status_ feature and `get_transaction_status` request handling.

### Limit exposure of `get_transaction_status`
Addresses the need to limit the exposure of the `get_transaction_status` request endpoint to those times when the _transaction-finality-status_ feature has been enabled.

Result of trying to exercise the `get_transaction_status` endpoing when chain_plugin was not configured to enable the _transaction-finality-status_.

**curl -v -d '{}' http://localhost:8788/v1/chain/get_transaction_status**

> HTTP/1.1 404 Not Found
> 
> {"code":404,"message":"Not Found","error":{"code":0,"name":"exception","what":"unspecified","details":[{"message":"Unknown Endpoint","file":"http_plugin.cpp","line_number":590,"method":"handle_http_request"}]}}


### Better http responses for `get_transaction_status` requests
Addresses the need to provide better http responses when no transaction id is provided to the `get_transaction_status` endpoint.

Previously a request without providing a transaction id would respond with a status 500.  With the updates the status now properly returns a 400 when no transaction id is provided, and a 200 when a transaction id is provided as seen in the statuses provided below.

**curl -v -d ''  http://localhost:8788/v1/chain/get_transaction_status**
> HTTP/1.1 400 Bad Request
>
> {"code":400,"message":"Invalid Request","error":{"code":3200006,"name":"invalid_http_request","what":"invalid http request","details":[{"message":"A Request body is required","file":"chain_api_plugin.cpp","line_number":38,"method":"parse_params"}]}}

**curl -v -d '{}' http://localhost:8788/v1/chain/get_transaction_status**

> HTTP/1.1 200 OK
> 
> {"state":"UNKNOWN","head_number":339,"head_id":"00000153fad376452e8ddd078872eb5cdd49c279c9e06d4ff419054f8c0ff2be","head_timestamp":"2022-04-29T13:00:45.500","irreversible_number":23,"irreversible_id":"0000001729b10465f55861de741030ef043b20724bc3af693dbc84234ac41ee4","irreversible_timestamp":"2022-04-29T12:58:07.500","last_tracked_block_id":"000000127bcb84f96dad3522e4ece08dd512ef770ca8c534ec52c763035b1e9a","last_tracked_block_number":18}

### Added Block Number for last tracked block to result

The get transaction status result now includes the block number for the last tracked block.

`
{
  "state": "IN_BLOCK",
  "block_number": 53,
  "block_id": "00000035a6a95839ecd39375825740c7335744dcc910962505165e4357b7fa05",
  "block_timestamp": "2022-04-29T12:58:22.500",
  "expiration": "2022-04-29T12:58:52.000",
  "head_number": 147,
  "head_id": "00000093e76c8092053e13abf968df190288bd674279641a801fe0052d7b18cf",
  "head_timestamp": "2022-04-29T12:59:09.500",
  "irreversible_number": 23,
  "irreversible_id": "0000001729b10465f55861de741030ef043b20724bc3af693dbc84234ac41ee4",
  "irreversible_timestamp": "2022-04-29T12:58:07.500",
  "last_tracked_block_id": "000000127bcb84f96dad3522e4ece08dd512ef770ca8c534ec52c763035b1e9a",
  "last_tracked_block_number": 18
}
`