### PR TITLE
Backport: chain api plugin / get_activated_protocol_features modifications

### DIFF
--- a/plugins/chain_api_plugin/chain.swagger.yaml
+++ b/plugins/chain_api_plugin/chain.swagger.yaml
@@ -691,31 +691,22 @@ paths:
           application/json:
             schema:
               type: object
-              required:
-                - params
               properties:
-                params:
-                  type: object
-                  description: Defines the filters to retreive the protocol features by
-                  required:
-                    - search_by_block_num
-                    - reverse
-                  properties:
-                    lower_bound:
-                      type: integer
-                      description: Lower bound
-                    upper_bound:
-                      type: integer
-                      description: Upper bound
-                    limit:
-                      type: integer
-                      description: The limit, default is 10
-                    search_by_block_num:
-                      type: boolean
-                      description: Flag to indicate it is has to search by block number
-                    reverse:
-                      type: boolean
-                      description: Flag to indicate it has to search in reverse
+                 lower_bound:
+                   type: integer
+                   description: Lower bound
+                 upper_bound:
+                   type: integer
+                   description: Upper bound
+                 limit:
+                   type: integer
+                   description: The limit, default is 10
+                 search_by_block_num:
+                   type: boolean
+                   description: Flag to indicate it is has to search by block number
+                 reverse:
+                   type: boolean
+                   description: Flag to indicate it has to search in reverse
       responses:
         "200":
           description: OK

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -1503,7 +1503,7 @@ read_only::get_activated_protocol_features( const read_only::get_activated_proto
    auto lower = ( params.search_by_block_num ? pfm.lower_bound( lower_bound_value )
                                              : pfm.at_activation_ordinal( lower_bound_value ) );
 
-   auto upper = ( params.search_by_block_num ? pfm.upper_bound( lower_bound_value )
+   auto upper = ( params.search_by_block_num ? pfm.upper_bound( upper_bound_value )
                                              : get_next_if_not_end( pfm.at_activation_ordinal( upper_bound_value ) ) );
 
    if( params.reverse ) {

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -76,7 +76,7 @@ class PluginHttpTest(unittest.TestCase):
         walletAccounts = [eosioAccount]
         self.keosd.create(testWalletName, walletAccounts)
 
-        retMap = self.nodeos.publishContract(eosioAccount, contractDir, wasmFile, abiFile, waitForTransBlock=True)
+        retMap = self.nodeos.publishContract(eosioAccount.name, contractDir, wasmFile, abiFile, waitForTransBlock=True)
 
         self.nodeos.preactivateAllBuiltinProtocolFeature()
 

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -6,6 +6,7 @@ import time
 import unittest
 
 from testUtils import Utils
+from testUtils import Account
 from TestHelper import TestHelper
 from Node import Node
 from WalletMgr import WalletMgr
@@ -16,11 +17,13 @@ class PluginHttpTest(unittest.TestCase):
     base_wallet_cmd_str = ("curl http://%s:%s/v1/") % (TestHelper.LOCAL_HOST, TestHelper.DEFAULT_WALLET_PORT)
     keosd = WalletMgr(True, TestHelper.DEFAULT_PORT, TestHelper.LOCAL_HOST, TestHelper.DEFAULT_WALLET_PORT, TestHelper.LOCAL_HOST)
     node_id = 1
-    nodeos = Node(TestHelper.LOCAL_HOST, TestHelper.DEFAULT_PORT, node_id)
+    nodeos = Node(TestHelper.LOCAL_HOST, TestHelper.DEFAULT_PORT, node_id, walletMgr=keosd)
     data_dir = Utils.getNodeDataDir(node_id)
     http_post_str = " -X POST -d "
     http_post_invalid_param = " '{invalid}' "
     empty_content_str = " ' { } '  "
+    EOSIO_ACCT_PRIVATE_DEFAULT_KEY = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3"
+    EOSIO_ACCT_PUBLIC_DEFAULT_KEY = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
 
     # make a fresh data dir
     def createDataDir(self):
@@ -57,6 +60,26 @@ class PluginHttpTest(unittest.TestCase):
         self.nodeos.launchCmd(start_nodeos_cmd, self.node_id)
         time.sleep(self.sleep_s)
 
+    def activateAllBuiltinProtocolFeatures(self):
+        self.nodeos.activatePreactivateFeature()
+
+        contract = "eosio.bios"
+        contractDir = "unittests/contracts/old_versions/v1.7.0-develop-preactivate_feature/%s" % (contract)
+        wasmFile = "%s.wasm" % (contract)
+        abiFile = "%s.abi" % (contract)
+
+        eosioAccount = Account("eosio")
+        eosioAccount.ownerPrivateKey = eosioAccount.activePrivateKey = self.EOSIO_ACCT_PRIVATE_DEFAULT_KEY
+        eosioAccount.ownerPublicKey = eosioAccount.activePublicKey = self.EOSIO_ACCT_PUBLIC_DEFAULT_KEY
+
+        testWalletName = "test"
+        walletAccounts = [eosioAccount]
+        self.keosd.create(testWalletName, walletAccounts)
+
+        retMap = self.nodeos.publishContract(eosioAccount, contractDir, wasmFile, abiFile, waitForTransBlock=True)
+
+        self.nodeos.preactivateAllBuiltinProtocolFeature()
+
     # test all chain api
     def test_ChainApi(self) :
         cmd_base = self.base_node_cmd_str + "chain/"
@@ -74,38 +97,88 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
         self.assertEqual(ret_json["code"], 400)
 
+        # activate the builtin protocol features and get some useful data
+        self.activateAllBuiltinProtocolFeatures()
+        allProtocolFeatures = self.nodeos.getSupportedProtocolFeatures()
+        allFeatureDigests = [d['feature_digest'] for d in allProtocolFeatures]
+        ACT_FEATURE_DEFAULT_LIMIT = 10
+
         # get_activated_protocol_features without parameter
         default_cmd = cmd_base + "get_activated_protocol_features"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(ACT_FEATURE_DEFAULT_LIMIT, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+
         # get_activated_protocol_features with empty content parameter
         empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
         ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(ACT_FEATURE_DEFAULT_LIMIT, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+        for index, _ in enumerate(ret_json["activated_protocol_features"]):
+            if index - 1 >= 0:
+                self.assertTrue(ret_json["activated_protocol_features"][index - 1]["activation_ordinal"] < ret_json["activated_protocol_features"][index]["activation_ordinal"])
+
         # get_activated_protocol_features with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)
         self.assertEqual(ret_json["code"], 400)
+
         # get_activated_protocol_features with 1st param
         param_1st_cmd = default_cmd + self.http_post_str + "'{\"lower_bound\":1}'"
         ret_json = Utils.runCmdReturnJson(param_1st_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(ACT_FEATURE_DEFAULT_LIMIT, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+
         # get_activated_protocol_features with 2nd param
         param_2nd_cmd = default_cmd + self.http_post_str + "'{\"upper_bound\":1000}'"
         ret_json = Utils.runCmdReturnJson(param_2nd_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(ACT_FEATURE_DEFAULT_LIMIT, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+
+        # get_activated_protocol_features with 2nd param
+        upper_bound_param = 7
+        param_2nd_cmd = default_cmd + self.http_post_str + ("'{\"upper_bound\":%s}'" % upper_bound_param)
+        ret_json = Utils.runCmdReturnJson(param_2nd_cmd)
+        self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+            self.assertTrue(dict_feature['activation_ordinal'] <= upper_bound_param)
+
         # get_activated_protocol_features with 3rd param
         param_3rd_cmd = default_cmd + self.http_post_str + "'{\"limit\":1}'"
         ret_json = Utils.runCmdReturnJson(param_3rd_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(1, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+
         # get_activated_protocol_features with 4th param
         param_4th_cmd = default_cmd + self.http_post_str + "'{\"search_by_block_num\":true}'"
         ret_json = Utils.runCmdReturnJson(param_4th_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(ACT_FEATURE_DEFAULT_LIMIT, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+
         # get_activated_protocol_features with 5th param
         param_5th_cmd = default_cmd + self.http_post_str + "'{\"reverse\":true}'"
         ret_json = Utils.runCmdReturnJson(param_5th_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        self.assertEqual(len(ret_json["activated_protocol_features"]), min(ACT_FEATURE_DEFAULT_LIMIT, len(allProtocolFeatures)))
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
+        for index, _ in enumerate(ret_json["activated_protocol_features"]):
+            if index - 1 >= 0:
+                self.assertTrue(ret_json["activated_protocol_features"][index - 1]["activation_ordinal"] > ret_json["activated_protocol_features"][index]["activation_ordinal"])
+
         # get_activated_protocol_features with valid parameter
         valid_cmd = ("%s%s '{%s,%s,%s,%s,%s}'") % ( default_cmd,
                                                     self.http_post_str,
@@ -116,6 +189,8 @@ class PluginHttpTest(unittest.TestCase):
                                                     "\"reverse\":true")
         ret_json = Utils.runCmdReturnJson(valid_cmd)
         self.assertEqual(type(ret_json["activated_protocol_features"]), list)
+        for dict_feature in ret_json["activated_protocol_features"]:
+            self.assertTrue(dict_feature['feature_digest'] in allFeatureDigests)
 
         # get_block with empty parameter
         default_cmd = cmd_base + "get_block"


### PR DESCRIPTION
Backports: https://github.com/EOSIO/eos/pull/11014

[heifner](https://github.com/heifner) merged 2 commits into develop-boxed from fix-chain-api-get-activated-protocol-features-dev-box on Jan 5

Made the following modifications related to the get_activated_protocol_features API call:

Corrected documentation that indicated a wrong format of the POST json payload needed for this call.

When the search_by_block num was used, the range of values to act was always empty due to a bug on the lower_bound_value used for both upper_bound and lower_bound.

Added some extra checks on the integration test plugin_http_api_test to take into account the data returned by the api call.

Backports: [chain api plugin / get_activated_protocol_features modifications #9873](https://github.com/EOSIO/eos/pull/9873)

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/256