### PR TITLE
fixing flakiness in voting and forked chain tests

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2755,7 +2755,11 @@ namespace eosio {
       }
       if( msg.reason == wrong_version ) {
          if( !retry ) no_retry = fatal_other; // only retry once on wrong version
-      } else {
+      }
+      else if ( msg.reason == benign_other ) {
+         if ( retry ) fc_dlog( logger, "received benign_other reason, retrying to connect");
+      }
+      else {
          retry = false;
       }
       flush_queues();

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2757,7 +2757,7 @@ namespace eosio {
          if( !retry ) no_retry = fatal_other; // only retry once on wrong version
       }
       else if ( msg.reason == benign_other ) {
-         if ( retry ) fc_dlog( logger, "received benign_other reason, retrying to connect");
+         if ( retry ) peer_dlog( this, "received benign_other reason, retrying to connect");
       }
       else {
          retry = false;

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1182,7 +1182,10 @@ class Node(object):
         # The voted schedule should be promoted now, then need to wait for that to become irreversible
         votingTallyWindow=120  #could be up to 120 blocks before the votes were tallied
         promotedBlockNum=self.getHeadBlockNum()+votingTallyWindow
-        self.waitForIrreversibleBlock(promotedBlockNum, timeout=rounds/2)
+        # There was waitForIrreversibleBlock but due to bug it was waiting for head and not lib.
+        # leaving waitForIrreversibleBlock here slows down voting test by few minutes so since
+        # it was fine with head block for few years, switching to waitForBlock instead
+        self.waitForBlock(promotedBlockNum, timeout=rounds/2)
 
         ibnSchedActive=self.getIrreversibleBlockNum()
 


### PR DESCRIPTION
### Resolve flakiness in nodeos_voting_lr_test and nodeos_forked_chain_lr_test
This is a port of a fix from the EOS PR 11022: https://github.com/EOSIO/eos/pull/11022

Fixes:

1. nodeos_voting_lr_test. It was broken after bugfix in `Node.waitForIrreversibleBlock` where it was waiting for head instead of lib. After fix this increased execution time and lead to timeout fails.
2. nodeos_forked_chain_lr_test. It had flakiness due to race condition in head catchup and switching forks that lead to `go_away_message` being sent with status `benign_other` due to unknown block requested. Fix adding retry after closing connection.