### PR TITLE
remove bash4 lowercase operation and just use python for release-build test

### DIFF
--- a/tests/release-build.sh
+++ b/tests/release-build.sh
@@ -11,8 +11,8 @@ echo 'nodeos from source should perform a "release build" which excludes asserts
 echo 'debugging symbols, and performs compiler optimizations.'
 echo ''
 
-NODEOS_DEBUG=$(programs/nodeos/nodeos --extract-build-info >(python3 -c 'import json,sys; print(json.load(sys.stdin)["debug"]);') &> /dev/null)
-if [[ "${NODEOS_DEBUG,,}" == 'false' ]]; then
+NODEOS_DEBUG=$(programs/nodeos/nodeos --extract-build-info >(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["debug"]).lower());') &> /dev/null)
+if [[ "${NODEOS_DEBUG}" == 'false' ]]; then
     echo 'PASS: Debug flag is not set.'
     echo ''
     exit 0


### PR DESCRIPTION
Remove a bash4ism from this test and just use Python to convert the boolean to a known-case string. Fixes the test on macos which ships with an ancient bash