### PR TITLE
Rename last_tracked_* to earliest_tracked_*

### DIFF
--- a/docs/02_cleos/03_command-reference/get/transaction-status.md
+++ b/docs/02_cleos/03_command-reference/get/transaction-status.md
@@ -34,7 +34,7 @@ This command simply returns the current chain status and transaction status info
     "irreversible_number": 25,
     "irreversible_id": "0000001922118216bc16bf2c60d950598d80af3beca820eab751f7beecdb29e4",
     "irreversible_timestamp": "2022-04-27T16:10:54.000",
-    "last_tracked_block_id": "000000129cee97f3e27312f0184d52d006a470f0e620553dfb4c5b4f3c856ab2",
-    "last_tracked_block_number": 18
+    "earliest_tracked_block_id": "000000129cee97f3e27312f0184d52d006a470f0e620553dfb4c5b4f3c856ab2",
+    "earliest_tracked_block_number": 18
 }
 ```

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1717,8 +1717,8 @@ read_only::get_transaction_status_results read_only::get_transaction_status(cons
       chain::block_header::num_from_id(ch_state.irr_id),
       ch_state.irr_id,
       ch_state.irr_block_timestamp,
-      ch_state.last_tracked_block_id,
-      chain::block_header::num_from_id(ch_state.last_tracked_block_id)
+      ch_state.earliest_tracked_block_id,
+      chain::block_header::num_from_id(ch_state.earliest_tracked_block_id)
    };
 }
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -144,8 +144,8 @@ public:
       uint32_t                             irreversible_number = 0;
       chain::block_id_type                 irreversible_id;
       fc::time_point                       irreversible_timestamp;
-      chain::block_id_type                 last_tracked_block_id;
-      uint32_t                             last_tracked_block_number = 0;
+      chain::block_id_type                 earliest_tracked_block_id;
+      uint32_t                             earliest_tracked_block_number = 0;
    };
    get_transaction_status_results get_transaction_status(const get_transaction_status_params& params) const;
 
@@ -817,7 +817,7 @@ FC_REFLECT(eosio::chain_apis::read_only::get_info_results,
            (server_version_string)(fork_db_head_block_num)(fork_db_head_block_id)(server_full_version_string)(total_cpu_weight)(total_net_weight) )
 FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_params, (id) )
 FC_REFLECT(eosio::chain_apis::read_only::get_transaction_status_results, (state)(block_number)(block_id)(block_timestamp)(expiration)(head_number)(head_id)
-           (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(last_tracked_block_id)(last_tracked_block_number) )
+           (head_timestamp)(irreversible_number)(irreversible_id)(irreversible_timestamp)(earliest_tracked_block_id)(earliest_tracked_block_number) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_params, (lower_bound)(upper_bound)(limit)(search_by_block_num)(reverse) )
 FC_REFLECT(eosio::chain_apis::read_only::get_activated_protocol_features_results, (activated_protocol_features)(more) )
 FC_REFLECT(eosio::chain_apis::read_only::get_block_params, (block_num_or_id))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/trx_finality_status_processing.hpp
@@ -22,7 +22,7 @@ namespace eosio::chain_apis {
          chain::block_timestamp_type   head_block_timestamp;
          chain::block_id_type          irr_id;
          chain::block_timestamp_type   irr_block_timestamp;
-         chain::block_id_type          last_tracked_block_id;
+         chain::block_id_type          earliest_tracked_block_id;
       };
 
       struct trx_state {

--- a/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/test/test_trx_finality_status_processing.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    auto cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == eosio::chain::block_id_type{});
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == eosio::chain::block_id_type{});
+   BOOST_CHECK(cs.earliest_tracked_block_id == eosio::chain::block_id_type{});
 
    using op_ts = std::optional<eosio::chain_apis::trx_finality_status_processing::trx_state>;
 
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_20->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == bs_20->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_20->id);
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
    BOOST_REQUIRE(ts);
@@ -303,7 +303,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_21->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == bs_20->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_20->id);
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
    BOOST_REQUIRE(ts);
@@ -369,7 +369,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_22->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == bs_20->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_20->id);
 
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_22_alt->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == bs_20->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_20->id);
 
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
@@ -525,7 +525,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_19->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == bs_19->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_19->id);
 
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
@@ -620,7 +620,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == bs_19_alt->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == bs_19_alt->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_19_alt->id);
 
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_logic) { try {
    BOOST_CHECK(cs.head_id == bs_19_alt->id);
    BOOST_CHECK(cs.irr_id == bs_19_alt->id);
    BOOST_CHECK(cs.irr_block_timestamp == bs_19_alt->block->timestamp);
-   BOOST_CHECK(cs.last_tracked_block_id == bs_19_alt->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == bs_19_alt->id);
 
 
    ts = status.get_trx_state(std::get<1>(trx_pairs_20[0])->id());
@@ -990,7 +990,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_storage_reduction) { try {
    auto cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == b_11.bs->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == b_01.bs->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == b_01.bs->id);
 
    // Test expects the next block range to exceed max_storage. Need to adjust
    // this test if this fails.
@@ -1009,7 +1009,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_storage_reduction) { try {
    BOOST_CHECK(cs.head_block_timestamp == b_12.bs->block->timestamp);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
    BOOST_CHECK(cs.irr_block_timestamp == eosio::chain::block_timestamp_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == b_03.bs->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == b_03.bs->id);
 
 
    b_01.verify_spec_block_not_there();
@@ -1127,7 +1127,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_lifespan) { try {
    auto cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == b_06.bs->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == b_02.bs->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == b_02.bs->id);
 
 
    block_frame b_07(status, "04:44:30.500");
@@ -1146,7 +1146,7 @@ BOOST_AUTO_TEST_CASE(trx_finality_status_lifespan) { try {
    cs = status.get_chain_state();
    BOOST_CHECK(cs.head_id == b_07.bs->id);
    BOOST_CHECK(cs.irr_id == eosio::chain::block_id_type{});
-   BOOST_CHECK(cs.last_tracked_block_id == b_03.bs->id);
+   BOOST_CHECK(cs.earliest_tracked_block_id == b_03.bs->id);
 
 
    block_frame b_08(status, "04:44:35.500");

--- a/plugins/chain_plugin/trx_finality_status_processing.cpp
+++ b/plugins/chain_plugin/trx_finality_status_processing.cpp
@@ -28,7 +28,7 @@ namespace eosio::chain_apis {
       chain::block_timestamp_type                      _head_block_timestamp;
       chain::block_id_type                             _irr_block_id;
       chain::block_timestamp_type                      _irr_block_timestamp;
-      chain::block_id_type                             _last_tracked_block_id;
+      chain::block_id_type                             _earliest_tracked_block_id;
       const fc::microseconds                           _success_duration;
       const fc::microseconds                           _failure_duration;
    };
@@ -107,7 +107,7 @@ namespace eosio::chain_apis {
          // find the lowest value successful block
          auto success_iter = indx.lower_bound(boost::make_tuple(true, fc::time_point{}));
          if (success_iter != indx.cend()) {
-            _last_tracked_block_id = success_iter->block_id;
+            _earliest_tracked_block_id = success_iter->block_id;
          }
       }
 
@@ -239,7 +239,7 @@ namespace eosio::chain_apis {
    }
 
    trx_finality_status_processing::chain_state trx_finality_status_processing::get_chain_state() const {
-      return { .head_id = _my->_head_block_id, .head_block_timestamp = _my->_head_block_timestamp, .irr_id = _my->_irr_block_id, .irr_block_timestamp = _my->_irr_block_timestamp, .last_tracked_block_id = _my->_last_tracked_block_id };
+      return { .head_id = _my->_head_block_id, .head_block_timestamp = _my->_head_block_timestamp, .irr_id = _my->_irr_block_id, .irr_block_timestamp = _my->_irr_block_timestamp, .earliest_tracked_block_id = _my->_earliest_tracked_block_id };
    }
 
    std::optional<trx_finality_status_processing::trx_state> trx_finality_status_processing::get_trx_state( const chain::transaction_id_type& id ) const {


### PR DESCRIPTION
- Address issue: https://github.com/eosnetworkfoundation/mandel/issues/176
- Alleviate confusion around `last_` actually  typically meaning current when referring to blocks.  Clear up by going with a more clear definition of `earliest_`.

### Updated Transaction Status Result
Transaction status result should now look like the following:
```
{
  "state": "UNKNOWN",
  "head_number": 11807884,
  "head_id": "00b42c8c15d2a75cf8410153b637855e4842dbc18c852446b1dbf783452a41f8",
  "head_timestamp": "2022-05-02T18:06:21.000",
  "irreversible_number": 11807553,
  "irreversible_id": "00b42b41281540815209d6d04c760b4f53ef37c3137c8dd8550f124557912ea4",
  "irreversible_timestamp": "2022-05-02T18:03:29.500",
  "earliest_tracked_block_id": "00b411ce8263d756c087f9b1b5636d0f05169de3764d7d52e0cd902f3bd284ec",
  "earliest_tracked_block_number": 11801038
}
```