### PR TITLE
Increase http-max-response-time-ms for tests

### DIFF
--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -72,6 +72,7 @@ try:
     extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 " + \
                    f"--transaction-finality-status-success-duration-sec {successDuration} --transaction-finality-status-failure-duration-sec {failure_duration}"
     extraNodeosArgs+=" --plugin eosio::trace_api_plugin --trace-no-abis"
+    extraNodeosArgs+=" --http-max-response-time-ms 990000"
 
 
     # ***   setup topogrophy   ***

--- a/tests/trx_finality_status_test.py
+++ b/tests/trx_finality_status_test.py
@@ -72,6 +72,7 @@ try:
     extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 " + \
                    f"--transaction-finality-status-success-duration-sec {successDuration} --transaction-finality-status-failure-duration-sec {failure_duration}"
     extraNodeosArgs+=" --plugin eosio::trace_api_plugin --trace-no-abis"
+    extraNodeosArgs+=" --http-max-response-time-ms 990000"
     if cluster.launch(prodCount=prodCount, onlyBios=False, pnodes=pnodes, totalNodes=totalNodes, totalProducers=pnodes*prodCount,
                       useBiosBootFile=False, topo="line", extraNodeosArgs=extraNodeosArgs) is False:
         Utils.errorExit("Failed to stand up eos cluster.")


### PR DESCRIPTION
All of our integration tests pass a large `http-max-response-time-ms` so that loading contracts does not time out on slow test machines. Added this to the two new transaction finality integration tests.

Resolves #229 