### PR TITLE
Backported code to preemptively create wallet dir

### DIFF
--- a/plugins/wallet_plugin/wallet_plugin.cpp
+++ b/plugins/wallet_plugin/wallet_plugin.cpp
@@ -42,9 +42,10 @@ void wallet_plugin::plugin_initialize(const variables_map& options) {
       if (options.count("wallet-dir")) {
          auto dir = options.at("wallet-dir").as<boost::filesystem::path>();
          if (dir.is_relative())
-            wallet_manager_ptr->set_dir(app().data_dir() / dir);
-         else
-            wallet_manager_ptr->set_dir(dir);
+            dir = app().data_dir() / dir;
+         if( !bfs::exists(dir) )
+            bfs::create_directories(dir);
+         wallet_manager_ptr->set_dir(dir);
       }
       if (options.count("unlock-timeout")) {
          auto timeout = options.at("unlock-timeout").as<int64_t>();

--- a/programs/keosd/main.cpp
+++ b/programs/keosd/main.cpp
@@ -84,8 +84,13 @@ int main(int argc, char** argv)
          .default_http_port = 0
       });
       app().register_plugin<wallet_api_plugin>();
-      if(!app().initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv))
-         return -1;
+      if(!app().initialize<wallet_plugin, wallet_api_plugin, http_plugin>(argc, argv)) {
+         const auto &opts = app().get_options();
+         if (opts.count("help") || opts.count("version") || opts.count("full-version") ||
+             opts.count("print-default-config")) {
+            return 0;
+         }
+      }
       initialize_logging();
       auto& http = app().get_plugin<http_plugin>();
       http.add_handler("/v1/" + keosd::config::key_store_executable_name + "/stop", [&a=app()](string, string, url_response_callback cb) { cb(200, fc::variant(fc::variant_object())); a.quit(); } );


### PR DESCRIPTION
Resolves https://github.com/eosnetworkfoundation/mandel/issues/212

Preemptively create the wallet directory before set_dir is called (which erroneously attempts to lock the file wallet.lock in a non-existent directory). This change eliminates the problem of requiring that the user must explicitly create the directory before using keosd.

https://github.com/EOSIO/eos/pull/8490