### PR TITLE
Add message body check (400) for http calls

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -126,6 +126,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(abi_bin_to_json, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_required_keys, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_transaction_id, 200, http_params_types::params_required),
+      CHAIN_RO_CALL_ASYNC(compute_transaction, chain_apis::read_only::compute_transaction_results, 200, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202, http_params_types::params_required),

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -31,57 +31,29 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
    }
 };
 
-namespace {
-   template<typename T>
-   T parse_params(const std::string& body) {
-      if (body.empty()) {
-         EOS_THROW(chain::invalid_http_request, "A Request body is required");
-      }
-
-      try {
-        try {
-           return fc::json::from_string(body).as<T>();
-        } catch (const chain::chain_exception& e) { // EOS_RETHROW_EXCEPTIONS does not re-type these so, re-code it
-          throw fc::exception(e);
-        }
-      } EOS_RETHROW_EXCEPTIONS(chain::invalid_http_request, "Unable to parse valid input from POST body");
+// Only want a simple 'Invalid transaction id' if unable to parse the body
+template<>
+chain_apis::read_only::get_transaction_status_params
+parse_params<chain_apis::read_only::get_transaction_status_params, http_params_types::params_required>(const std::string& body) {
+   if (body.empty()) {
+      EOS_THROW(chain::invalid_http_request, "A Request body is required");
    }
 
-   // Only want a simple 'Invalid transaction id' if unable to parse the body
-   template<>
-   chain_apis::read_only::get_transaction_status_params parse_params<chain_apis::read_only::get_transaction_status_params>(const std::string& body) {
-      if (body.empty()) {
-         EOS_THROW(chain::invalid_http_request, "A Request body is required");
-      }
-
-      try {
-         auto v = fc::json::from_string( body ).as<chain_apis::read_only::get_transaction_status_params>();
-         if( v.id == transaction_id_type() ) throw false;
-      } catch( ... ) {
-         EOS_THROW(chain::invalid_http_request, "Invalid transaction id");
-      }
+   try {
+      auto v = fc::json::from_string( body ).as<chain_apis::read_only::get_transaction_status_params>();
+      if( v.id == transaction_id_type() ) throw false;
+      return v;
+   } catch( ... ) {
+      EOS_THROW(chain::invalid_http_request, "Invalid transaction id");
    }
 }
 
-#define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
+#define CALL_WITH_400(api_name, api_handle, api_namespace, call_name, http_response_code, params_type) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
           api_handle.validate(); \
           try { \
-             if (body.empty()) body = "{}"; \
-             fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
-             cb(http_response_code, std::move(result)); \
-          } catch (...) { \
-             http_plugin::handle_exception(#api_name, #call_name, body, cb); \
-          } \
-       }}
-
-#define CALL_WITH_400(api_name, api_handle, api_namespace, call_name, http_response_code) \
-{std::string("/v1/" #api_name "/" #call_name), \
-   [api_handle](string, string body, url_response_callback cb) mutable { \
-          api_handle.validate(); \
-          try { \
-             auto params = parse_params<api_namespace::call_name ## _params>(body);\
+             auto params = parse_params<api_namespace::call_name ## _params, params_type>(body);\
              fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \
           } catch (...) { \
@@ -89,32 +61,12 @@ namespace {
           } \
        }}
 
-#define CALL_ASYNC(api_name, api_handle, api_namespace, call_name, call_result, http_response_code) \
-{std::string("/v1/" #api_name "/" #call_name), \
-   [api_handle](string, string body, url_response_callback cb) mutable { \
-      if (body.empty()) body = "{}"; \
-      api_handle.validate(); \
-      api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>(),\
-         [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
-            if (std::holds_alternative<fc::exception_ptr>(result)) {\
-               try {\
-                  std::get<fc::exception_ptr>(result)->dynamic_rethrow_exception();\
-               } catch (...) {\
-                  http_plugin::handle_exception(#api_name, #call_name, body, cb);\
-               }\
-            } else {\
-               cb(http_response_code, std::visit(async_result_visitor(), result)); \
-            }\
-         });\
-   }\
-}
-
-#define CALL_ASYNC_WITH_400(api_name, api_handle, api_namespace, call_name, call_result, http_response_code) \
+#define CALL_ASYNC_WITH_400(api_name, api_handle, api_namespace, call_name, call_result, http_response_code, params_type) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
       api_handle.validate(); \
       try { \
-         auto params = parse_params<api_namespace::call_name ## _params>(body);\
+         auto params = parse_params<api_namespace::call_name ## _params, params_type>(body);\
          api_handle.call_name( std::move(params),\
             [cb, body](const std::variant<fc::exception_ptr, call_result>& result){\
                if (std::holds_alternative<fc::exception_ptr>(result)) {\
@@ -133,15 +85,12 @@ namespace {
    }\
 }
 
-#define CHAIN_RO_CALL(call_name, http_response_code) CALL(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
-#define CHAIN_RW_CALL(call_name, http_response_code) CALL(chain, rw_api, chain_apis::read_write, call_name, http_response_code)
-#define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
-#define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code) CALL_ASYNC(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
+#define CHAIN_RO_CALL(call_name, http_response_code, params_type) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code, params_type)
+#define CHAIN_RW_CALL(call_name, http_response_code, params_type) CALL_WITH_400(chain, rw_api, chain_apis::read_write, call_name, http_response_code, params_type)
+#define CHAIN_RO_CALL_ASYNC(call_name, call_result, http_response_code, params_type) CALL_ASYNC_WITH_400(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code, params_type)
+#define CHAIN_RW_CALL_ASYNC(call_name, call_result, http_response_code, params_type) CALL_ASYNC_WITH_400(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code, params_type)
 
-#define CHAIN_RO_CALL_ASYNC_WITH_400(call_name, call_result, http_response_code) CALL_ASYNC_WITH_400(chain, ro_api, chain_apis::read_only, call_name, call_result, http_response_code)
-#define CHAIN_RW_CALL_ASYNC_WITH_400(call_name, call_result, http_response_code) CALL_ASYNC_WITH_400(chain, rw_api, chain_apis::read_write, call_name, call_result, http_response_code)
-
-#define CHAIN_RO_CALL_WITH_400(call_name, http_response_code) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code)
+#define CHAIN_RO_CALL_WITH_400(call_name, http_response_code, params_type) CALL_WITH_400(chain, ro_api, chain_apis::read_only, call_name, http_response_code, params_type)
 
 void chain_api_plugin::plugin_startup() {
    ilog( "starting chain_api_plugin" );
@@ -154,46 +103,45 @@ void chain_api_plugin::plugin_startup() {
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
 
    _http_plugin.add_api({
-      CHAIN_RO_CALL(get_info, 200)}, appbase::priority::medium_high);
+      CHAIN_RO_CALL(get_info, 200, http_params_types::no_params_required)}, appbase::priority::medium_high);
    _http_plugin.add_api({
-      CHAIN_RO_CALL(get_activated_protocol_features, 200),
-      CHAIN_RO_CALL(get_block, 200),
-      CHAIN_RO_CALL(get_block_info, 200),
-      CHAIN_RO_CALL(get_block_header_state, 200),
-      CHAIN_RO_CALL(get_account, 200),
-      CHAIN_RO_CALL(get_code, 200),
-      CHAIN_RO_CALL(get_code_hash, 200),
-      CHAIN_RO_CALL(get_abi, 200),
-      CHAIN_RO_CALL(get_raw_code_and_abi, 200),
-      CHAIN_RO_CALL(get_raw_abi, 200),
-      CHAIN_RO_CALL(get_table_rows, 200),
-      CHAIN_RO_CALL(get_table_by_scope, 200),
-      CHAIN_RO_CALL(get_currency_balance, 200),
-      CHAIN_RO_CALL(get_currency_stats, 200),
-      CHAIN_RO_CALL(get_producers, 200),
-      CHAIN_RO_CALL(get_producer_schedule, 200),
-      CHAIN_RO_CALL(get_scheduled_transactions, 200),
-      CHAIN_RO_CALL(abi_json_to_bin, 200),
-      CHAIN_RO_CALL(abi_bin_to_json, 200),
-      CHAIN_RO_CALL(get_required_keys, 200),
-      CHAIN_RO_CALL(get_transaction_id, 200),
-      CHAIN_RO_CALL_ASYNC_WITH_400(compute_transaction, chain_apis::read_only::compute_transaction_results, 200),
-      CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202),
-      CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202),
-      CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202),
-      CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202),
-      CHAIN_RW_CALL_ASYNC_WITH_400(send_transaction2, chain_apis::read_write::send_transaction_results, 202)
+      CHAIN_RO_CALL(get_activated_protocol_features, 200, http_params_types::possible_no_params),
+      CHAIN_RO_CALL(get_block, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_block_info, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_block_header_state, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_account, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_code, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_code_hash, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_abi, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_raw_code_and_abi, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_raw_abi, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_table_rows, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_table_by_scope, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_currency_balance, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_currency_stats, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_producers, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_producer_schedule, 200, http_params_types::no_params_required),
+      CHAIN_RO_CALL(get_scheduled_transactions, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(abi_json_to_bin, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(abi_bin_to_json, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_required_keys, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_transaction_id, 200, http_params_types::params_required),
+      CHAIN_RW_CALL_ASYNC(push_block, chain_apis::read_write::push_block_results, 202, http_params_types::params_required),
+      CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202, http_params_types::params_required),
+      CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202, http_params_types::params_required),
+      CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required),
+      CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required)
    });
 
    if (chain.account_queries_enabled()) {
       _http_plugin.add_async_api({
-         CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200),
+         CHAIN_RO_CALL_WITH_400(get_accounts_by_authorizers, 200, http_params_types::params_required),
       });
    }
 
    if (chain.transaction_finality_status_enabled()) {
       _http_plugin.add_async_api({
-         CHAIN_RO_CALL_WITH_400(get_transaction_status, 200),
+         CHAIN_RO_CALL_WITH_400(get_transaction_status, 200, http_params_types::params_required),
       });
    }
 }

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -102,8 +102,8 @@ void chain_api_plugin::plugin_startup() {
    auto& _http_plugin = app().get_plugin<http_plugin>();
    ro_api.set_shorten_abi_errors( !_http_plugin.verbose_errors() );
 
-   _http_plugin.add_api({
-      CHAIN_RO_CALL(get_info, 200, http_params_types::no_params_required)}, appbase::priority::medium_high);
+   _http_plugin.add_api( {
+      CHAIN_RO_CALL(get_info, 200, http_params_types::no_params)}, appbase::priority::medium_high);
    _http_plugin.add_api({
       CHAIN_RO_CALL(get_activated_protocol_features, 200, http_params_types::possible_no_params),
       CHAIN_RO_CALL(get_block, 200, http_params_types::params_required),
@@ -120,7 +120,7 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RO_CALL(get_currency_balance, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_currency_stats, 200, http_params_types::params_required),
       CHAIN_RO_CALL(get_producers, 200, http_params_types::params_required),
-      CHAIN_RO_CALL(get_producer_schedule, 200, http_params_types::no_params_required),
+      CHAIN_RO_CALL(get_producer_schedule, 200, http_params_types::no_params),
       CHAIN_RO_CALL(get_scheduled_transactions, 200, http_params_types::params_required),
       CHAIN_RO_CALL(abi_json_to_bin, 200, http_params_types::params_required),
       CHAIN_RO_CALL(abi_bin_to_json, 200, http_params_types::params_required),

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -316,7 +316,7 @@ public:
    fc::variant get_block(const get_block_params& params) const;
 
    struct get_block_info_params {
-      uint32_t block_num;
+      uint32_t block_num = 0;
    };
 
    fc::variant get_block_info(const get_block_info_params& params) const;
@@ -364,7 +364,7 @@ public:
       name        scope;
       name        table;
       name        payer;
-      uint32_t    count;
+      uint32_t    count = 0;
    };
    struct get_table_by_scope_result {
       vector<get_table_by_scope_result_row> rows;

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -159,7 +159,7 @@ namespace eosio {
       error_info error;
    };
 
-   inline std::string_view get_trimmed_string_view(const std::string& body) {
+   inline std::string_view make_trimmed_string_view(const std::string& body) {
       if (body.empty()) {
          return {};
       }
@@ -188,9 +188,8 @@ namespace eosio {
       return {body.substr(left, right-left+1)};
    }
 
-   // @pre requires no leading and trailing spaces
    inline bool is_empty_content(const std::string& body) {
-      const auto trimmed_body_view = get_trimmed_string_view(body);
+      const auto trimmed_body_view = make_trimmed_string_view(body);
       if (trimmed_body_view.empty()) {
          return true;
       }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -189,7 +189,7 @@ namespace eosio {
       if ((left == right) && (body[left] == ' ')) {
          return {};
       }
-      return {&body[left], right-left+1};
+      return std::string_view(body).substr(left, right-left+1);
    }
 
    inline bool is_empty_content(const std::string& body) {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -159,6 +159,10 @@ namespace eosio {
       error_info error;
    };
 
+   /**
+    * @brief Used to trim whitespace from body. 
+    * Returned string_view valid only for lifetime of body
+    */
    inline std::string_view make_trimmed_string_view(const std::string& body) {
       if (body.empty()) {
          return {};

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -213,7 +213,7 @@ namespace eosio {
    }
 
    enum class http_params_types {
-      no_params_required = 0,
+      no_params = 0,
       params_required = 1,
       possible_no_params = 2
    };
@@ -228,14 +228,14 @@ namespace eosio {
 
       try {
          try {
-            if constexpr (params_type == http_params_types::no_params_required || params_type == http_params_types::possible_no_params) {
+            if constexpr (params_type == http_params_types::no_params || params_type == http_params_types::possible_no_params) {
                if (is_empty_content(body)) {
                   if constexpr (std::is_same_v<T, std::string>) {
                      return std::string("{}");
                   }
                   return {};
                }
-               if constexpr (params_type == http_params_types::no_params_required) {
+               if constexpr (params_type == http_params_types::no_params) {
                   EOS_THROW(chain::invalid_http_request, "no parameter should be given");
                }
             }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -159,10 +159,8 @@ namespace eosio {
 
       error_info error;
    };
-
-   inline bool isEmptyContent(std::string& body) {
-      boost::algorithm::trim(body);
-
+   // @pre requires no leading and trailing spaces
+   inline bool is_empty_content(const std::string_view& body) {
       if (body.empty()) {
          return true;
       }
@@ -189,8 +187,9 @@ namespace eosio {
 
    template<typename T, http_params_types params_type>
    T parse_params(std::string& body) {  // needs to trim space,
+      boost::algorithm::trim(body);
       if constexpr (params_type == http_params_types::params_required) {
-         if (isEmptyContent(body)) {
+         if (is_empty_content(body)) {
             EOS_THROW(chain::invalid_http_request, "A Request body is required");
          }
       }
@@ -198,7 +197,7 @@ namespace eosio {
       try {
          try {
             if constexpr (params_type == http_params_types::no_params_required || params_type == http_params_types::possible_no_params) {
-               if (isEmptyContent(body)) {
+               if (is_empty_content(body)) {
                   if constexpr (std::is_same_v<T, std::string>) {
                      return std::string("{}");
                   }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -191,7 +191,7 @@ namespace eosio {
       try {
          try {
             if constexpr (params_type == http_params_types::no_params_required || params_type == http_params_types::possible_no_params) {
-               if (!is_valid_json_object(body)) {
+               if (body.empty()) {
                   if constexpr (std::is_same_v<T, std::string>) {
                      return std::string("{}");
                   }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -159,21 +159,6 @@ namespace eosio {
       error_info error;
    };
 
-   // Does body contain a JSON object with data
-   inline bool is_valid_json_object(const std::string& body) {
-      if( body.empty() ) return false;
-      // contains: { <data> }
-      auto open_bracket = body.find('{');
-      if( open_bracket == std::string::npos ) return false;
-      auto close_bracket = body.rfind('}');
-      if( close_bracket == std::string::npos) return false;
-      if( close_bracket < open_bracket ) return false;
-      // verify JSON object has data and not empty
-      auto data = body.find_first_not_of(" \t\f\v\n\r", open_bracket+1);
-      if( data == close_bracket ) return false;
-      return true;
-   }
-
    enum class http_params_types {
       no_params_required = 0,
       params_required = 1,
@@ -183,7 +168,7 @@ namespace eosio {
    template<typename T, http_params_types params_type>
    T parse_params(const std::string& body) {
       if constexpr (params_type == http_params_types::params_required) {
-         if (!is_valid_json_object(body)) {
+         if (body.empty()) {
             EOS_THROW(chain::invalid_http_request, "A Request body is required");
          }
       }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -159,6 +159,21 @@ namespace eosio {
       error_info error;
    };
 
+   // Does body contain a JSON object with data
+   inline bool is_valid_json_object(const std::string& body) {
+      if( body.empty() ) return false;
+      // contains: { <data> }
+      auto open_bracket = body.find('{');
+      if( open_bracket == std::string::npos ) return false;
+      auto close_bracket = body.rfind('}');
+      if( close_bracket == std::string::npos) return false;
+      if( close_bracket < open_bracket ) return false;
+      // verify JSON object has data and not empty
+      auto data = body.find_first_not_of(" \t\f\v\n\r", open_bracket+1);
+      if( data == close_bracket ) return false;
+      return true;
+   }
+
    enum class http_params_types {
       no_params_required = 0,
       params_required = 1,
@@ -168,7 +183,7 @@ namespace eosio {
    template<typename T, http_params_types params_type>
    T parse_params(const std::string& body) {
       if constexpr (params_type == http_params_types::params_required) {
-         if (body.empty()) {
+         if (!is_valid_json_object(body)) {
             EOS_THROW(chain::invalid_http_request, "A Request body is required");
          }
       }
@@ -176,7 +191,7 @@ namespace eosio {
       try {
          try {
             if constexpr (params_type == http_params_types::no_params_required || params_type == http_params_types::possible_no_params) {
-               if (body.empty()) {
+               if (!is_valid_json_object(body)) {
                   if constexpr (std::is_same_v<T, std::string>) {
                      return std::string("{}");
                   }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -185,7 +185,7 @@ namespace eosio {
       if ((left == right) && (body[left] == ' ')) {
          return {};
       }
-      return {body.substr(left, right-left+1)};
+      return {&body[left], right-left+1};
    }
 
    inline bool is_empty_content(const std::string& body) {

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -160,7 +160,7 @@ namespace eosio {
       error_info error;
    };
 
-   static inline bool isEmptyContent(std::string& body) {
+   inline bool isEmptyContent(std::string& body) {
       boost::algorithm::trim(body);
 
       if (body.empty()) {

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -35,7 +35,7 @@ using namespace eosio;
      fc::variant result( api_handle.call_name( std::move(params) ) );
 
 #define INVOKE_R_V(api_handle, call_name) \
-     body = parse_params<std::string, http_params_types::no_params_required>(body); \
+     body = parse_params<std::string, http_params_types::no_params>(body); \
      auto result = api_handle.call_name();
 
 #define INVOKE_V_R(api_handle, call_name, in_param) \

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -27,11 +27,10 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
    }
 };
 
-#define CALL(api_name, api_handle, call_name, INVOKE, http_response_code) \
+#define CALL_WITH_400(api_name, api_handle, call_name, INVOKE, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [&api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
-             if (body.empty()) body = "{}"; \
              INVOKE \
              cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
@@ -59,28 +58,27 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
 }
 
 #define INVOKE_R_R(api_handle, call_name, in_param) \
-     auto result = api_handle.call_name(fc::json::from_string(body).as<in_param>());
+     auto params = parse_params<in_param, http_params_types::params_required>(body);\
+     auto result = api_handle.call_name(std::move(params));
 
-#define INVOKE_R_R_R_R(api_handle, call_name, in_param0, in_param1, in_param2) \
-     const auto& vs = fc::json::json::from_string(body).as<fc::variants>(); \
-     auto result = api_handle.call_name(vs.at(0).as<in_param0>(), vs.at(1).as<in_param1>(), vs.at(2).as<in_param2>());
+#define INVOKE_R_R_II(api_handle, call_name, in_param) \
+     auto params = parse_params<in_param, http_params_types::possible_no_params>(body);\
+     auto result = api_handle.call_name(std::move(params));
 
 #define INVOKE_R_V(api_handle, call_name) \
+     body = parse_params<std::string, http_params_types::no_params_required>(body); \
      auto result = api_handle.call_name();
 
 #define INVOKE_R_V_ASYNC(api_handle, call_name)\
      api_handle.call_name(next);
 
 #define INVOKE_V_R(api_handle, call_name, in_param) \
-     api_handle.call_name(fc::json::from_string(body).as<in_param>()); \
-     eosio::detail::producer_api_plugin_response result{"ok"};
-
-#define INVOKE_V_R_R(api_handle, call_name, in_param0, in_param1) \
-     const auto& vs = fc::json::json::from_string(body).as<fc::variants>(); \
-     api_handle.call_name(vs.at(0).as<in_param0>(), vs.at(1).as<in_param1>()); \
+     auto params = parse_params<in_param, http_params_types::params_required>(body);\
+     api_handle.call_name(std::move(params)); \
      eosio::detail::producer_api_plugin_response result{"ok"};
 
 #define INVOKE_V_V(api_handle, call_name) \
+     body = parse_params<std::string, http_params_types::no_params_required>(body); \
      api_handle.call_name(); \
      eosio::detail::producer_api_plugin_response result{"ok"};
 
@@ -91,38 +89,38 @@ void producer_api_plugin::plugin_startup() {
    auto& producer = app().get_plugin<producer_plugin>();
 
    app().get_plugin<http_plugin>().add_api({
-       CALL(producer, producer, pause,
+       CALL_WITH_400(producer, producer, pause,
             INVOKE_V_V(producer, pause), 201),
-       CALL(producer, producer, resume,
+       CALL_WITH_400(producer, producer, resume,
             INVOKE_V_V(producer, resume), 201),
-       CALL(producer, producer, paused,
+       CALL_WITH_400(producer, producer, paused,
             INVOKE_R_V(producer, paused), 201),
-       CALL(producer, producer, get_runtime_options,
+       CALL_WITH_400(producer, producer, get_runtime_options,
             INVOKE_R_V(producer, get_runtime_options), 201),
-       CALL(producer, producer, update_runtime_options,
+       CALL_WITH_400(producer, producer, update_runtime_options,
             INVOKE_V_R(producer, update_runtime_options, producer_plugin::runtime_options), 201),
-       CALL(producer, producer, add_greylist_accounts,
+       CALL_WITH_400(producer, producer, add_greylist_accounts,
             INVOKE_V_R(producer, add_greylist_accounts, producer_plugin::greylist_params), 201),
-       CALL(producer, producer, remove_greylist_accounts,
+       CALL_WITH_400(producer, producer, remove_greylist_accounts,
             INVOKE_V_R(producer, remove_greylist_accounts, producer_plugin::greylist_params), 201),
-       CALL(producer, producer, get_greylist,
+       CALL_WITH_400(producer, producer, get_greylist,
             INVOKE_R_V(producer, get_greylist), 201),
-       CALL(producer, producer, get_whitelist_blacklist,
+       CALL_WITH_400(producer, producer, get_whitelist_blacklist,
             INVOKE_R_V(producer, get_whitelist_blacklist), 201),
-       CALL(producer, producer, set_whitelist_blacklist,
+       CALL_WITH_400(producer, producer, set_whitelist_blacklist,
             INVOKE_V_R(producer, set_whitelist_blacklist, producer_plugin::whitelist_blacklist), 201),
-       CALL(producer, producer, get_integrity_hash,
+       CALL_WITH_400(producer, producer, get_integrity_hash,
             INVOKE_R_V(producer, get_integrity_hash), 201),
        CALL_ASYNC(producer, producer, create_snapshot, producer_plugin::snapshot_information,
             INVOKE_R_V_ASYNC(producer, create_snapshot), 201),
-       CALL(producer, producer, get_scheduled_protocol_feature_activations,
+       CALL_WITH_400(producer, producer, get_scheduled_protocol_feature_activations,
             INVOKE_R_V(producer, get_scheduled_protocol_feature_activations), 201),
-       CALL(producer, producer, schedule_protocol_feature_activations,
+       CALL_WITH_400(producer, producer, schedule_protocol_feature_activations,
             INVOKE_V_R(producer, schedule_protocol_feature_activations, producer_plugin::scheduled_protocol_feature_activations), 201),
-       CALL(producer, producer, get_supported_protocol_features,
-            INVOKE_R_R(producer, get_supported_protocol_features,
+       CALL_WITH_400(producer, producer, get_supported_protocol_features,
+            INVOKE_R_R_II(producer, get_supported_protocol_features,
                                  producer_plugin::get_supported_protocol_features_params), 201),
-       CALL(producer, producer, get_account_ram_corrections,
+       CALL_WITH_400(producer, producer, get_account_ram_corrections,
             INVOKE_R_R(producer, get_account_ram_corrections, producer_plugin::get_account_ram_corrections_params), 201),
    }, appbase::priority::medium_high);
 }
@@ -146,10 +144,8 @@ void producer_api_plugin::plugin_initialize(const variables_map& options) {
 
 
 #undef INVOKE_R_R
-#undef INVOKE_R_R_R_R
 #undef INVOKE_R_V
 #undef INVOKE_V_R
-#undef INVOKE_V_R_R
 #undef INVOKE_V_V
 #undef CALL
 

--- a/plugins/producer_api_plugin/producer_api_plugin.cpp
+++ b/plugins/producer_api_plugin/producer_api_plugin.cpp
@@ -66,7 +66,7 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
      auto result = api_handle.call_name(std::move(params));
 
 #define INVOKE_R_V(api_handle, call_name) \
-     body = parse_params<std::string, http_params_types::no_params_required>(body); \
+     body = parse_params<std::string, http_params_types::no_params>(body); \
      auto result = api_handle.call_name();
 
 #define INVOKE_R_V_ASYNC(api_handle, call_name)\
@@ -78,7 +78,7 @@ struct async_result_visitor : public fc::visitor<fc::variant> {
      eosio::detail::producer_api_plugin_response result{"ok"};
 
 #define INVOKE_V_V(api_handle, call_name) \
-     body = parse_params<std::string, http_params_types::no_params_required>(body); \
+     body = parse_params<std::string, http_params_types::no_params>(body); \
      api_handle.call_name(); \
      eosio::detail::producer_api_plugin_response result{"ok"};
 

--- a/plugins/test_control_api_plugin/test_control_api_plugin.cpp
+++ b/plugins/test_control_api_plugin/test_control_api_plugin.cpp
@@ -31,26 +31,26 @@ struct async_result_visitor : public fc::visitor<std::string> {
    }
 };
 
-#define CALL(api_name, api_handle, api_namespace, call_name, http_response_code) \
+#define CALL_WITH_API_400(api_name, api_handle, api_namespace, call_name, http_response_code, params_type) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
-             if (body.empty()) body = "{}"; \
-             fc::variant result( api_handle.call_name(fc::json::from_string(body).as<api_namespace::call_name ## _params>()) ); \
+             auto params = parse_params<api_namespace::call_name ## _params, params_type>(body);\
+             fc::variant result( api_handle.call_name( std::move(params) ) ); \
              cb(http_response_code, std::move(result)); \
           } catch (...) { \
              http_plugin::handle_exception(#api_name, #call_name, body, cb); \
           } \
        }}
 
-#define TEST_CONTROL_RW_CALL(call_name, http_response_code) CALL(test_control, rw_api, test_control_apis::read_write, call_name, http_response_code)
+#define TEST_CONTROL_RW_CALL(call_name, http_response_code, params_type) CALL_WITH_API_400(test_control, rw_api, test_control_apis::read_write, call_name, http_response_code, params_type)
 
 void test_control_api_plugin::plugin_startup() {
    my.reset(new test_control_api_plugin_impl(app().get_plugin<chain_plugin>().chain()));
    auto rw_api = app().get_plugin<test_control_plugin>().get_read_write_api();
 
    app().get_plugin<http_plugin>().add_api({
-      TEST_CONTROL_RW_CALL(kill_node_on_producer, 202)
+      TEST_CONTROL_RW_CALL(kill_node_on_producer, 202, http_params_types::params_required)
    });
 }
 

--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -51,7 +51,7 @@ using namespace eosio;
      auto result = api_handle.call_name(params.at(0).as<in_param0>(), params.at(1).as<in_param1>(), params.at(2).as<in_param2>());
 
 #define INVOKE_R_V(api_handle, call_name) \
-     body = parse_params<std::string, http_params_types::no_params_required>(body); \
+     body = parse_params<std::string, http_params_types::no_params>(body); \
      auto result = api_handle.call_name();
 
 #define INVOKE_V_R(api_handle, call_name, in_param) \
@@ -76,7 +76,7 @@ using namespace eosio;
      eosio::detail::wallet_api_plugin_empty result;
 
 #define INVOKE_V_V(api_handle, call_name) \
-     body = parse_params<std::string, http_params_types::no_params_required>(body); \
+     body = parse_params<std::string, http_params_types::no_params>(body); \
      api_handle.call_name(); \
      eosio::detail::wallet_api_plugin_empty result;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/compute_transaction_test.py ${CMAKE_C
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/subjective_billing_test.py ${CMAKE_CURRENT_BINARY_DIR}/subjective_billing_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_high_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_high_transaction_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_retry_transaction_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_retry_transaction_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test.py COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -181,6 +182,10 @@ set_property(TEST larger_lib_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME http_plugin_test COMMAND tests/http_plugin_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_tests_properties(http_plugin_test PROPERTIES TIMEOUT 100)
 set_property(TEST http_plugin_test PROPERTY LABELS nonparallelizable_tests)
+
+add_test(NAME plugin_http_api_test COMMAND tests/plugin_http_api_test.py WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_tests_properties(plugin_http_api_test PROPERTIES TIMEOUT 40)
+set_property(TEST plugin_http_api_test PROPERTY LABELS nonparallelizable_tests)
 
 if(ENABLE_COVERAGE_TESTING)
 

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1458,6 +1458,14 @@ class Node(object):
         param = { }
         return self.processCurlCmd("producer", "create_snapshot", json.dumps(param))
 
+    # kill all exsiting nodeos in case lingering from previous test
+    @staticmethod
+    def killAllNodeos():
+        # kill the eos server
+        cmd="pkill -9 %s" % (Utils.EosServerName)
+        ret_code = subprocess.call(cmd.split(), stdout=Utils.FNull)
+        Utils.Print("cmd: %s, ret:%d" % (cmd, ret_code))
+
     @staticmethod
     def findStderrFiles(path):
         files=[]

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1,0 +1,1132 @@
+#!/usr/bin/env python3
+import json
+import os
+import shutil
+import time
+import unittest
+
+from testUtils import Utils
+from TestHelper import TestHelper
+from Node import Node
+from WalletMgr import WalletMgr
+
+class PluginHttpTest(unittest.TestCase):
+    sleep_s = 2
+    base_node_cmd_str = ("curl http://%s:%s/v1/") % (TestHelper.LOCAL_HOST, TestHelper.DEFAULT_PORT)
+    base_wallet_cmd_str = ("curl http://%s:%s/v1/") % (TestHelper.LOCAL_HOST, TestHelper.DEFAULT_WALLET_PORT)
+    keosd = WalletMgr(True, TestHelper.DEFAULT_PORT, TestHelper.LOCAL_HOST, TestHelper.DEFAULT_WALLET_PORT, TestHelper.LOCAL_HOST)
+    node_id = 1
+    nodeos = Node(TestHelper.LOCAL_HOST, TestHelper.DEFAULT_PORT, node_id)
+    data_dir = Utils.getNodeDataDir(node_id)
+    http_post_str = " -X POST -d "
+    http_post_invalid_param = " '{invalid}' "
+
+    # make a fresh data dir
+    def createDataDir(self):
+        if os.path.exists(self.data_dir):
+            shutil.rmtree(self.data_dir)
+        os.makedirs(self.data_dir)
+
+    # kill nodeos and keosd and clean up dir
+    def cleanEnv(self) :
+        self.keosd.killall(True)
+        WalletMgr.cleanup()
+        Node.killAllNodeos()
+        if os.path.exists(self.data_dir):
+            shutil.rmtree(self.data_dir)
+        time.sleep(self.sleep_s)
+
+    # start keosd and nodeos
+    def startEnv(self) :
+        self.createDataDir(self)
+        self.keosd.launch()
+        nodeos_plugins = (" --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s"
+                          " --plugin %s --plugin %s --plugin %s --plugin %s ") % ( "eosio::trace_api_plugin",
+                                                                                   "eosio::test_control_api_plugin",
+                                                                                   "eosio::test_control_plugin",
+                                                                                   "eosio::net_plugin",
+                                                                                   "eosio::net_api_plugin",
+                                                                                   "eosio::producer_plugin",
+                                                                                   "eosio::producer_api_plugin",
+                                                                                   "eosio::chain_api_plugin",
+                                                                                   "eosio::http_plugin",
+                                                                                   "eosio::history_plugin",
+                                                                                   "eosio::history_api_plugin")
+        nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --filter-on=%s --access-control-allow-origin=%s "
+                        "--contracts-console --http-validate-host=%s --verbose-http-errors ") % (self.data_dir, self.data_dir, "\"*\"", "\'*\'", "false")
+        start_nodeos_cmd = ("%s -e -p eosio %s %s ") % (Utils.EosServerPath, nodeos_plugins, nodeos_flags)
+        self.nodeos.launchCmd(start_nodeos_cmd, self.node_id)
+        time.sleep(self.sleep_s)
+
+    # test all chain api
+    def test_ChainApi(self) :
+        cmd_base = self.base_node_cmd_str + "chain/"
+
+        # get_info without parameter
+        default_cmd = cmd_base + "get_info"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("server_version", ret_json)
+        # get_info with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+
+        # get_activated_protocol_features without parameter
+        default_cmd = cmd_base + "get_activated_protocol_features"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_activated_protocol_features with 1st param
+        param_1st_cmd = default_cmd + self.http_post_str + "'{\"lower_bound\":1}'"
+        ret_json = Utils.runCmdReturnJson(param_1st_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with 2nd param
+        param_2nd_cmd = default_cmd + self.http_post_str + "'{\"upper_bound\":1000}'"
+        ret_json = Utils.runCmdReturnJson(param_2nd_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with 3rd param
+        param_3rd_cmd = default_cmd + self.http_post_str + "'{\"limit\":1}'"
+        ret_json = Utils.runCmdReturnJson(param_3rd_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with 4th param
+        param_4th_cmd = default_cmd + self.http_post_str + "'{\"search_by_block_num\":true}'"
+        ret_json = Utils.runCmdReturnJson(param_4th_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with 5th param
+        param_5th_cmd = default_cmd + self.http_post_str + "'{\"reverse\":true}'"
+        ret_json = Utils.runCmdReturnJson(param_5th_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with valid parameter
+        valid_cmd = ("%s%s '{%s,%s,%s,%s,%s}'") % ( default_cmd,
+                                                    self.http_post_str,
+                                                    "\"lower_bound\":1",
+                                                    "\"upper_bound\":1000",
+                                                    "\"limit\":10",
+                                                    "\"search_by_block_num\":true",
+                                                    "\"reverse\":true")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+
+        # get_block with empty parameter
+        default_cmd = cmd_base + "get_block"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"block_num_or_id\":1}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["block_num"], 1)
+
+        # get_block_info with empty parameter
+        default_cmd = cmd_base + "get_block_info"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block_info with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block_info with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"block_num\":1}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["block_num"], 1)
+
+        # get_block_header_state with empty parameter
+        default_cmd = cmd_base + "get_block_header_state"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_block_header_state with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_block_header_state with valid parameter, the irreversible is not available, unknown block number
+        valid_cmd = default_cmd + self.http_post_str + "'{\"block_num_or_id\":1}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3100002)
+
+        # get_account with empty parameter
+        default_cmd = cmd_base + "get_account"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_account with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_account with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"account_name\":\"default\"}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_code with empty parameter
+        default_cmd = cmd_base + "get_code"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_code with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_code with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"account_name\":\"default\"}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_code_hash with empty parameter
+        default_cmd = cmd_base + "get_code_hash"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_code_hash with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_code_hash with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"account_name\":\"default\"}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_abi with empty parameter
+        default_cmd = cmd_base + "get_abi"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_abi with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_abi with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"account_name\":\"default\"}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_raw_code_and_abi with empty parameter
+        default_cmd = cmd_base + "get_raw_code_and_abi"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_raw_code_and_abi with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_raw_code_and_abi with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"account_name\":\"default\"}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_raw_abi with empty parameter
+        default_cmd = cmd_base + "get_raw_abi"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_raw_abi with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_raw_abi with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + "'{\"account_name\":\"default\"}'"
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_table_rows with empty parameter
+        default_cmd = cmd_base + "get_table_rows"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_table_rows with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_table_rows with valid parameter
+        valid_cmd = ("%s%s '{%s,%s,%s,%s,%s,%s,%s,%s}'") % (  default_cmd,
+                                                              self.http_post_str,
+                                                              "\"json\":true",
+                                                              "\"code\":\"cancancan345\"",
+                                                              "\"scope\":\"cancancan345\"",
+                                                              "\"table\":\"vote\"",
+                                                              "\"index_position\":2",
+                                                              "\"key_type\":\"i128\"",
+                                                              "\"lower_bound\":\"0x0000000000000000D0F2A472A8EB6A57\"",
+                                                              "\"upper_bound\":\"0xFFFFFFFFFFFFFFFFD0F2A472A8EB6A57\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_table_by_scope with empty parameter
+        default_cmd = cmd_base + "get_table_by_scope"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_table_by_scope with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_table_by_scope with valid parameter
+        valid_cmd = ("%s%s '{%s,%s,%s,%s,%s}'") % (   default_cmd,
+                                                      self.http_post_str,
+                                                      "\"code\":\"cancancan345\"",
+                                                      "\"table\":\"vote\"",
+                                                      "\"index_position\":2",
+                                                      "\"lower_bound\":\"0x0000000000000000D0F2A472A8EB6A57\"",
+                                                      "\"upper_bound\":\"0xFFFFFFFFFFFFFFFFD0F2A472A8EB6A57\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_currency_balance with empty parameter
+        default_cmd = cmd_base + "get_currency_balance"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_currency_balance with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_currency_balance with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"code\":\"eosio.token\", \"account\":\"unknown\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_currency_stats with empty parameter
+        default_cmd = cmd_base + "get_currency_stats"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_currency_stats with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_currency_stats with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"code\":\"eosio.token\",\"symbol\":\"SYS\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_producers with empty parameter
+        default_cmd = cmd_base + "get_producers"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_producers with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_producers with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"json\":true,\"lower_bound\":\"\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(type(ret_json["rows"]), list)
+
+        # get_producer_schedule with empty parameter
+        default_cmd = cmd_base + "get_producer_schedule"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(type(ret_json["active"]), dict)
+        # get_producer_schedule with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # get_scheduled_transactions with empty parameter
+        default_cmd = cmd_base + "get_scheduled_transactions"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_scheduled_transactions with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_scheduled_transactions with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"json\":true,\"lower_bound\":\"\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(type(ret_json["transactions"]), list)
+
+        # abi_json_to_bin with empty parameter
+        default_cmd = cmd_base + "abi_json_to_bin"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # abi_json_to_bin with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # abi_json_to_bin with valid parameter
+        valid_cmd = ("%s%s '{%s,%s,%s}'") % (default_cmd,
+                                             self.http_post_str,
+                                             "\"code\":\"eosio.token\"",
+                                             "\"action\":\"issue\"",
+                                             "\"args\":{\"to\":\"eosio.token\", \"quantity\":\"1.0000\%20EOS\",\"memo\":\"m\"}")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # abi_bin_to_json with empty parameter
+        default_cmd = cmd_base + "abi_bin_to_json"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # abi_bin_to_json with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # abi_bin_to_json with valid parameter
+        valid_cmd = ("%s%s '{%s,%s,%s}'") % (default_cmd,
+                                             self.http_post_str,
+                                             "\"code\":\"eosio.token\"",
+                                             "\"action\":\"issue\"",
+                                             "\"args\":\"ee6fff5a5c02c55b6304000000000100a6823403ea3055000000572d3ccdcd0100000000007015d600000000a8ed32322a00000000007015d6000000005c95b1ca102700000000000004454f53000000000968656c6c6f206d616e00\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_required_keys with empty p4arameter
+        default_cmd = cmd_base + "get_required_keys"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_required_keys with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_required_keys with valid parameter
+        valid_cmd = ("%s%s '{\"transaction\":{%s,%s,%s,%s,%s,%s,%s},\"available_keys\":[%s,%s,%s]}'") % \
+                    (default_cmd,
+                     self.http_post_str,
+                     "\"ref_block_num\":\"100\"",
+                     "\"ref_block_prefix\": \"137469861\"",
+                     "\"expiration\": \"2020-09-25T06:28:49\"",
+                     "\"scope\":[\"initb\", \"initc\"]",
+                     "\"actions\": [{\"code\": \"currency\",\"type\":\"transfer\",\"recipients\": [\"initb\", \"initc\"],\"authorization\": [{\"account\": \"initb\", \"permission\": \"active\"}],\"data\":\"000000000041934b000000008041934be803000000000000\"}]",
+                     "\"signatures\": []",
+                     "\"authorizations\": []",
+                     "\"EOS4toFS3YXEQCkuuw1aqDLrtHim86Gz9u3hBdcBw5KNPZcursVHq\"",
+                     "\"EOS7d9A3uLe6As66jzN8j44TXJUqJSK3bFjjEEqR4oTvNAB3iM9SA\"",
+                     "\"EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_transaction_id with empty p4arameter
+        default_cmd = cmd_base + "get_transaction_id"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_transaction_id with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_transaction_id with valid parameter
+        valid_cmd = ("%s%s '{%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s}'") % \
+                    (default_cmd,
+                     self.http_post_str,
+                     "\"expiration\":\"2020-08-01T07:15:49\"",
+                     "\"ref_block_num\": 34881",
+                     "\"ref_block_prefix\":2972818865",
+                     "\"max_net_usage_words\":0",
+                     "\"max_cpu_usage_ms\":0",
+                     "\"delay_sec\":0",
+                     "\"context_free_actions\":[]",
+                     "\"actions\":[{\"account\":\"eosio.token\",\"name\": \"transfer\",\"authorization\": [{\"actor\": \"han\",\"permission\": \"active\"}],\"data\": \"000000000000a6690000000000ea305501000000000000000453595300000000016d\"}]",
+                     "\"transaction_extensions\": []",
+                     "\"signatures\": [\"SIG_K1_KeqfqiZu1GwUxQb7jzK9Fdks6HFaVBQ9AJtCZZj56eG9qGgvVMVtx8EerBdnzrhFoX437sgwtojf2gfz6S516Ty7c22oEp\"]",
+                     "\"context_free_data\": []")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertEqual(ret_str, "\"0be762a6406bab15530e87f21e02d1c58e77944ee55779a76f4112e3b65cac48\"")
+
+        # push_block with empty parameter
+        default_cmd = cmd_base + "push_block"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_block with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_block with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"block\":\"signed_block\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(len(ret_json), 0)
+
+        # push_transaction with empty parameter
+        default_cmd = cmd_base + "push_transaction"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_transaction with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_transaction with valid parameter
+        valid_cmd = ("%s%s '{%s, %s, %s, %s}'") % (default_cmd,
+                                                   self.http_post_str,
+                                                   "\"signatures\":[\"SIG_K1_KeqfqiZu1GwUxQb7jzK9Fdks6HFaVBQ9AJtCZZj56eG9qGgvVMVtx8EerBdnzrhFoX437sgwtojf2gfz6S516Ty7c22oEp\"]",
+                                                   "\"compression\": true",
+                                                   "\"packed_context_free_data\": \"context_free_data\"",
+                                                   "\"packed_trx\": \"packed_trx\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # push_transactions with empty parameter
+        default_cmd = cmd_base + "push_transactions"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_transactions with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_transactions with valid parameter
+        valid_cmd = ("%s%s '[{%s, %s, %s, %s}]'") % (default_cmd,
+                                                   self.http_post_str,
+                                                   "\"signatures\":[\"SIG_K1_KeqfqiZu1GwUxQb7jzK9Fdks6HFaVBQ9AJtCZZj56eG9qGgvVMVtx8EerBdnzrhFoX437sgwtojf2gfz6S516Ty7c22oEp\"]",
+                                                   "\"compression\": true",
+                                                   "\"packed_context_free_data\": \"context_free_data\"",
+                                                   "\"packed_trx\": \"packed_trx\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn("transaction_id", ret_json[0])
+
+        # send_transaction with empty parameter
+        default_cmd = cmd_base + "send_transaction"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # send_transaction with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # send_transaction with valid parameter
+        valid_cmd = ("%s%s '{%s, %s, %s, %s}'") % (default_cmd,
+                                                   self.http_post_str,
+                                                   "\"signatures\":[\"SIG_K1_KeqfqiZu1GwUxQb7jzK9Fdks6HFaVBQ9AJtCZZj56eG9qGgvVMVtx8EerBdnzrhFoX437sgwtojf2gfz6S516Ty7c22oEp\"]",
+                                                   "\"compression\": true",
+                                                   "\"packed_context_free_data\": \"context_free_data\"",
+                                                   "\"packed_trx\": \"packed_trx\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+    # test all history api
+    def test_HistoryApi(self) :
+        cmd_base = self.base_node_cmd_str + "history/"
+
+        # get_actions with empty parameter
+        default_cmd = cmd_base + "get_actions"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_actions with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_actions with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"account_name\":\"test\", \"pos\":-1, \"offset\":2}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn("last_irreversible_block", ret_json)
+
+        # get_transaction with empty parameter
+        default_cmd = cmd_base + "get_transaction"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_transaction with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_transaction with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"id\":\"test\", \"block_num_hint\":1}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        # no transaction, so 500 error being sent back instead
+        self.assertEqual(ret_json["code"], 500)
+        self.assertEqual(ret_json["error"]["code"], 3010009)
+
+        # get_key_accounts with empty parameter
+        default_cmd = cmd_base + "get_key_accounts"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_key_accounts with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_key_accounts with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"public_key\":\"EOS6FxXbikY5ZUN9qEdeLbEYLKZzJwRYRr2PuC3rqfSu67LvhPARi\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn("account_names", ret_json)
+
+        # get_controlled_accounts with empty parameter
+        default_cmd = cmd_base + "get_controlled_accounts"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_controlled_accounts with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_controlled_accounts with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"controlling_account\":\"test\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn("controlled_accounts", ret_json)
+
+    # test all net api
+    def test_NetApi(self) :
+        cmd_base = self.base_node_cmd_str + "net/"
+
+        # connect with empty parameter
+        default_cmd = cmd_base + "connect"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # connect with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # connect with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"localhost\"'")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertEqual("\"added connection\"", ret_str)
+
+        # disconnect with empty parameter
+        default_cmd = cmd_base + "disconnect"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # disconnect with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # disconnect with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"localhost123\"'")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertEqual("\"no known connection for host\"", ret_str)
+
+        # status with empty parameter
+        default_cmd = cmd_base + "status"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # status with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # status with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"localhost\"'")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertEqual(ret_str, "null")
+
+        # connections with empty parameter
+        default_cmd = cmd_base + "connections"
+        ret_str = Utils.runCmdReturnStr(default_cmd)
+        self.assertEqual(ret_str, "[]")
+        # connections with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+    # test all producer api
+    def test_ProducerApi(self) :
+        cmd_base = self.base_node_cmd_str + "producer/"
+
+        # pause with empty parameter
+        default_cmd = cmd_base + "pause"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["result"], "ok")
+        # pause with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # resume with empty parameter
+        default_cmd = cmd_base + "resume"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["result"], "ok")
+        # resume with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # paused with empty parameter
+        default_cmd = cmd_base + "paused"
+        ret_str = Utils.runCmdReturnStr(default_cmd)
+        self.assertEqual(ret_str, "false")
+        # paused with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # get_runtime_options with empty parameter
+        default_cmd = cmd_base + "get_runtime_options"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("max_transaction_time", ret_json)
+        # get_runtime_options with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # update_runtime_options with empty parameter
+        default_cmd = cmd_base + "update_runtime_options"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # update_runtime_options with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # update_runtime_options with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{%s, %s, %s, %s, %s, %s, %s, %s}'") % ("\"max_transaction_time\":30",
+                                                                                                 "\"max_irreversible_block_age\":1",
+                                                                                                 "\"produce_time_offset_us\":10000",
+                                                                                                 "\"last_block_time_offset_us\":0",
+                                                                                                 "\"max_scheduled_transaction_time_per_block_ms\":10000",
+                                                                                                 "\"subjective_cpu_leeway_us\":0",
+                                                                                                 "\"incoming_defer_ratio\":1.0",
+                                                                                                 "\"greylist_limit\":100")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn(ret_json["result"], "ok")
+
+        # add_greylist_accounts with empty parameter
+        default_cmd = cmd_base + "add_greylist_accounts"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # add_greylist_accounts with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # add_greylist_accounts with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"accounts\":[\"test1\", \"test2\"]}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn(ret_json["result"], "ok")
+
+        # remove_greylist_accounts with empty parameter
+        default_cmd = cmd_base + "remove_greylist_accounts"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # remove_greylist_accounts with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # remove_greylist_accounts with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"accounts\":[\"test1\", \"test2\"]}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn(ret_json["result"], "ok")
+
+        # get_greylist with empty parameter
+        default_cmd = cmd_base + "get_greylist"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("accounts", ret_json)
+        # get_greylist with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # get_whitelist_blacklist with empty parameter
+        default_cmd = cmd_base + "get_whitelist_blacklist"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("actor_whitelist", ret_json)
+        self.assertIn("actor_blacklist", ret_json)
+        self.assertIn("contract_whitelist", ret_json)
+        self.assertIn("contract_blacklist", ret_json)
+        self.assertIn("action_blacklist", ret_json)
+        self.assertIn("key_blacklist", ret_json)
+        # get_whitelist_blacklist with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # set_whitelist_blacklist with empty parameter
+        default_cmd = cmd_base + "set_whitelist_blacklist"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # set_whitelist_blacklist with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # set_whitelist_blacklist with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{%s, %s, %s, %s, %s, %s}'") % ("\"actor_whitelist\":[\"test2\"]",
+                                                                                         "\"actor_blacklist\":[\"test3\"]",
+                                                                                         "\"contract_whitelist\":[\"test4\"]",
+                                                                                         "\"contract_blacklist\":[\"test5\"]",
+                                                                                         "\"action_blacklist\":[]",
+                                                                                         "\"key_blacklist\":[]")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn(ret_json["result"], "ok")
+
+        # get_integrity_hash with empty parameter
+        default_cmd = cmd_base + "get_integrity_hash"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("head_block_id", ret_json)
+        self.assertIn("integrity_hash", ret_json)
+        # get_integrity_hash with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # create_snapshot with empty parameter
+        default_cmd = cmd_base + "create_snapshot"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 500)
+        self.assertEqual(ret_json["error"]["code"], 3170000)
+        # create_snapshot with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+        self.assertEqual(ret_json["error"]["code"], 3170000)
+        # create_snapshot with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"content-type: application/x-www-form-urlencoded; charset=UTF-8\"}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+        self.assertEqual(ret_json["error"]["code"], 3170000)
+
+        # get_scheduled_protocol_feature_activations with empty parameter
+        default_cmd = cmd_base + "get_scheduled_protocol_feature_activations"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("protocol_features_to_activate", ret_json)
+        # get_scheduled_protocol_feature_activations with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # schedule_protocol_feature_activations with empty parameter
+        default_cmd = cmd_base + "schedule_protocol_feature_activations"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # schedule_protocol_feature_activations with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # schedule_protocol_feature_activations with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"protocol_features_to_activate\":[]}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn(ret_json["result"], "ok")
+
+        # get_supported_protocol_features with empty parameter
+        default_cmd = cmd_base + "get_supported_protocol_features"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("feature_digest", ret_json[0])
+        self.assertIn("subjective_restrictions", ret_json[0])
+        # get_supported_protocol_features with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_supported_protocol_features with 1st parameter
+        params_1st_cmd = default_cmd + self.http_post_str + ("'{\"exclude_disabled\":true}'")
+        ret_json = Utils.runCmdReturnJson(params_1st_cmd)
+        self.assertIn("feature_digest", ret_json[0])
+        self.assertIn("subjective_restrictions", ret_json[0])
+        # get_supported_protocol_features with 2nd parameter
+        params_2nd_cmd = default_cmd + self.http_post_str + ("'{\"exclude_unactivatable\":true}'")
+        ret_json = Utils.runCmdReturnJson(params_2nd_cmd)
+        self.assertIn("feature_digest", ret_json[0])
+        self.assertIn("subjective_restrictions", ret_json[0])
+        # get_supported_protocol_features with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"exclude_disabled\":true, \"exclude_unactivatable\":true}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn("feature_digest", ret_json[0])
+        self.assertIn("subjective_restrictions", ret_json[0])
+
+        # get_account_ram_corrections with empty parameter
+        default_cmd = cmd_base + "get_account_ram_corrections"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_account_ram_corrections with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_account_ram_corrections with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"lower_bound\":\"\", \"upper_bound\":\"\", \"limit\":1, \"reverse\":false}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertIn("rows", ret_json)
+
+    # test all wallet api
+    def test_WalletApi(self) :
+        cmd_base = self.base_wallet_cmd_str + "wallet/"
+
+        # set_timeout with empty parameter
+        default_cmd = cmd_base + "set_timeout"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # set_timeout with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # set_timeout with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"1234567\"'")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertEqual("{}", ret_str)
+
+        # sign_transaction with empty parameter
+        default_cmd = cmd_base + "sign_transaction"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # sign_transaction with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # sign_transaction with valid parameter
+        signed_transaction = ("{%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s}") % ("\"expiration\":\"2020-08-01T07:15:49\"",
+                                                                        "\"ref_block_num\": 34881",
+                                                                        "\"ref_block_prefix\":2972818865",
+                                                                        "\"max_net_usage_words\":0",
+                                                                        "\"max_cpu_usage_ms\":0",
+                                                                        "\"delay_sec\":0",
+                                                                        "\"context_free_actions\":[]",
+                                                                        "\"actions\": []",
+                                                                        "\"transaction_extensions\": []",
+                                                                        "\"signatures\": [\"SIG_K1_KeqfqiZu1GwUxQb7jzK9Fdks6HFaVBQ9AJtCZZj56eG9qGgvVMVtx8EerBdnzrhFoX437sgwtojf2gfz6S516Ty7c22oEp\"]",
+                                                                        "\"context_free_data\": []")
+        valid_cmd = default_cmd + self.http_post_str + ("'[%s, %s, %s]'") % (signed_transaction,
+                                                                             "[\"EOS696giL6VxeJhtEgKtWPK8aQeT8YXNjw2a7vE5wHunffhfa5QSQ\"]",
+                                                                             "\"cf057bbfb72640471fd910bcb67639c22df9f92470936cddc1ade0e2f2e7dc4f\"")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+        self.assertEqual(ret_json["error"]["code"], 3120004)
+
+        # create with empty parameter
+        default_cmd = cmd_base + "create"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"test1\"'")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertTrue( ret_str)
+
+        # open with empty parameter
+        default_cmd = cmd_base + "open"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"fakeacct\"'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # lock_all with empty parameter
+        default_cmd = cmd_base + "lock_all"
+        ret_str = Utils.runCmdReturnStr(default_cmd)
+        self.assertEqual("{}", ret_str)
+        # lock_all with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # lock with empty parameter
+        default_cmd = cmd_base + "lock"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # lock with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # lock with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'\"name\":\"auser\"'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # unlock with empty parameter
+        default_cmd = cmd_base + "unlock"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # unlock with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # unlock with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'[\"auser\", \"nopassword\"]'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # import_key with empty parameter
+        default_cmd = cmd_base + "import_key"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # import_key with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # import_key with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'[\"auser\", \"nokey\"]'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # remove_key with empty parameter
+        default_cmd = cmd_base + "remove_key"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # remove_key with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # remove_key with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'[\"auser\", \"none\", \"none\"]'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # create_key with empty parameter
+        default_cmd = cmd_base + "remove_key"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create_key with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create_key with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'[\"auser\", \"none\", \"none\"]'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # list_wallets with empty parameter
+        default_cmd = cmd_base + "list_wallets"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(type(ret_json), list)
+        # list_wallets with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+        # list_keys with empty parameter
+        default_cmd = cmd_base + "list_keys"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # list_keys with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # list_keys with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'[\"auser\", \"unknownkey\"]'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 500)
+
+        # get_public_keys with empty parameter
+        default_cmd = cmd_base + "get_public_keys"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(type(ret_json), dict)
+        # list_wallets with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+
+    # test all test control api
+    def test_TestControlApi(self) :
+        cmd_base = self.base_node_cmd_str + "test_control/"
+
+        # kill_node_on_producer with empty parameter
+        default_cmd = cmd_base + "kill_node_on_producer"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # kill_node_on_producer with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # kill_node_on_producer with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"name\":\"auser\", \"where_in_sequence\":12, \"based_on_lib\":true}'")
+        ret_str = Utils.runCmdReturnStr(valid_cmd)
+        self.assertIn("{}", ret_str)
+
+    # test all trace api
+    def test_TraceApi(self) :
+        cmd_base = self.base_node_cmd_str + "trace_api/"
+
+        # get_block with empty parameter
+        default_cmd = cmd_base + "get_block"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_block with valid parameter
+        valid_cmd = default_cmd + self.http_post_str + ("'{\"block_num\":1}'")
+        ret_json = Utils.runCmdReturnJson(valid_cmd)
+        self.assertEqual(ret_json["code"], 404)
+        self.assertEqual(ret_json["error"]["code"], 0)
+
+    @classmethod
+    def setUpClass(self):
+        self.cleanEnv(self)
+        self.startEnv(self)
+
+    @classmethod
+    def tearDownClass(self):
+        self.cleanEnv(self)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -20,6 +20,7 @@ class PluginHttpTest(unittest.TestCase):
     data_dir = Utils.getNodeDataDir(node_id)
     http_post_str = " -X POST -d "
     http_post_invalid_param = " '{invalid}' "
+    empty_content_str = " ' { } '  "
 
     # make a fresh data dir
     def createDataDir(self):
@@ -66,6 +67,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_info"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertIn("server_version", ret_json)
+        # get_info with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("server_version", ret_json)
         # get_info with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -74,6 +79,10 @@ class PluginHttpTest(unittest.TestCase):
         # get_activated_protocol_features without parameter
         default_cmd = cmd_base + "get_activated_protocol_features"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        # get_activated_protocol_features with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
         # get_activated_protocol_features with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
@@ -114,6 +123,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_block"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
+        # get_block with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
         # get_block with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -127,6 +140,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_block_info"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
+        # get_block_info with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
         # get_block_info with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -139,6 +156,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_block_header_state with empty parameter
         default_cmd = cmd_base + "get_block_header_state"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_block_header_state with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_block_header_state with invalid parameter
@@ -157,6 +179,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_account with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_account with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -170,6 +197,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_code with empty parameter
         default_cmd = cmd_base + "get_code"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_code with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_code with invalid parameter
@@ -187,6 +219,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_code_hash with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_code_hash with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -200,6 +237,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_abi with empty parameter
         default_cmd = cmd_base + "get_abi"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_abi with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_abi with invalid parameter
@@ -217,6 +259,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_raw_code_and_abi with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_raw_code_and_abi with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -232,6 +279,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_raw_abi with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_raw_abi with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -245,6 +297,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_table_rows with empty parameter
         default_cmd = cmd_base + "get_table_rows"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_table_rows with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_table_rows with invalid parameter
@@ -271,6 +328,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_table_by_scope with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_table_by_scope with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -292,6 +354,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_currency_balance with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_currency_balance with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -305,6 +372,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_currency_stats with empty parameter
         default_cmd = cmd_base + "get_currency_stats"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_currency_stats with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_currency_stats with invalid parameter
@@ -322,6 +394,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_producers with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_producers with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -336,6 +413,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_producer_schedule"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(type(ret_json["active"]), dict)
+        # get_producer_schedule with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(type(ret_json["active"]), dict)
         # get_producer_schedule with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -345,6 +426,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_scheduled_transactions with empty parameter
         default_cmd = cmd_base + "get_scheduled_transactions"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_scheduled_transactions with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_scheduled_transactions with invalid parameter
@@ -360,6 +446,11 @@ class PluginHttpTest(unittest.TestCase):
         # abi_json_to_bin with empty parameter
         default_cmd = cmd_base + "abi_json_to_bin"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # abi_json_to_bin with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # abi_json_to_bin with invalid parameter
@@ -381,6 +472,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # abi_bin_to_json with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # abi_bin_to_json with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -398,6 +494,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_required_keys with empty p4arameter
         default_cmd = cmd_base + "get_required_keys"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_required_keys with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_required_keys with invalid parameter
@@ -422,9 +523,14 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(valid_cmd)
         self.assertEqual(ret_json["code"], 500)
 
-        # get_transaction_id with empty p4arameter
+        # get_transaction_id with empty parameter
         default_cmd = cmd_base + "get_transaction_id"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_transaction_id with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_transaction_id with invalid parameter
@@ -455,6 +561,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_block with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # push_block with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -468,6 +579,11 @@ class PluginHttpTest(unittest.TestCase):
         # push_transaction with empty parameter
         default_cmd = cmd_base + "push_transaction"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_transaction with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # push_transaction with invalid parameter
@@ -490,6 +606,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # push_transactions with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # push_transactions with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -508,6 +629,11 @@ class PluginHttpTest(unittest.TestCase):
         # send_transaction with empty parameter
         default_cmd = cmd_base + "send_transaction"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # send_transaction with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # send_transaction with invalid parameter
@@ -534,6 +660,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_actions with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_actions with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -547,6 +678,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_transaction with empty parameter
         default_cmd = cmd_base + "get_transaction"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_transaction with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_transaction with invalid parameter
@@ -566,6 +702,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_key_accounts with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_key_accounts with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -579,6 +720,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_controlled_accounts with empty parameter
         default_cmd = cmd_base + "get_controlled_accounts"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_controlled_accounts with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_controlled_accounts with invalid parameter
@@ -600,6 +746,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # connect with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # connect with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -613,6 +764,11 @@ class PluginHttpTest(unittest.TestCase):
         # disconnect with empty parameter
         default_cmd = cmd_base + "disconnect"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # disconnect with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # disconnect with invalid parameter
@@ -630,6 +786,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # status with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # status with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -642,6 +803,10 @@ class PluginHttpTest(unittest.TestCase):
 
         # connections with empty parameter
         default_cmd = cmd_base + "connections"
+        ret_str = Utils.runCmdReturnStr(default_cmd)
+        self.assertEqual(ret_str, "[]")
+        # connections with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
         ret_str = Utils.runCmdReturnStr(default_cmd)
         self.assertEqual(ret_str, "[]")
         # connections with invalid parameter
@@ -658,6 +823,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "pause"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["result"], "ok")
+        # pause with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["result"], "ok")
         # pause with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -668,6 +837,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "resume"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["result"], "ok")
+        # resume with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["result"], "ok")
         # resume with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -676,6 +849,10 @@ class PluginHttpTest(unittest.TestCase):
 
         # paused with empty parameter
         default_cmd = cmd_base + "paused"
+        ret_str = Utils.runCmdReturnStr(default_cmd)
+        self.assertEqual(ret_str, "false")
+        # paused with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
         ret_str = Utils.runCmdReturnStr(default_cmd)
         self.assertEqual(ret_str, "false")
         # paused with invalid parameter
@@ -688,6 +865,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_runtime_options"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertIn("max_transaction_time", ret_json)
+        # get_runtime_options with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("max_transaction_time", ret_json)
         # get_runtime_options with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -697,6 +878,11 @@ class PluginHttpTest(unittest.TestCase):
         # update_runtime_options with empty parameter
         default_cmd = cmd_base + "update_runtime_options"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # update_runtime_options with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # update_runtime_options with invalid parameter
@@ -721,6 +907,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # add_greylist_accounts with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # add_greylist_accounts with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -734,6 +925,11 @@ class PluginHttpTest(unittest.TestCase):
         # remove_greylist_accounts with empty parameter
         default_cmd = cmd_base + "remove_greylist_accounts"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # remove_greylist_accounts with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # remove_greylist_accounts with invalid parameter
@@ -750,6 +946,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_greylist"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertIn("accounts", ret_json)
+        # get_greylist with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("accounts", ret_json)
         # get_greylist with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -765,6 +965,15 @@ class PluginHttpTest(unittest.TestCase):
         self.assertIn("contract_blacklist", ret_json)
         self.assertIn("action_blacklist", ret_json)
         self.assertIn("key_blacklist", ret_json)
+        # get_whitelist_blacklist with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("actor_whitelist", ret_json)
+        self.assertIn("actor_blacklist", ret_json)
+        self.assertIn("contract_whitelist", ret_json)
+        self.assertIn("contract_blacklist", ret_json)
+        self.assertIn("action_blacklist", ret_json)
+        self.assertIn("key_blacklist", ret_json)
         # get_whitelist_blacklist with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -774,6 +983,11 @@ class PluginHttpTest(unittest.TestCase):
         # set_whitelist_blacklist with empty parameter
         default_cmd = cmd_base + "set_whitelist_blacklist"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # set_whitelist_blacklist with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # set_whitelist_blacklist with invalid parameter
@@ -796,6 +1010,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertIn("head_block_id", ret_json)
         self.assertIn("integrity_hash", ret_json)
+        # get_integrity_hash with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("head_block_id", ret_json)
+        self.assertIn("integrity_hash", ret_json)
         # get_integrity_hash with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -805,6 +1024,11 @@ class PluginHttpTest(unittest.TestCase):
         # create_snapshot with empty parameter
         default_cmd = cmd_base + "create_snapshot"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 500)
+        self.assertEqual(ret_json["error"]["code"], 3170000)
+        # create_snapshot with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 500)
         self.assertEqual(ret_json["error"]["code"], 3170000)
         # create_snapshot with invalid parameter
@@ -822,6 +1046,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_scheduled_protocol_feature_activations"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertIn("protocol_features_to_activate", ret_json)
+        # get_scheduled_protocol_feature_activations with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("protocol_features_to_activate", ret_json)
         # get_scheduled_protocol_feature_activations with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -831,6 +1059,11 @@ class PluginHttpTest(unittest.TestCase):
         # schedule_protocol_feature_activations with empty parameter
         default_cmd = cmd_base + "schedule_protocol_feature_activations"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # schedule_protocol_feature_activations with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # schedule_protocol_feature_activations with invalid parameter
@@ -846,6 +1079,11 @@ class PluginHttpTest(unittest.TestCase):
         # get_supported_protocol_features with empty parameter
         default_cmd = cmd_base + "get_supported_protocol_features"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("feature_digest", ret_json[0])
+        self.assertIn("subjective_restrictions", ret_json[0])
+        # get_supported_protocol_features with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertIn("feature_digest", ret_json[0])
         self.assertIn("subjective_restrictions", ret_json[0])
         # get_supported_protocol_features with invalid parameter
@@ -874,6 +1112,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_account_ram_corrections with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # get_account_ram_corrections with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -893,6 +1136,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # set_timeout with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # set_timeout with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -906,6 +1154,11 @@ class PluginHttpTest(unittest.TestCase):
         # sign_transaction with empty parameter
         default_cmd = cmd_base + "sign_transaction"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # sign_transaction with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # sign_transaction with invalid parameter
@@ -937,6 +1190,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # create with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -950,6 +1208,11 @@ class PluginHttpTest(unittest.TestCase):
         # open with empty parameter
         default_cmd = cmd_base + "open"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # open with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # create with invalid parameter
@@ -966,6 +1229,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "lock_all"
         ret_str = Utils.runCmdReturnStr(default_cmd)
         self.assertEqual("{}", ret_str)
+        # lock_all with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_str = Utils.runCmdReturnStr(default_cmd)
+        self.assertEqual("{}", ret_str)
         # lock_all with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -975,6 +1242,11 @@ class PluginHttpTest(unittest.TestCase):
         # lock with empty parameter
         default_cmd = cmd_base + "lock"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # lock with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # lock with invalid parameter
@@ -992,6 +1264,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # unlock with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # unlock with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -1005,6 +1282,11 @@ class PluginHttpTest(unittest.TestCase):
         # import_key with empty parameter
         default_cmd = cmd_base + "import_key"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # import_key with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # import_key with invalid parameter
@@ -1022,6 +1304,11 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
+        # remove_key with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
         # remove_key with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -1035,6 +1322,11 @@ class PluginHttpTest(unittest.TestCase):
         # create_key with empty parameter
         default_cmd = cmd_base + "remove_key"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # create_key with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # create_key with invalid parameter
@@ -1051,6 +1343,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "list_wallets"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(type(ret_json), list)
+        # list_wallets with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(type(ret_json), list)
         # list_wallets with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -1060,6 +1356,11 @@ class PluginHttpTest(unittest.TestCase):
         # list_keys with empty parameter
         default_cmd = cmd_base + "list_keys"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # list_keys with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # list_keys with invalid parameter
@@ -1076,6 +1377,10 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_public_keys"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(type(ret_json), dict)
+        # get_public_keys with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertEqual(type(ret_json), dict)
         # list_wallets with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
@@ -1089,6 +1394,11 @@ class PluginHttpTest(unittest.TestCase):
         # kill_node_on_producer with empty parameter
         default_cmd = cmd_base + "kill_node_on_producer"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        self.assertEqual(ret_json["error"]["code"], 3200006)
+        # get_info with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
         # kill_node_on_producer with invalid parameter
@@ -1108,6 +1418,10 @@ class PluginHttpTest(unittest.TestCase):
         # get_block with empty parameter
         default_cmd = cmd_base + "get_block"
         ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertEqual(ret_json["code"], 400)
+        # get_info with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
         # get_block with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -41,7 +41,7 @@ class PluginHttpTest(unittest.TestCase):
     def startEnv(self) :
         self.createDataDir(self)
         self.keosd.launch()
-        nodeos_plugins = (" --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s"
+        nodeos_plugins = (" --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s"
                           " --plugin %s --plugin %s --plugin %s --plugin %s ") % ( "eosio::trace_api_plugin",
                                                                                    "eosio::test_control_api_plugin",
                                                                                    "eosio::test_control_plugin",
@@ -50,10 +50,8 @@ class PluginHttpTest(unittest.TestCase):
                                                                                    "eosio::producer_plugin",
                                                                                    "eosio::producer_api_plugin",
                                                                                    "eosio::chain_api_plugin",
-                                                                                   "eosio::http_plugin",
-                                                                                   "eosio::history_plugin",
-                                                                                   "eosio::history_api_plugin")
-        nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --filter-on=%s --access-control-allow-origin=%s "
+                                                                                   "eosio::http_plugin")
+        nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --access-control-allow-origin=%s "
                         "--contracts-console --http-validate-host=%s --verbose-http-errors ") % (self.data_dir, self.data_dir, "\"*\"", "\'*\'", "false")
         start_nodeos_cmd = ("%s -e -p eosio %s %s ") % (Utils.EosServerPath, nodeos_plugins, nodeos_flags)
         self.nodeos.launchCmd(start_nodeos_cmd, self.node_id)
@@ -651,91 +649,6 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(valid_cmd)
         self.assertEqual(ret_json["code"], 500)
 
-    # test all history api
-    def test_HistoryApi(self) :
-        cmd_base = self.base_node_cmd_str + "history/"
-
-        # get_actions with empty parameter
-        default_cmd = cmd_base + "get_actions"
-        ret_json = Utils.runCmdReturnJson(default_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_actions with empty content parameter
-        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
-        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_actions with invalid parameter
-        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
-        ret_json = Utils.runCmdReturnJson(invalid_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_actions with valid parameter
-        valid_cmd = default_cmd + self.http_post_str + ("'{\"account_name\":\"test\", \"pos\":-1, \"offset\":2}'")
-        ret_json = Utils.runCmdReturnJson(valid_cmd)
-        self.assertIn("last_irreversible_block", ret_json)
-
-        # get_transaction with empty parameter
-        default_cmd = cmd_base + "get_transaction"
-        ret_json = Utils.runCmdReturnJson(default_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_transaction with empty content parameter
-        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
-        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_transaction with invalid parameter
-        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
-        ret_json = Utils.runCmdReturnJson(invalid_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_transaction with valid parameter
-        valid_cmd = default_cmd + self.http_post_str + ("'{\"id\":\"test\", \"block_num_hint\":1}'")
-        ret_json = Utils.runCmdReturnJson(valid_cmd)
-        # no transaction, so 500 error being sent back instead
-        self.assertEqual(ret_json["code"], 500)
-        self.assertEqual(ret_json["error"]["code"], 3010009)
-
-        # get_key_accounts with empty parameter
-        default_cmd = cmd_base + "get_key_accounts"
-        ret_json = Utils.runCmdReturnJson(default_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_key_accounts with empty content parameter
-        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
-        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_key_accounts with invalid parameter
-        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
-        ret_json = Utils.runCmdReturnJson(invalid_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_key_accounts with valid parameter
-        valid_cmd = default_cmd + self.http_post_str + ("'{\"public_key\":\"EOS6FxXbikY5ZUN9qEdeLbEYLKZzJwRYRr2PuC3rqfSu67LvhPARi\"}'")
-        ret_json = Utils.runCmdReturnJson(valid_cmd)
-        self.assertIn("account_names", ret_json)
-
-        # get_controlled_accounts with empty parameter
-        default_cmd = cmd_base + "get_controlled_accounts"
-        ret_json = Utils.runCmdReturnJson(default_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_controlled_accounts with empty content parameter
-        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
-        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_controlled_accounts with invalid parameter
-        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
-        ret_json = Utils.runCmdReturnJson(invalid_cmd)
-        self.assertEqual(ret_json["code"], 400)
-        self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_controlled_accounts with valid parameter
-        valid_cmd = default_cmd + self.http_post_str + ("'{\"controlling_account\":\"test\"}'")
-        ret_json = Utils.runCmdReturnJson(valid_cmd)
-        self.assertIn("controlled_accounts", ret_json)
 
     # test all net api
     def test_NetApi(self) :

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -52,7 +52,7 @@ class PluginHttpTest(unittest.TestCase):
                                                                                    "eosio::chain_api_plugin",
                                                                                    "eosio::http_plugin")
         nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --access-control-allow-origin=%s "
-                        "--contracts-console --http-validate-host=%s --verbose-http-errors ") % (self.data_dir, self.data_dir, "\"*\"", "\'*\'", "false")
+                        "--contracts-console --http-validate-host=%s --verbose-http-errors ") % (self.data_dir, self.data_dir, "\'*\'", "false")
         start_nodeos_cmd = ("%s -e -p eosio %s %s ") % (Utils.EosServerPath, nodeos_plugins, nodeos_flags)
         self.nodeos.launchCmd(start_nodeos_cmd, self.node_id)
         time.sleep(self.sleep_s)

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -937,23 +937,8 @@ class PluginHttpTest(unittest.TestCase):
         # create_snapshot with empty parameter
         default_cmd = cmd_base + "create_snapshot"
         ret_json = Utils.runCmdReturnJson(default_cmd)
-        self.assertEqual(ret_json["code"], 500)
-        self.assertEqual(ret_json["error"]["code"], 3170000)
-        # create_snapshot with empty content parameter
-        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
-        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
-        self.assertEqual(ret_json["code"], 500)
-        self.assertEqual(ret_json["error"]["code"], 3170000)
-        # create_snapshot with invalid parameter
-        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
-        ret_json = Utils.runCmdReturnJson(invalid_cmd)
-        self.assertEqual(ret_json["code"], 500)
-        self.assertEqual(ret_json["error"]["code"], 3170000)
-        # create_snapshot with valid parameter
-        valid_cmd = default_cmd + self.http_post_str + ("'{\"content-type: application/x-www-form-urlencoded; charset=UTF-8\"}'")
-        ret_json = Utils.runCmdReturnJson(valid_cmd)
-        self.assertEqual(ret_json["code"], 500)
-        self.assertEqual(ret_json["error"]["code"], 3170000)
+        self.assertIn("head_block_id", ret_json)
+        self.assertIn("snapshot_name", ret_json)
 
         # get_scheduled_protocol_feature_activations with empty parameter
         default_cmd = cmd_base + "get_scheduled_protocol_feature_activations"

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -48,7 +48,8 @@ target_include_directories( unit_test PUBLIC
                             ${CMAKE_BINARY_DIR}/contracts
                             ${CMAKE_CURRENT_SOURCE_DIR}/contracts
                             ${CMAKE_CURRENT_BINARY_DIR}/contracts
-                            ${CMAKE_CURRENT_BINARY_DIR}/include )
+                            ${CMAKE_CURRENT_BINARY_DIR}/include
+                            ${CMAKE_SOURCE_DIR}/plugins/http_plugin/include )
 
 ### MARK TEST SUITES FOR EXECUTION ###
 add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output --catch_system_errors=no)

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -1,0 +1,82 @@
+#include <boost/test/unit_test.hpp>
+#include <eosio/testing/tester.hpp>
+#include <eosio/http_plugin/http_plugin.hpp>
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::testing;
+
+template<typename T>
+auto call_parse_no_params_required(const string& body)
+{
+   return parse_params<T, http_params_types::no_params_required>(body);
+}
+
+template<typename T>
+auto call_parse_params_required(const string& body)
+{
+   return parse_params<T, http_params_types::params_required>(body);
+}
+
+template<typename T>
+auto call_parse_possible_no_params(const string& body)
+{
+   return parse_params<T, http_params_types::possible_no_params>(body);
+}
+
+BOOST_AUTO_TEST_SUITE(plugin_tests)
+
+BOOST_AUTO_TEST_CASE( parse_params ) try {
+   { // empty body, no input
+      const std::string empty_str;
+      BOOST_REQUIRE(empty_str.empty());
+      BOOST_REQUIRE_NO_THROW(
+         auto test_result = call_parse_no_params_required<int>(empty_str);
+         BOOST_REQUIRE(test_result == 0);
+      );
+      BOOST_REQUIRE_NO_THROW(
+         auto test_result = call_parse_possible_no_params<std::string>(empty_str);
+         BOOST_REQUIRE(test_result == "{}");
+      );
+      BOOST_REQUIRE_NO_THROW(
+            auto test_result = call_parse_no_params_required<std::string>(empty_str);
+            BOOST_REQUIRE(test_result == "{}");
+      );
+      BOOST_REQUIRE_THROW(
+            call_parse_params_required<int>(empty_str), chain::invalid_http_request
+      );
+   }
+   // invalid input
+   {
+      const std::string invalid_int_str = "#$%";
+      BOOST_REQUIRE(!invalid_int_str.empty());
+      BOOST_REQUIRE_THROW(
+         call_parse_no_params_required<int>(invalid_int_str), chain::invalid_http_request
+      );
+      BOOST_REQUIRE_THROW(
+         call_parse_possible_no_params<int>(invalid_int_str), chain::invalid_http_request
+      );
+      BOOST_REQUIRE_THROW(
+         call_parse_params_required<int>(invalid_int_str), chain::invalid_http_request
+      );
+   }
+   // valid input
+   {
+      const int exp_result = 1234;
+      const std::string valid_int_str = std::to_string(exp_result);
+      BOOST_REQUIRE(!valid_int_str.empty());
+      BOOST_REQUIRE_THROW(
+         call_parse_no_params_required<int>(valid_int_str), chain::invalid_http_request
+      );
+      BOOST_REQUIRE_NO_THROW(
+         const auto ret = call_parse_possible_no_params<int>(valid_int_str);
+         BOOST_REQUIRE(ret == exp_result);
+      );
+      BOOST_REQUIRE_NO_THROW(
+         const auto ret = call_parse_params_required<int>(valid_int_str);
+         BOOST_REQUIRE(ret == exp_result);
+      );
+   }
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -7,9 +7,9 @@ using namespace eosio::chain;
 using namespace eosio::testing;
 
 template<typename T>
-auto call_parse_no_params_required(const string& body)
+auto call_parse_no_params(const string& body)
 {
-   return parse_params<T, http_params_types::no_params_required>(body);
+   return parse_params<T, http_params_types::no_params>( body);
 }
 
 template<typename T>
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
       const std::string empty_str;
       BOOST_REQUIRE(empty_str.empty());
       BOOST_REQUIRE_NO_THROW(
-         auto test_result = call_parse_no_params_required<int>(empty_str);
+         auto test_result = call_parse_no_params<int>(empty_str);
          BOOST_REQUIRE(test_result == 0);
       );
       BOOST_REQUIRE_NO_THROW(
@@ -152,7 +152,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
          BOOST_REQUIRE(test_result == "{}");
       );
       BOOST_REQUIRE_NO_THROW(
-            auto test_result = call_parse_no_params_required<std::string>(empty_str);
+            auto test_result = call_parse_no_params<std::string>(empty_str);
             BOOST_REQUIRE(test_result == "{}");
       );
       BOOST_REQUIRE_THROW(
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
       const std::string invalid_int_str = "#$%";
       BOOST_REQUIRE(!invalid_int_str.empty());
       BOOST_REQUIRE_THROW(
-         call_parse_no_params_required<int>(invalid_int_str), chain::invalid_http_request
+         call_parse_no_params<int>(invalid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_THROW(
          call_parse_possible_no_params<int>(invalid_int_str), chain::invalid_http_request
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
       const std::string valid_int_str = std::to_string(exp_result);
       BOOST_REQUIRE(!valid_int_str.empty());
       BOOST_REQUIRE_THROW(
-         call_parse_no_params_required<int>(valid_int_str), chain::invalid_http_request
+         call_parse_no_params<int>(valid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_NO_THROW(
          const auto ret = call_parse_possible_no_params<int>(valid_int_str);

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -26,52 +26,52 @@ auto call_parse_possible_no_params(const string& body)
 
 BOOST_AUTO_TEST_SUITE(plugin_tests)
 
-BOOST_AUTO_TEST_CASE( get_trimmed_string_view ) try {
+BOOST_AUTO_TEST_CASE( make_trimmed_string_view ) try {
    {  // empty string
       const std::string empty_str;
       BOOST_REQUIRE(empty_str.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(empty_str).empty());
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(empty_str).empty());
    }
    {  // all spacee string
       for(size_t idx=0; idx<10; ++idx) {
          const std::string space_str(idx, ' ');
          BOOST_REQUIRE(space_str.size() == idx);
-         BOOST_REQUIRE(eosio::get_trimmed_string_view(space_str).empty());
+         BOOST_REQUIRE(eosio::make_trimmed_string_view(space_str).empty());
       }
    }
    {  // space on the head/tail only
       const std::string one_char_no_space  = "a";
       BOOST_REQUIRE(!one_char_no_space.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_no_space) == one_char_no_space);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_no_space) == one_char_no_space);
 
       const std::string one_char_with_leading_space = " " + one_char_no_space;
       BOOST_REQUIRE(!one_char_with_leading_space.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_with_leading_space) == one_char_no_space);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_with_leading_space) == one_char_no_space);
 
       const std::string one_char_with_trailing_space = one_char_no_space + " ";
       BOOST_REQUIRE(!one_char_with_trailing_space.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_with_trailing_space) == one_char_no_space);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_with_trailing_space) == one_char_no_space);
 
       const std::string one_char_with_space_both_side = " " + one_char_no_space + " ";
       BOOST_REQUIRE(!one_char_with_space_both_side.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_with_space_both_side) == one_char_no_space);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_with_space_both_side) == one_char_no_space);
    }
    {  // space on the head/tail and body only
       const std::string str_no_pace_both_side  = "a b";
       BOOST_REQUIRE(!str_no_pace_both_side.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_no_pace_both_side) == str_no_pace_both_side);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_no_pace_both_side) == str_no_pace_both_side);
 
       const std::string str_with_leading_space = " " + str_no_pace_both_side;
       BOOST_REQUIRE(!str_with_leading_space.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_with_leading_space) == str_no_pace_both_side);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_with_leading_space) == str_no_pace_both_side);
 
       const std::string str_with_with_trailing_space = str_no_pace_both_side + " ";
       BOOST_REQUIRE(!str_with_with_trailing_space.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_with_with_trailing_space) == str_no_pace_both_side);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_with_with_trailing_space) == str_no_pace_both_side);
 
       const std::string str_with_with_space_both_side = " " + str_no_pace_both_side + " ";
       BOOST_REQUIRE(!str_with_with_space_both_side.empty());
-      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_with_with_space_both_side) == str_no_pace_both_side);
+      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_with_with_space_both_side) == str_no_pace_both_side);
    }
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -7,35 +7,80 @@ using namespace eosio::chain;
 using namespace eosio::testing;
 
 template<typename T>
-auto call_parse_no_params_required(const string& body)
+auto call_parse_no_params_required(string& body)
 {
    return parse_params<T, http_params_types::no_params_required>(body);
 }
 
 template<typename T>
-auto call_parse_params_required(const string& body)
+auto call_parse_params_required(string& body)
 {
    return parse_params<T, http_params_types::params_required>(body);
 }
 
 template<typename T>
-auto call_parse_possible_no_params(const string& body)
+auto call_parse_possible_no_params(string& body)
 {
    return parse_params<T, http_params_types::possible_no_params>(body);
 }
 
-namespace {
-struct int_struct {
-   int v = 0;
-};
-} // anonymous namespace
-FC_REFLECT(int_struct, (v));
-
 BOOST_AUTO_TEST_SUITE(plugin_tests)
+
+BOOST_AUTO_TEST_CASE( isEmptyContent ) try {
+   {  // empty string
+      std::string empty_str;
+      BOOST_REQUIRE(empty_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_str) == true);
+   }
+   {  // empty content string
+      std::string empty_content_str = "{}";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
+      empty_content_str = " {} ";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
+      empty_content_str = " { } ";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
+      empty_content_str = " { \t} ";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
+   }
+   {  // one char string
+      std::string one_char_str = "{";
+      BOOST_REQUIRE(!one_char_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(one_char_str) == false) ;
+      one_char_str = "}";
+      BOOST_REQUIRE(!one_char_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(one_char_str) == false) ;
+      one_char_str = " ";  // it will be trimmed
+      BOOST_REQUIRE(!one_char_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(one_char_str) == true) ;
+   }
+   {  // some content string
+      std::string empty_content_str = "{a}";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == false);
+      empty_content_str = " {\'\'} ";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == false);
+      empty_content_str = " {\" \"} ";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == false);
+   }
+   {  // invalid string
+      std::string invalid_str = "{  a";
+      BOOST_REQUIRE(!invalid_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(invalid_str) == false);
+invalid_str = " a } ";
+      BOOST_REQUIRE(! invalid_str.empty());
+      BOOST_REQUIRE(eosio::isEmptyContent(invalid_str) == false);
+   }
+} FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( parse_params ) try {
    { // empty body, no input
-      const std::string empty_str;
+      std::string empty_str;
       BOOST_REQUIRE(empty_str.empty());
       BOOST_REQUIRE_NO_THROW(
          auto test_result = call_parse_no_params_required<int>(empty_str);
@@ -50,30 +95,30 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
             BOOST_REQUIRE(test_result == "{}");
       );
       BOOST_REQUIRE_THROW(
-            call_parse_params_required<int_struct>(empty_str), chain::invalid_http_request
+            call_parse_params_required<int>(empty_str), chain::invalid_http_request
       );
    }
    // invalid input
    {
-      const std::string invalid_int_str = "#$%";
+      std::string invalid_int_str = "#$%";
       BOOST_REQUIRE(!invalid_int_str.empty());
       BOOST_REQUIRE_THROW(
-         call_parse_no_params_required<int_struct>(invalid_int_str), chain::invalid_http_request
+         call_parse_no_params_required<int>(invalid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_THROW(
-         call_parse_possible_no_params<int_struct>(invalid_int_str), chain::invalid_http_request
+         call_parse_possible_no_params<int>(invalid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_THROW(
-         call_parse_params_required<int_struct>(invalid_int_str), chain::invalid_http_request
+         call_parse_params_required<int>(invalid_int_str), chain::invalid_http_request
       );
    }
    // valid input
    {
-      int_struct exp_result = {1234};
-      const std::string valid_int_str = fc::json::to_string(exp_result, fc::time_point::maximum());
+      const int exp_result = 1234;
+      std::string valid_int_str = std::to_string(exp_result);
       BOOST_REQUIRE(!valid_int_str.empty());
       BOOST_REQUIRE_THROW(
-         call_parse_no_params_required<int_struct>(valid_int_str), chain::invalid_http_request
+         call_parse_no_params_required<int>(valid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_NO_THROW(
          const auto ret = call_parse_possible_no_params<int_struct>(valid_int_str);
@@ -82,6 +127,22 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
       BOOST_REQUIRE_NO_THROW(
          const auto ret = call_parse_params_required<int_struct>(valid_int_str);
          BOOST_REQUIRE(ret.v == exp_result.v);
+      );
+   }
+   // empty content
+   {
+      std::string empty_content_str = " { \t } ";
+      BOOST_REQUIRE(!empty_content_str.empty());
+      BOOST_REQUIRE_NO_THROW(
+            auto test_result = call_parse_possible_no_params<std::string>(empty_content_str);
+            BOOST_REQUIRE(test_result == "{}");
+      );
+      BOOST_REQUIRE_NO_THROW(
+            auto test_result = call_parse_possible_no_params<std::string>(empty_content_str);
+            BOOST_REQUIRE(test_result == "{}");
+      );
+      BOOST_REQUIRE_THROW(
+            call_parse_params_required<int>(empty_content_str), chain::invalid_http_request
       );
    }
 } FC_LOG_AND_RETHROW()

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -7,24 +7,73 @@ using namespace eosio::chain;
 using namespace eosio::testing;
 
 template<typename T>
-auto call_parse_no_params_required(string& body)
+auto call_parse_no_params_required(const string& body)
 {
    return parse_params<T, http_params_types::no_params_required>(body);
 }
 
 template<typename T>
-auto call_parse_params_required(string& body)
+auto call_parse_params_required(const string& body)
 {
    return parse_params<T, http_params_types::params_required>(body);
 }
 
 template<typename T>
-auto call_parse_possible_no_params(string& body)
+auto call_parse_possible_no_params(const string& body)
 {
    return parse_params<T, http_params_types::possible_no_params>(body);
 }
 
 BOOST_AUTO_TEST_SUITE(plugin_tests)
+
+BOOST_AUTO_TEST_CASE( get_trimmed_string_view ) try {
+   {  // empty string
+      const std::string empty_str;
+      BOOST_REQUIRE(empty_str.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(empty_str).empty());
+   }
+   {  // all spacee string
+      for(size_t idx=0; idx<10; ++idx) {
+         const std::string space_str(idx, ' ');
+         BOOST_REQUIRE(space_str.size() == idx);
+         BOOST_REQUIRE(eosio::get_trimmed_string_view(space_str).empty());
+      }
+   }
+   {  // space on the head/tail only
+      const std::string one_char_no_space  = "a";
+      BOOST_REQUIRE(!one_char_no_space.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_no_space) == one_char_no_space);
+
+      const std::string one_char_with_leading_space = " " + one_char_no_space;
+      BOOST_REQUIRE(!one_char_with_leading_space.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_with_leading_space) == one_char_no_space);
+
+      const std::string one_char_with_trailing_space = one_char_no_space + " ";
+      BOOST_REQUIRE(!one_char_with_trailing_space.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_with_trailing_space) == one_char_no_space);
+
+      const std::string one_char_with_space_both_side = " " + one_char_no_space + " ";
+      BOOST_REQUIRE(!one_char_with_space_both_side.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(one_char_with_space_both_side) == one_char_no_space);
+   }
+   {  // space on the head/tail and body only
+      const std::string str_no_pace_both_side  = "a b";
+      BOOST_REQUIRE(!str_no_pace_both_side.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_no_pace_both_side) == str_no_pace_both_side);
+
+      const std::string str_with_leading_space = " " + str_no_pace_both_side;
+      BOOST_REQUIRE(!str_with_leading_space.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_with_leading_space) == str_no_pace_both_side);
+
+      const std::string str_with_with_trailing_space = str_no_pace_both_side + " ";
+      BOOST_REQUIRE(!str_with_with_trailing_space.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_with_with_trailing_space) == str_no_pace_both_side);
+
+      const std::string str_with_with_space_both_side = " " + str_no_pace_both_side + " ";
+      BOOST_REQUIRE(!str_with_with_space_both_side.empty());
+      BOOST_REQUIRE(eosio::get_trimmed_string_view(str_with_with_space_both_side) == str_no_pace_both_side);
+   }
+} FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE( is_empty_content ) try {
    {  // empty string
@@ -42,6 +91,15 @@ BOOST_AUTO_TEST_CASE( is_empty_content ) try {
       const std::string empty_content_str_3 = "{ \t}";
       BOOST_REQUIRE(!empty_content_str_3.empty());
       BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_3) == true);
+      const std::string empty_content_str_4 = " { }";
+      BOOST_REQUIRE(!empty_content_str_4.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_4) == true);
+      const std::string empty_content_str_5 = "{ } ";
+      BOOST_REQUIRE(!empty_content_str_5.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_5) == true);
+      const std::string empty_content_str_6 = " { } ";
+      BOOST_REQUIRE(!empty_content_str_6.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_6) == true);
    }
    {  // one char string
       const std::string one_char_str_1 = "{";
@@ -52,7 +110,7 @@ BOOST_AUTO_TEST_CASE( is_empty_content ) try {
       BOOST_REQUIRE(eosio::is_empty_content(one_char_str_2) == false) ;
       const std::string one_char_str_3 = " ";
       BOOST_REQUIRE(!one_char_str_3.empty());
-      BOOST_REQUIRE(eosio::is_empty_content(one_char_str_3) == false) ;
+      BOOST_REQUIRE(eosio::is_empty_content(one_char_str_3) == true) ;
    }
    {  // some content string
       const std::string empty_content_str_1 = "{a}";
@@ -72,10 +130,10 @@ BOOST_AUTO_TEST_CASE( is_empty_content ) try {
       const std::string invalid_str_2 = " a }";
       BOOST_REQUIRE(! invalid_str_2.empty());
       BOOST_REQUIRE(eosio::is_empty_content(invalid_str_2) == false);
-      const std::string invalid_str_3 =  " {}";
+      const std::string invalid_str_3 =  " {a}";
       BOOST_REQUIRE(!invalid_str_3.empty());
       BOOST_REQUIRE(eosio::is_empty_content(invalid_str_3) == false);
-      const std::string invalid_str_4 =  "{} ";
+      const std::string invalid_str_4 =  "{a} ";
       BOOST_REQUIRE(!invalid_str_4.empty());
       BOOST_REQUIRE(eosio::is_empty_content(invalid_str_4 ) == false);
    }
@@ -83,7 +141,7 @@ BOOST_AUTO_TEST_CASE( is_empty_content ) try {
 
 BOOST_AUTO_TEST_CASE( parse_params ) try {
    { // empty body, no input
-      std::string empty_str;
+      const std::string empty_str;
       BOOST_REQUIRE(empty_str.empty());
       BOOST_REQUIRE_NO_THROW(
          auto test_result = call_parse_no_params_required<int>(empty_str);
@@ -103,7 +161,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
    }
    // invalid input
    {
-      std::string invalid_int_str = "#$%";
+      const std::string invalid_int_str = "#$%";
       BOOST_REQUIRE(!invalid_int_str.empty());
       BOOST_REQUIRE_THROW(
          call_parse_no_params_required<int>(invalid_int_str), chain::invalid_http_request
@@ -118,7 +176,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
    // valid input
    {
       const int exp_result = 1234;
-      std::string valid_int_str = std::to_string(exp_result);
+      const std::string valid_int_str = std::to_string(exp_result);
       BOOST_REQUIRE(!valid_int_str.empty());
       BOOST_REQUIRE_THROW(
          call_parse_no_params_required<int>(valid_int_str), chain::invalid_http_request
@@ -134,7 +192,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
    }
    // empty content
    {
-      std::string empty_content_str = " { \t } ";
+      const std::string empty_content_str = " { \t } ";
       BOOST_REQUIRE(!empty_content_str.empty());
       BOOST_REQUIRE_NO_THROW(
             auto test_result = call_parse_possible_no_params<std::string>(empty_content_str);

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -26,55 +26,58 @@ auto call_parse_possible_no_params(string& body)
 
 BOOST_AUTO_TEST_SUITE(plugin_tests)
 
-BOOST_AUTO_TEST_CASE( isEmptyContent ) try {
+BOOST_AUTO_TEST_CASE( is_empty_content ) try {
    {  // empty string
-      std::string empty_str;
+      const std::string empty_str;
       BOOST_REQUIRE(empty_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_str) == true);
+      BOOST_REQUIRE(eosio::is_empty_content(empty_str) == true);
    }
    {  // empty content string
-      std::string empty_content_str = "{}";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
-      empty_content_str = " {} ";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
-      empty_content_str = " { } ";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
-      empty_content_str = " { \t} ";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == true);
+      const std::string empty_content_str_1 = "{}";
+      BOOST_REQUIRE(!empty_content_str_1.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_1) == true);
+      const std::string empty_content_str_2 = "{ }";
+      BOOST_REQUIRE(!empty_content_str_2.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_2) == true);
+      const std::string empty_content_str_3 = "{ \t}";
+      BOOST_REQUIRE(!empty_content_str_3.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_3) == true);
    }
    {  // one char string
-      std::string one_char_str = "{";
-      BOOST_REQUIRE(!one_char_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(one_char_str) == false) ;
-      one_char_str = "}";
-      BOOST_REQUIRE(!one_char_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(one_char_str) == false) ;
-      one_char_str = " ";  // it will be trimmed
-      BOOST_REQUIRE(!one_char_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(one_char_str) == true) ;
+      const std::string one_char_str_1 = "{";
+      BOOST_REQUIRE(!one_char_str_1.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(one_char_str_1) == false) ;
+      const std::string one_char_str_2 = "}";
+      BOOST_REQUIRE(!one_char_str_2.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(one_char_str_2) == false) ;
+      const std::string one_char_str_3 = " ";
+      BOOST_REQUIRE(!one_char_str_3.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(one_char_str_3) == false) ;
    }
    {  // some content string
-      std::string empty_content_str = "{a}";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == false);
-      empty_content_str = " {\'\'} ";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == false);
-      empty_content_str = " {\" \"} ";
-      BOOST_REQUIRE(!empty_content_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(empty_content_str) == false);
+      const std::string empty_content_str_1 = "{a}";
+      BOOST_REQUIRE(!empty_content_str_1.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_1) == false);
+      const std::string empty_content_str_2 = "{\'\'}";
+      BOOST_REQUIRE(!empty_content_str_2.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_2) == false);
+      const std::string empty_content_str_3 = "{\" \"}";
+      BOOST_REQUIRE(!empty_content_str_3.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(empty_content_str_3) == false);
    }
    {  // invalid string
-      std::string invalid_str = "{  a";
-      BOOST_REQUIRE(!invalid_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(invalid_str) == false);
-invalid_str = " a } ";
-      BOOST_REQUIRE(! invalid_str.empty());
-      BOOST_REQUIRE(eosio::isEmptyContent(invalid_str) == false);
+      const std::string invalid_str_1 = "{  a";
+      BOOST_REQUIRE(!invalid_str_1.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(invalid_str_1) == false);
+      const std::string invalid_str_2 = " a }";
+      BOOST_REQUIRE(! invalid_str_2.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(invalid_str_2) == false);
+      const std::string invalid_str_3 =  " {}";
+      BOOST_REQUIRE(!invalid_str_3.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(invalid_str_3) == false);
+      const std::string invalid_str_4 =  "{} ";
+      BOOST_REQUIRE(!invalid_str_4.empty());
+      BOOST_REQUIRE(eosio::is_empty_content(invalid_str_4 ) == false);
    }
 } FC_LOG_AND_RETHROW()
 

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -42,36 +42,36 @@ BOOST_AUTO_TEST_CASE( make_trimmed_string_view ) try {
    {  // space on the head/tail only
       const std::string one_char_no_space  = "a";
       BOOST_REQUIRE(!one_char_no_space.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_no_space) == one_char_no_space);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(one_char_no_space), one_char_no_space);
 
       const std::string one_char_with_leading_space = " " + one_char_no_space;
       BOOST_REQUIRE(!one_char_with_leading_space.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_with_leading_space) == one_char_no_space);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(one_char_with_leading_space), one_char_no_space);
 
       const std::string one_char_with_trailing_space = one_char_no_space + " ";
       BOOST_REQUIRE(!one_char_with_trailing_space.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_with_trailing_space) == one_char_no_space);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(one_char_with_trailing_space), one_char_no_space);
 
       const std::string one_char_with_space_both_side = " " + one_char_no_space + " ";
       BOOST_REQUIRE(!one_char_with_space_both_side.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(one_char_with_space_both_side) == one_char_no_space);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(one_char_with_space_both_side), one_char_no_space);
    }
    {  // space on the head/tail and body only
       const std::string str_no_pace_both_side  = "a b";
       BOOST_REQUIRE(!str_no_pace_both_side.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_no_pace_both_side) == str_no_pace_both_side);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(str_no_pace_both_side), str_no_pace_both_side);
 
       const std::string str_with_leading_space = " " + str_no_pace_both_side;
       BOOST_REQUIRE(!str_with_leading_space.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_with_leading_space) == str_no_pace_both_side);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(str_with_leading_space), str_no_pace_both_side);
 
       const std::string str_with_with_trailing_space = str_no_pace_both_side + " ";
       BOOST_REQUIRE(!str_with_with_trailing_space.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_with_with_trailing_space) == str_no_pace_both_side);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(str_with_with_trailing_space), str_no_pace_both_side);
 
       const std::string str_with_with_space_both_side = " " + str_no_pace_both_side + " ";
       BOOST_REQUIRE(!str_with_with_space_both_side.empty());
-      BOOST_REQUIRE(eosio::make_trimmed_string_view(str_with_with_space_both_side) == str_no_pace_both_side);
+      BOOST_CHECK_EQUAL(eosio::make_trimmed_string_view(str_with_with_space_both_side), str_no_pace_both_side);
    }
 } FC_LOG_AND_RETHROW()
 
@@ -182,12 +182,12 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
          call_parse_no_params_required<int>(valid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_NO_THROW(
-         const auto ret = call_parse_possible_no_params<int_struct>(valid_int_str);
-         BOOST_REQUIRE(ret.v == exp_result.v);
+         const auto ret = call_parse_possible_no_params<int>(valid_int_str);
+         BOOST_REQUIRE(ret == exp_result);
       );
       BOOST_REQUIRE_NO_THROW(
-         const auto ret = call_parse_params_required<int_struct>(valid_int_str);
-         BOOST_REQUIRE(ret.v == exp_result.v);
+         const auto ret = call_parse_params_required<int>(valid_int_str);
+         BOOST_REQUIRE(ret == exp_result);
       );
    }
    // empty content

--- a/unittests/plugin_tests.cpp
+++ b/unittests/plugin_tests.cpp
@@ -24,6 +24,13 @@ auto call_parse_possible_no_params(const string& body)
    return parse_params<T, http_params_types::possible_no_params>(body);
 }
 
+namespace {
+struct int_struct {
+   int v = 0;
+};
+} // anonymous namespace
+FC_REFLECT(int_struct, (v));
+
 BOOST_AUTO_TEST_SUITE(plugin_tests)
 
 BOOST_AUTO_TEST_CASE( parse_params ) try {
@@ -43,7 +50,7 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
             BOOST_REQUIRE(test_result == "{}");
       );
       BOOST_REQUIRE_THROW(
-            call_parse_params_required<int>(empty_str), chain::invalid_http_request
+            call_parse_params_required<int_struct>(empty_str), chain::invalid_http_request
       );
    }
    // invalid input
@@ -51,30 +58,30 @@ BOOST_AUTO_TEST_CASE( parse_params ) try {
       const std::string invalid_int_str = "#$%";
       BOOST_REQUIRE(!invalid_int_str.empty());
       BOOST_REQUIRE_THROW(
-         call_parse_no_params_required<int>(invalid_int_str), chain::invalid_http_request
+         call_parse_no_params_required<int_struct>(invalid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_THROW(
-         call_parse_possible_no_params<int>(invalid_int_str), chain::invalid_http_request
+         call_parse_possible_no_params<int_struct>(invalid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_THROW(
-         call_parse_params_required<int>(invalid_int_str), chain::invalid_http_request
+         call_parse_params_required<int_struct>(invalid_int_str), chain::invalid_http_request
       );
    }
    // valid input
    {
-      const int exp_result = 1234;
-      const std::string valid_int_str = std::to_string(exp_result);
+      int_struct exp_result = {1234};
+      const std::string valid_int_str = fc::json::to_string(exp_result, fc::time_point::maximum());
       BOOST_REQUIRE(!valid_int_str.empty());
       BOOST_REQUIRE_THROW(
-         call_parse_no_params_required<int>(valid_int_str), chain::invalid_http_request
+         call_parse_no_params_required<int_struct>(valid_int_str), chain::invalid_http_request
       );
       BOOST_REQUIRE_NO_THROW(
-         const auto ret = call_parse_possible_no_params<int>(valid_int_str);
-         BOOST_REQUIRE(ret == exp_result);
+         const auto ret = call_parse_possible_no_params<int_struct>(valid_int_str);
+         BOOST_REQUIRE(ret.v == exp_result.v);
       );
       BOOST_REQUIRE_NO_THROW(
-         const auto ret = call_parse_params_required<int>(valid_int_str);
-         BOOST_REQUIRE(ret == exp_result);
+         const auto ret = call_parse_params_required<int_struct>(valid_int_str);
+         BOOST_REQUIRE(ret.v == exp_result.v);
       );
    }
 } FC_LOG_AND_RETHROW()


### PR DESCRIPTION
Apply parameters check for every http calls.
* If empty body is not allowed, then report `"A Request body is required"` with error code `400`.
* Require JSON body to contain data for JSON object, `{}` will report: `"A Request body is required"` with error code `400`.
* If unable to parse JSON object for http param report: `"Unable to parse valid input from POST body"` with error code `400`. 

- Resolves #198 
- Resolves #199 
- Backports https://github.com/EOSIO/eos/pull/9033 & https://github.com/EOSIO/eos/pull/9209 & https://github.com/EOSIO/eos/pull/9317