### PR TITLE
Fix "cleos net peers" command error

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3267,7 +3267,7 @@ int main( int argc, char** argv ) {
 
    auto connections = net->add_subcommand("peers", localized("status of all existing peers"));
    connections->callback([&] {
-      const auto& v = call(url, net_connections, new_host);
+      const auto& v = call(url, net_connections);
       std::cout << fc::json::to_pretty_string(v) << std::endl;
    });
 

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -52,7 +52,8 @@ class PluginHttpTest(unittest.TestCase):
                                                                                    "eosio::chain_api_plugin",
                                                                                    "eosio::http_plugin")
         nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --access-control-allow-origin=%s "
-                        "--contracts-console --http-validate-host=%s --verbose-http-errors ") % (self.data_dir, self.data_dir, "\'*\'", "false")
+                        "--contracts-console --http-validate-host=%s --verbose-http-errors "
+                        "--p2p-peer-address localhost:9011 ") % (self.data_dir, self.data_dir, "\'*\'", "false")
         start_nodeos_cmd = ("%s -e -p eosio %s %s ") % (Utils.EosServerPath, nodeos_plugins, nodeos_flags)
         self.nodeos.launchCmd(start_nodeos_cmd, self.node_id)
         time.sleep(self.sleep_s)
@@ -717,11 +718,11 @@ class PluginHttpTest(unittest.TestCase):
         # connections with empty parameter
         default_cmd = cmd_base + "connections"
         ret_str = Utils.runCmdReturnStr(default_cmd)
-        self.assertEqual(ret_str, "[]")
+        self.assertIn("\"peer\":\"localhost:9011\"", ret_str)
         # connections with empty content parameter
         empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
         ret_str = Utils.runCmdReturnStr(default_cmd)
-        self.assertEqual(ret_str, "[]")
+        self.assertIn("\"peer\":\"localhost:9011\"", ret_str)
         # connections with invalid parameter
         invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
         ret_json = Utils.runCmdReturnJson(invalid_cmd)


### PR DESCRIPTION
Fix https://github.com/EOSIO/eos/issues/9867 by removing the host parameter from the implementation of cleos net peers, because this parameter is not supported.

Backport: https://github.com/EOSIO/eos/pull/9935

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/246