### PR TITLE
Do not limit transaction deadline if subjective billing disabled for account

### DIFF
--- a/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
+++ b/plugins/producer_plugin/include/eosio/producer_plugin/subjective_billing.hpp
@@ -114,7 +114,7 @@ public: // public for tests
 public:
    void disable() { _disabled = true; }
    void disable_account( chain::account_name a ) { _disabled_accounts.emplace( a ); }
-   bool is_account_disabled(const account_name& a ) const { return _disabled_accounts.count( a ); }
+   bool is_account_disabled(const account_name& a ) const { return _disabled || _disabled_accounts.count( a ); }
 
    /// @param in_pending_block pass true if pt's bill time is accounted for in the pending block
    void subjective_bill( const transaction_id_type& id, const fc::time_point& expire, const account_name& first_auth,

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1953,7 +1953,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
             if( max_trx_time.count() < 0 ) max_trx_time = fc::microseconds::maximum();
 
             auto prev_billed_cpu_time_us = trx->billed_cpu_time_us;
-            if( prev_billed_cpu_time_us > 0 && !rl.is_unlimited_cpu( first_auth )) {
+            if( prev_billed_cpu_time_us > 0 && !_subjective_billing.is_account_disabled( first_auth ) && !rl.is_unlimited_cpu( first_auth )) {
                uint64_t prev_billed_plus100_us = prev_billed_cpu_time_us + EOS_PERCENT( prev_billed_cpu_time_us, 100 * config::percent_1 );
                if( prev_billed_plus100_us < max_trx_time.count() ) max_trx_time = fc::microseconds( prev_billed_plus100_us );
             }

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -963,6 +963,12 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_cpu_extended_test) { try {
    cfg.min_transaction_cpu_usage  = 1;
 
    tester t( conf_genesis.first, conf_genesis.second );
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // eos_vm_oc wasm_runtime does not tier-up and completes compile before continuing execution.
+      // A completely different test with different constraints would be needed to test with eos_vm_oc.
+      // Since non-tier-up is not a normal valid nodeos runtime, just skip this test for eos_vm_oc.
+      return;
+   }
    t.execute_setup_policy( setup_policy::full );
    t.produce_blocks(2);
    t.create_account( "pause"_n );
@@ -1020,6 +1026,12 @@ BOOST_AUTO_TEST_CASE(checktime_pause_max_trx_extended_test) { try {
    cfg.min_transaction_cpu_usage  = 1;
 
    tester t( conf_genesis.first, conf_genesis.second );
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // eos_vm_oc wasm_runtime does not tier-up and completes compile before continuing execution.
+      // A completely different test with different constraints would be needed to test with eos_vm_oc.
+      // Since non-tier-up is not a normal valid nodeos runtime, just skip this test for eos_vm_oc.
+      return;
+   }
    t.execute_setup_policy( setup_policy::full );
    t.produce_blocks(2);
    t.create_account( "pause"_n );
@@ -1059,6 +1071,12 @@ BOOST_AUTO_TEST_CASE(checktime_pause_block_deadline_not_extended_test) { try {
    cfg.min_transaction_cpu_usage  = 1;
 
    tester t( conf_genesis.first, conf_genesis.second );
+   if( t.get_config().wasm_runtime == wasm_interface::vm_type::eos_vm_oc ) {
+      // eos_vm_oc wasm_runtime does not tier-up and completes compile before continuing execution.
+      // A completely different test with different constraints would be needed to test with eos_vm_oc.
+      // Since non-tier-up is not a normal valid nodeos runtime, just skip this test for eos_vm_oc.
+      return;
+   }
    t.execute_setup_policy( setup_policy::full );
    t.produce_blocks(2);
    t.create_account( "pause"_n );


### PR DESCRIPTION
- Transactions were limited to (2 * previous_run_time) when already speculatively executed on a node. Do not impose this restriction when subjective billing is disable or disable for an account.
- Resolves #195