### PR TITLE
Fix transaction retry issue

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2292,7 +2292,8 @@ void read_write::send_transaction2(const read_write::send_transaction2_params& p
                next( std::get<fc::exception_ptr>( result ) );
             } else {
                try {
-                  if( retry && trx_retry.has_value() ) {
+                  auto trx_trace_ptr = std::get<transaction_trace_ptr>( result );
+                  if( retry && trx_retry.has_value() && !trx_trace_ptr->except) {
                      // will be ack'ed via next later
                      trx_retry->track_transaction( ptrx, retry_num_blocks,
                         [ptrx, next](const std::variant<fc::exception_ptr, std::unique_ptr<fc::variant>>& result ) {
@@ -2304,7 +2305,6 @@ void read_write::send_transaction2(const read_write::send_transaction2_params& p
                            }
                         } );
                   } else {
-                     auto trx_trace_ptr = std::get<transaction_trace_ptr>( result );
                      fc::variant output;
                      try {
                         output = db.to_variant_with_abi( *trx_trace_ptr, abi_serializer::create_yield_function( abi_serializer_max_time ) );

--- a/tests/nodeos_retry_transaction_test.py
+++ b/tests/nodeos_retry_transaction_test.py
@@ -174,6 +174,13 @@ try:
     startTime = nextTime
     lastIrreversibleBlockNum = None
 
+    overdrawAccount = accounts[0]
+    Print(f"Attempt to transfer more funds than available from {overdrawAccount.name} to test transaction fails with overdrawn balance, not expiration in retry.")
+    overdrawTransferAmount = "1001.0000 {0}".format(CORE_SYMBOL)
+    Print("Transfer funds %s from account %s to %s" % (overdrawTransferAmount, overdrawAccount.name, cluster.eosioAccount.name))
+    overdrawtrans = node.transferFunds(overdrawAccount, cluster.eosioAccount, overdrawTransferAmount, "test overdraw transfer", exitOnError=False, reportStatus=False, retry=1)
+    assert overdrawtrans["processed"]["except"]["stack"][0]["data"]["s"] == "overdrawn balance", "ERROR: Overdraw transaction attempt should have failed with overdrawn balance."
+
     def cacheTransIdInBlock(transId, transToBlock, node):
         global lastIrreversibleBlockNum
         lastPassLIB = None


### PR DESCRIPTION
Update to not retry if there was a valid reason the transaction failed.

Add test case.  This test case will use a funds transfer that would cause an overdraw to verify it fails due to the overdraw except instead of due to expiration in the retry.

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/215