### PR TITLE
fixup behavior of force-all-checks & disable-replay-opts to match likely expectation

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3122,7 +3122,7 @@ std::optional<producer_authority_schedule> controller::proposed_producers()const
    return producer_authority_schedule::from_shared(gpo.proposed_schedule);
 }
 
-bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) const {
+bool controller::light_validation_allowed() const {
    if (!my->pending || my->in_trx_requiring_checks) {
       return false;
    }
@@ -3130,7 +3130,8 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
    const auto pb_status = my->pending->_block_status;
 
    // in a pending irreversible or previously validated block and we have forcing all checks
-   const bool consider_skipping_on_replay = (pb_status == block_status::irreversible || pb_status == block_status::validated) && !replay_opts_disabled_by_policy;
+   const bool consider_skipping_on_replay =
+         (pb_status == block_status::irreversible || pb_status == block_status::validated) && !my->conf.force_all_checks;
 
    // OR in a signed block and in light validation mode
    const bool consider_skipping_on_validate = (pb_status == block_status::complete &&
@@ -3141,7 +3142,11 @@ bool controller::light_validation_allowed(bool replay_opts_disabled_by_policy) c
 
 
 bool controller::skip_auth_check() const {
-   return light_validation_allowed(my->conf.force_all_checks);
+   return light_validation_allowed();
+}
+
+bool controller::skip_trx_checks() const {
+   return light_validation_allowed();
 }
 
 bool controller::skip_db_sessions( block_status bs ) const {
@@ -3151,16 +3156,12 @@ bool controller::skip_db_sessions( block_status bs ) const {
       && !my->in_trx_requiring_checks;
 }
 
-bool controller::skip_db_sessions( ) const {
+bool controller::skip_db_sessions() const {
    if (my->pending) {
       return skip_db_sessions(my->pending->_block_status);
    } else {
       return false;
    }
-}
-
-bool controller::skip_trx_checks() const {
-   return light_validation_allowed(my->conf.force_all_checks);
 }
 
 bool controller::is_trusted_producer( const account_name& producer) const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3160,7 +3160,7 @@ bool controller::skip_db_sessions( ) const {
 }
 
 bool controller::skip_trx_checks() const {
-   return light_validation_allowed(my->conf.disable_replay_opts);
+   return light_validation_allowed(my->conf.force_all_checks);
 }
 
 bool controller::is_trusted_producer( const account_name& producer) const {

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -277,11 +277,11 @@ namespace eosio { namespace chain {
 
          int64_t set_proposed_producers( vector<producer_authority> producers );
 
-         bool light_validation_allowed(bool replay_opts_disabled_by_policy) const;
+         bool light_validation_allowed() const;
          bool skip_auth_check()const;
-         bool skip_db_sessions( )const;
-         bool skip_db_sessions( block_status bs )const;
          bool skip_trx_checks()const;
+         bool skip_db_sessions()const;
+         bool skip_db_sessions( block_status bs )const;
          bool is_trusted_producer( const account_name& producer) const;
 
          bool contracts_console()const;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -358,7 +358,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("extract-build-info", bpo::value<bfs::path>(),
           "extract build environment information as JSON, write into specified file, and exit")
          ("force-all-checks", bpo::bool_switch()->default_value(false),
-          "do not skip any checks that can be skipped while replaying irreversible blocks")
+          "do not skip any validation checks while replaying blocks (useful for replaying blocks from untrusted source)")
          ("disable-replay-opts", bpo::bool_switch()->default_value(false),
           "disable optimizations that specifically target replay")
          ("replay-blockchain", bpo::bool_switch()->default_value(false),


### PR DESCRIPTION
This ports over EOSIO/eos#8848

> The implementation of the following options were changed to more closely reflect their descriptions.
> - `force-all-checks`
>          do not skip any validation checks while replaying blocks (useful for replaying blocks from untrusted source)
> - `disable-replay-opts`
>          disable optimizations that specifically target replay
>
> Previously `disable-replay-opts` was tied to skipping transaction validation checks during replay. However, the existing option `force-all-checks` is a better indication of this functionality. Now `disable-replay-opts` only disables **optimizations** during replay; specifically the creation of database undo sessions. Now `force-all-checks` enforces the additional transaction validation checks that can be skipped when blocks are from a trusted source.
>
> `controller::skip_trx_checks()` and `controller::skip_auth_check()` both now respect the `force-all-checks` option.

Came over cleanly. One dropped commit as it was a no-op in Mandel.