### PR TITLE
Default to returning WASM as returning WAST has been deprecated.

### DIFF
--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -216,7 +216,7 @@ public:
 
    struct get_code_params {
       name account_name;
-      bool code_as_wasm = false;
+      bool code_as_wasm = true;
    };
 
    struct get_code_hash_results {


### PR DESCRIPTION
Default to returning WASM as returning WAST has been deprecated.

As there is no more support for get_code to return WAST the default to return WASM should be true.

Backport https://github.com/EOSIO/eos/pull/9706

Resolves https://github.com/eosnetworkfoundation/mandel/issues/243
