### PR TITLE
Apply 400 check to db_size

### DIFF
--- a/plugins/db_size_api_plugin/db_size_api_plugin.cpp
+++ b/plugins/db_size_api_plugin/db_size_api_plugin.cpp
@@ -1,6 +1,7 @@
 #include <fc/variant.hpp>
 #include <fc/io/json.hpp>
 #include <eosio/db_size_api_plugin/db_size_api_plugin.hpp>
+#include <eosio/http_plugin/http_plugin.hpp>
 
 namespace eosio {
 
@@ -8,11 +9,11 @@ static appbase::abstract_plugin& _db_size_api_plugin = app().register_plugin<db_
 
 using namespace eosio;
 
-#define CALL(api_name, api_handle, call_name, INVOKE, http_response_code) \
+#define CALL_WITH_400(api_name, api_handle, call_name, INVOKE, http_response_code) \
 {std::string("/v1/" #api_name "/" #call_name), \
    [api_handle](string, string body, url_response_callback cb) mutable { \
           try { \
-             if (body.empty()) body = "{}"; \
+             body = parse_params<std::string, http_params_types::no_params>(body); \
              INVOKE \
              cb(http_response_code, fc::variant(result)); \
           } catch (...) { \
@@ -26,8 +27,7 @@ using namespace eosio;
 
 void db_size_api_plugin::plugin_startup() {
    app().get_plugin<http_plugin>().add_api({
-       CALL(db_size, this, get,
-            INVOKE_R_V(this, get), 200),
+       CALL_WITH_400(db_size, this, get,  INVOKE_R_V(this, get), 200),
    });
 }
 

--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -41,7 +41,7 @@ class PluginHttpTest(unittest.TestCase):
     def startEnv(self) :
         self.createDataDir(self)
         self.keosd.launch()
-        nodeos_plugins = (" --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s"
+        nodeos_plugins = (" --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s --plugin %s"
                           " --plugin %s --plugin %s --plugin %s --plugin %s ") % ( "eosio::trace_api_plugin",
                                                                                    "eosio::test_control_api_plugin",
                                                                                    "eosio::test_control_plugin",
@@ -50,7 +50,8 @@ class PluginHttpTest(unittest.TestCase):
                                                                                    "eosio::producer_plugin",
                                                                                    "eosio::producer_api_plugin",
                                                                                    "eosio::chain_api_plugin",
-                                                                                   "eosio::http_plugin")
+                                                                                   "eosio::http_plugin",
+                                                                                   "eosio::db_size_api_plugin")
         nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --access-control-allow-origin=%s "
                         "--contracts-console --http-validate-host=%s --verbose-http-errors ") % (self.data_dir, self.data_dir, "\'*\'", "false")
         start_nodeos_cmd = ("%s -e -p eosio %s %s ") % (Utils.EosServerPath, nodeos_plugins, nodeos_flags)
@@ -1294,7 +1295,7 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
         self.assertEqual(ret_json["error"]["code"], 3200006)
-        # get_info with empty content parameter
+        # kill_node_on_producer with empty content parameter
         empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
         ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
@@ -1317,7 +1318,7 @@ class PluginHttpTest(unittest.TestCase):
         default_cmd = cmd_base + "get_block"
         ret_json = Utils.runCmdReturnJson(default_cmd)
         self.assertEqual(ret_json["code"], 400)
-        # get_info with empty content parameter
+        # get_block with empty content parameter
         empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
         ret_json = Utils.runCmdReturnJson(empty_content_cmd)
         self.assertEqual(ret_json["code"], 400)
@@ -1330,6 +1331,30 @@ class PluginHttpTest(unittest.TestCase):
         ret_json = Utils.runCmdReturnJson(valid_cmd)
         self.assertEqual(ret_json["code"], 404)
         self.assertEqual(ret_json["error"]["code"], 0)
+
+    # test all db_size api
+    def test_DbSizeApi(self) :
+        cmd_base = self.base_node_cmd_str + "db_size/"
+
+        # get with empty parameter
+        default_cmd = cmd_base + "get"
+        ret_json = Utils.runCmdReturnJson(default_cmd)
+        self.assertIn("free_bytes", ret_json)
+        self.assertIn("used_bytes", ret_json)
+        self.assertIn("size", ret_json)
+        self.assertIn("indices", ret_json)
+        # get with empty content parameter
+        empty_content_cmd = default_cmd + self.http_post_str + self.empty_content_str
+        ret_json = Utils.runCmdReturnJson(empty_content_cmd)
+        self.assertIn("free_bytes", ret_json)
+        self.assertIn("used_bytes", ret_json)
+        self.assertIn("size", ret_json)
+        self.assertIn("indices", ret_json)
+        # get with invalid parameter
+        invalid_cmd = default_cmd + self.http_post_str + self.http_post_invalid_param
+        ret_json = Utils.runCmdReturnJson(invalid_cmd)
+        self.assertEqual(ret_json["code"], 400)
+
 
     @classmethod
     def setUpClass(self):


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/9212

> Apply 400 check on db_size api "get",
> 
> If empty body or empty content body is passed in, the RPC returns with correct info, otherwise return 400.

Resolves https://github.com/eosnetworkfoundation/mandel/issues/239