### PR TITLE
Remove Unused Variable in transaction_context::init()

### DIFF
--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -92,7 +92,6 @@ namespace eosio { namespace chain {
    void transaction_context::init(uint64_t initial_net_usage)
    {
       EOS_ASSERT( !is_initialized, transaction_exception, "cannot initialize twice" );
-      const static int64_t large_number_no_overflow = std::numeric_limits<int64_t>::max()/2;
 
       const auto& cfg = control.get_global_properties().configuration;
       auto& rl = control.get_mutable_resource_limits_manager();


### PR DESCRIPTION
Ports over a simple change from EOSIO/eos#8269

> Remove unused variable `large_number_no_overflow` in `transaction_context::init`