### PR TITLE
Fix duplicate symbol error in trace_api::configuration_utils

### DIFF
--- a/plugins/trace_api_plugin/CMakeLists.txt
+++ b/plugins/trace_api_plugin/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library( trace_api_plugin
              store_provider.cpp
              abi_data_handler.cpp
              compressed_file.cpp
+             configuration_utils.cpp
              trace_api_plugin.cpp
              ${HEADERS} )
 

--- a/plugins/trace_api_plugin/configuration_utils.cpp
+++ b/plugins/trace_api_plugin/configuration_utils.cpp
@@ -1,0 +1,37 @@
+#include <eosio/trace_api/configuration_utils.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <regex>
+#include <fc/io/json.hpp>
+
+
+namespace eosio::trace_api::configuration_utils {
+   using namespace eosio;
+
+   chain::abi_def abi_def_from_file(const std::string& file_name, const fc::path& data_dir )
+   {
+      fc::variant abi_variant;
+      auto abi_path = fc::path(file_name);
+      if (abi_path.is_relative()) {
+         abi_path = data_dir / abi_path;
+      }
+
+      EOS_ASSERT(fc::exists(abi_path) && !fc::is_directory(abi_path), chain::plugin_config_exception, "${path} does not exist or is not a file", ("path", abi_path.generic_string()));
+      try {
+         abi_variant = fc::json::from_file(abi_path);
+      } EOS_RETHROW_EXCEPTIONS(chain::json_parse_exception, "Fail to parse JSON from file: ${file}", ("file", abi_path.generic_string()));
+
+      chain::abi_def result;
+      fc::from_variant(abi_variant, result);
+      return result;
+   }
+
+   std::pair<std::string, std::string> parse_kv_pairs( const std::string& input ) {
+      EOS_ASSERT(!input.empty(), chain::plugin_config_exception, "Key-Value Pair is Empty");
+      auto delim = input.find("=");
+      EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\"");
+      EOS_ASSERT(delim != 0, chain::plugin_config_exception, "Missing Key");
+      EOS_ASSERT(delim + 1 != input.size(), chain::plugin_config_exception, "Missing Value");
+      return std::make_pair(input.substr(0, delim), input.substr(delim + 1));
+   }
+
+}

--- a/plugins/trace_api_plugin/include/eosio/trace_api/configuration_utils.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/configuration_utils.hpp
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <regex>
 #include <fc/filesystem.hpp>
-#include <fc/io/json.hpp>
-#include <eosio/chain/exceptions.hpp>
 #include <eosio/chain/abi_def.hpp>
 
 namespace eosio::trace_api::configuration_utils {
@@ -17,23 +14,7 @@ namespace eosio::trace_api::configuration_utils {
     * @return the ABI implied
     * @throws json_parse_exception if the JSON is malformed
     */
-   chain::abi_def abi_def_from_file(const std::string& file_name, const fc::path& data_dir )
-   {
-      fc::variant abi_variant;
-      auto abi_path = fc::path(file_name);
-      if (abi_path.is_relative()) {
-         abi_path = data_dir / abi_path;
-      }
-
-      EOS_ASSERT(fc::exists(abi_path) && !fc::is_directory(abi_path), chain::plugin_config_exception, "${path} does not exist or is not a file", ("path", abi_path.generic_string()));
-      try {
-         abi_variant = fc::json::from_file(abi_path);
-      } EOS_RETHROW_EXCEPTIONS(chain::json_parse_exception, "Fail to parse JSON from file: ${file}", ("file", abi_path.generic_string()));
-
-      chain::abi_def result;
-      fc::from_variant(abi_variant, result);
-      return result;
-   }
+   chain::abi_def abi_def_from_file(const std::string& file_name, const fc::path& data_dir );
 
    /**
     * Given a string in the form <key>=<value> where key cannot contain an `=` character and value can contain anything
@@ -42,13 +23,6 @@ namespace eosio::trace_api::configuration_utils {
     * @param input
     * @return
     */
-   std::pair<std::string, std::string> parse_kv_pairs( const std::string& input ) {
-      EOS_ASSERT(!input.empty(), chain::plugin_config_exception, "Key-Value Pair is Empty");
-      auto delim = input.find("=");
-      EOS_ASSERT(delim != std::string::npos, chain::plugin_config_exception, "Missing \"=\"");
-      EOS_ASSERT(delim != 0, chain::plugin_config_exception, "Missing Key");
-      EOS_ASSERT(delim + 1 != input.size(), chain::plugin_config_exception, "Missing Value");
-      return std::make_pair(input.substr(0, delim), input.substr(delim + 1));
-   }
+   std::pair<std::string, std::string> parse_kv_pairs( const std::string& input );
 
 }


### PR DESCRIPTION
[fix duplicate symbol error in trace_api::configuration_utils - 2.1 by spoonincode · Pull Request #10672 · EOSIO/eos](https://github.com/EOSIO/eos/pull/10672) 

[spoonincode](https://github.com/spoonincode) merged 1 commit into release/2.1.x from trace_api_cfgutils_21x on Aug 30, 2021

Backport https://github.com/EOSIO/eos/pull/10672
Backport of fix in [#10670](https://github.com/EOSIO/eos/pull/10670) that was needed to compile with gcc11

Resolves https://github.com/eosnetworkfoundation/mandel/issues/235