### PR TITLE
remove std::iterator<> usage

### DIFF
--- a/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
+++ b/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
@@ -151,7 +151,14 @@ public:
 
    const protocol_feature& add_feature( const builtin_protocol_feature& f );
 
-   class const_iterator : public std::iterator<std::bidirectional_iterator_tag, const protocol_feature> {
+   class const_iterator {
+   public:
+      using iterator_category = std::bidirectional_iterator_tag;
+      using value_type = const protocol_feature;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const protocol_feature*;
+      using reference = const protocol_feature&;
+
    protected:
       protocol_feature_set_type::const_iterator _itr;
 
@@ -252,7 +259,14 @@ public:
 
    protocol_feature_manager( protocol_feature_set&& pfs, std::function<deep_mind_handler*()> get_deep_mind_logger );
 
-   class const_iterator : public std::iterator<std::bidirectional_iterator_tag, const protocol_feature> {
+   class const_iterator {
+   public:
+      using iterator_category = std::bidirectional_iterator_tag;
+      using value_type = const protocol_feature;
+      using difference_type = std::ptrdiff_t;
+      using pointer = const protocol_feature*;
+      using reference = const protocol_feature&;
+
    protected:
       const protocol_feature_manager* _pfm = nullptr;
       std::size_t                     _index = 0;

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -278,6 +278,10 @@ namespace eosio { namespace chain {
 
    public:
       using iterator_category = std::output_iterator_tag;
+      using value_type = void;
+      using difference_type = void;
+      using pointer = void;
+      using reference = void;
 
       using container_type = Container;
 

--- a/libraries/chain/include/eosio/chain/types.hpp
+++ b/libraries/chain/include/eosio/chain/types.hpp
@@ -271,12 +271,14 @@ namespace eosio { namespace chain {
 
 
    template<typename Container>
-   class end_insert_iterator : public std::iterator< std::output_iterator_tag, void, void, void, void >
+   class end_insert_iterator
    {
    protected:
       Container* container;
 
    public:
+      using iterator_category = std::output_iterator_tag;
+
       using container_type = Container;
 
       explicit end_insert_iterator( Container& c )


### PR DESCRIPTION
`std::iterator<>` was depreciated in C++17. gcc 12 (well, actually libstdc++ 12) is getting chatty about this. Remove usage of it.