### PR TITLE
remove unused checktime & call depth wasm injection

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/intrinsic_mapping.hpp
@@ -22,8 +22,8 @@ inline constexpr auto get_intrinsic_table() {
       "eosvmoc_internal.indirect_call_mismatch",
       "eosvmoc_internal.indirect_call_oob",
       "eosvmoc_internal.depth_assert",
-      "eosio_injection.call_depth_assert",  //these two are never used by EOS VM OC but all intrinsics
-      "eosio_injection.checktime",          //must be mapped
+      "eosio_injection.call_depth_assert",  //now unused; left for purposes of not upsetting existing code mappings
+      "eosio_injection.checktime",          //now unused; left for purposes of not upsetting existing code mappings
       "env.__ashlti3",
       "env.__ashrti3",
       "env.__lshlti3",

--- a/libraries/chain/wasm_eosio_injection.cpp
+++ b/libraries/chain/wasm_eosio_injection.cpp
@@ -1,10 +1,7 @@
 #include <eosio/chain/wasm_eosio_constraints.hpp>
 #include <eosio/chain/wasm_eosio_injection.hpp>
-#include <eosio/chain/wasm_eosio_binary_ops.hpp>
 #include <fc/exception/exception.hpp>
-#include <eosio/chain/exceptions.hpp>
 #include "IR/Module.h"
-#include "IR/Operators.h"
 #include "WASM/WASM.h"
 
 namespace eosio { namespace chain { namespace wasm_injections {
@@ -29,19 +26,5 @@ void data_segments_injection_visitor::inject( Module& m ) {
 }
 void data_segments_injection_visitor::initializer() {
 }
-
-int32_t  call_depth_check_and_insert_checktime::global_idx = -1;
-uint32_t instruction_counter::icnt = 0;
-uint32_t instruction_counter::tcnt = 0;
-uint32_t instruction_counter::bcnt = 0;
-std::queue<uint32_t> instruction_counter::fcnts;
-
-int32_t  checktime_injection::idx = 0;
-int32_t  checktime_injection::chktm_idx = 0;
-std::stack<size_t>                   checktime_block_type::block_stack;
-std::stack<size_t>                   checktime_block_type::type_stack;
-std::queue<std::vector<size_t>>      checktime_block_type::orderings;
-std::queue<std::map<size_t, size_t>> checktime_block_type::bcnt_tables;
-size_t  checktime_function_end::fcnt = 0;
 
 }}} // namespace eosio, chain, injectors

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/compile_trampoline.cpp
@@ -27,7 +27,7 @@ void run_compile(wrapped_fd&& response_sock, wrapped_fd&& wasm_code) noexcept { 
    WASM::scoped_skip_checks no_check;
    WASM::serialize(stream, module);
    module.userSections.clear();
-   wasm_injections::wasm_binary_injection<false> injector(module);
+   wasm_injections::wasm_binary_injection injector(module);
    injector.inject();
 
    instantiated_code code = LLVMJIT::instantiateModule(module);


### PR DESCRIPTION
In EOSIO 2.0, two sets of WASM injection configurations were used:
* for wabt: softfloat, call depth, and checktime
* for EOS VM OC: softfloat

With the removal of wabt call depth and checktime injections are no longer required. Remove them.