### PR TITLE
bios boot tutorial sleep was too short on linux

### DIFF
--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -286,7 +286,7 @@ def stepStartWallet():
     importKeys()
 def stepStartBoot():
     startNode(0, {'name': 'eosio', 'pvt': args.private_key, 'pub': args.public_key})
-    sleep(1.5)
+    sleep(10.0)
 def stepInstallSystemContracts():
     run(args.cleos + 'set contract eosio.token ' + args.contracts_dir + '/eosio.token/')
     run(args.cleos + 'set contract eosio.msig ' + args.contracts_dir + '/eosio.msig/')


### PR DESCRIPTION
### port of https://github.com/EOSIO/eos/pull/9738

> The bios-boot-tutorial.py needs to give nodeos additional time starting up before it continues on with execution. If the script moves too fast, nodeos may not be at a point it is accepting p2p transactions and the follow on steps in the script will fail. 10 seconds seems long enough to allow the script to consistently succeed.

issue https://github.com/eosnetworkfoundation/mandel/issues/207