### PR TITLE
Backport: Reduce logging for failed http plugin calls

### DIFF
--- a/plugins/http_plugin/http_plugin.cpp
+++ b/plugins/http_plugin/http_plugin.cpp
@@ -941,13 +941,8 @@ class http_plugin_impl : public std::enable_shared_from_this<http_plugin_impl> {
          } catch (fc::exception& e) {
             error_results results{500, "Internal Service Error", error_results::error_info(e, verbose_http_errors)};
             cb( 500, fc::variant( results ));
-            if (e.code() != chain::greylist_net_usage_exceeded::code_value &&
-                e.code() != chain::greylist_cpu_usage_exceeded::code_value &&
-                e.code() != fc::timeout_exception::code_value ) {
-               fc_elog( logger, "FC Exception encountered while processing ${api}.${call}",
-                        ("api", api_name)( "call", call_name ) );
-            }
-            fc_dlog( logger, "Exception Details: ${e}", ("e", e.to_detail_string()) );
+            fc_dlog( logger, "Exception while processing ${api}.${call}: ${e}",
+                     ("api", api_name)( "call", call_name )("e", e.to_detail_string()) );
          } catch (std::exception& e) {
             error_results results{500, "Internal Service Error", error_results::error_info(fc::exception( FC_LOG_MESSAGE( error, e.what())), verbose_http_errors)};
             cb( 500, fc::variant( results ));


### PR DESCRIPTION
Public API nodes with default info level logging for http_plugin have huge logs filled with:
`Dec 12 00:00:13 node1 nodeos[29695]: error 2020-12-12T00:00:13.966 nodeos    http_plugin.cpp:964           handle_exception     ] FC Exception encountered while processing chain.push_transaction
Dec 12 00:00:14 node1 nodeos[29695]: error 2020-12-12T00:00:14.061 nodeos    http_plugin.cpp:964           handle_exception     ] FC Exception encountered while processing chain.push_transaction`

Reduce this noise. Full details should be enabled via `debug` logging for private API nodes. There is no error in the system if a `push_transaction` generates an exception. That is normal operating conditions.

Backport: https://github.com/EOSIO/eos/pull/9820

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/244