### PR TITLE
cleos remove wasm to wast conversion

### DIFF
--- a/libraries/chain/include/eosio/chain/wast_to_wasm.hpp
+++ b/libraries/chain/include/eosio/chain/wast_to_wasm.hpp
@@ -5,7 +5,5 @@
 namespace eosio { namespace chain {
 
 std::vector<uint8_t> wast_to_wasm( const std::string& wast );
-std::string  wasm_to_wast( const std::vector<uint8_t>& wasm, bool strip_names );
-std::string  wasm_to_wast( const uint8_t* data, uint64_t size, bool strip_names );
 
 } } /// eosio::chain

--- a/libraries/chain/wast_to_wasm.cpp
+++ b/libraries/chain/wast_to_wasm.cpp
@@ -4,10 +4,10 @@
 #include <IR/Validate.h>
 #include <WAST/WAST.h>
 #include <WASM/WASM.h>
-#include <Runtime/Runtime.h>
 #include <sstream>
 #include <iomanip>
 #include <fc/exception/exception.hpp>
+#include <fc/scoped_exit.hpp>
 #include <eosio/chain/exceptions.hpp>
 
 namespace eosio { namespace chain {
@@ -57,21 +57,5 @@ namespace eosio { namespace chain {
       }
 
    } FC_CAPTURE_AND_RETHROW( (wast) ) }  /// wast_to_wasm
-
-   std::string     wasm_to_wast( const std::vector<uint8_t>& wasm, bool strip_names ) {
-      return wasm_to_wast( wasm.data(), wasm.size(), strip_names );
-   } /// wasm_to_wast
-
-   std::string     wasm_to_wast( const uint8_t* data, uint64_t size, bool strip_names ) 
-   { try {
-       IR::Module module;
-       Serialization::MemoryInputStream stream((const U8*)data,size);
-       WASM::serialize(stream,module);
-       if(strip_names)
-          module.userSections.clear();
-        // Print the module to WAST.
-       return WAST::print(module);
-   } FC_CAPTURE_AND_RETHROW() } /// wasm_to_wast
-
 
 } } // eosio::chain

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -79,7 +79,6 @@ Options:
 
 #include <eosio/chain/name.hpp>
 #include <eosio/chain/config.hpp>
-#include <eosio/chain/wast_to_wasm.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain_plugin/chain_plugin.hpp>
 #include <eosio/chain/contract_types.hpp>
@@ -2691,14 +2690,14 @@ int main( int argc, char** argv ) {
    // get code
    string codeFilename;
    string abiFilename;
-   bool code_as_wasm = false;
+   bool code_as_wasm = true;
    auto getCode = get->add_subcommand("code", localized("Retrieve the code and ABI for an account"));
    getCode->add_option("name", accountName, localized("The name of the account whose code should be retrieved"))->required();
-   getCode->add_option("-c,--code",codeFilename, localized("The name of the file to save the contract .wast/wasm to") );
+   getCode->add_option("-c,--code",codeFilename, localized("The name of the file to save the contract wasm to") );
    getCode->add_option("-a,--abi",abiFilename, localized("The name of the file to save the contract .abi to") );
-   getCode->add_flag("--wasm", code_as_wasm, localized("Save contract as wasm"));
+   getCode->add_flag("--wasm", code_as_wasm, localized("Save contract as wasm (ignored, default)"));
    getCode->callback([&] {
-      string code_hash, wasm, wast, abi;
+      string code_hash, wasm, abi;
       try {
          const auto result = call(get_raw_code_and_abi_func, fc::mutable_variant_object("account_name", accountName));
          const std::vector<char> wasm_v = result["wasm"].as_blob().data;
@@ -2710,8 +2709,6 @@ int main( int argc, char** argv ) {
          code_hash = (string)hash;
 
          wasm = string(wasm_v.begin(), wasm_v.end());
-         if(!code_as_wasm && wasm_v.size())
-            wast = wasm_to_wast((const uint8_t*)wasm_v.data(), wasm_v.size(), false);
 
          abi_def abi_d;
          if(abi_serializer::to_abi(abi_v, abi_d))
@@ -2721,25 +2718,18 @@ int main( int argc, char** argv ) {
          //see if this is an old nodeos that doesn't support get_raw_code_and_abi
          const auto old_result = call(get_code_func, fc::mutable_variant_object("account_name", accountName)("code_as_wasm",code_as_wasm));
          code_hash = old_result["code_hash"].as_string();
-         if(code_as_wasm) {
-            wasm = old_result["wasm"].as_string();
-            std::cout << localized("Warning: communicating to older ${n} which returns malformed binary wasm", ("n", node_executable_name)) << std::endl;
-         }
-         else
-            wast = old_result["wast"].as_string();
+         wasm = old_result["wasm"].as_string();
+         std::cout << localized("Warning: communicating to older ${n} which returns malformed binary wasm", ("n", node_executable_name)) << std::endl;
          abi = fc::json::to_pretty_string(old_result["abi"]);
       }
 
       std::cout << localized("code hash: ${code_hash}", ("code_hash", code_hash)) << std::endl;
 
       if( codeFilename.size() ){
-         std::cout << localized("saving ${type} to ${codeFilename}", ("type", (code_as_wasm ? "wasm" : "wast"))("codeFilename", codeFilename)) << std::endl;
+         std::cout << localized("saving wasm to ${codeFilename}", ("codeFilename", codeFilename)) << std::endl;
 
          std::ofstream out( codeFilename.c_str() );
-         if(code_as_wasm)
-            out << wasm;
-         else
-            out << wast;
+         out << wasm;
       }
       if( abiFilename.size() ) {
          std::cout << localized("saving abi to ${abiFilename}", ("abiFilename", abiFilename)) << std::endl;

--- a/unittests/wasm_tests.cpp
+++ b/unittests/wasm_tests.cpp
@@ -1665,15 +1665,16 @@ BOOST_FIXTURE_TEST_CASE( fuzz, TESTER ) try {
       vector<uint8_t> wasm(g80k_deep_loop_with_voidData, g80k_deep_loop_with_voidData + g80k_deep_loop_with_voidSize);
       BOOST_CHECK_THROW(set_code("fuzzy"_n, wasm), wasm_exception);
    }
+   {
+      vector<uint8_t> wasm(ggetcode_deepindentData, ggetcode_deepindentData + ggetcode_deepindentSize);
+      set_code( "fuzzy"_n, wasm );
+   }
+   {
+      vector<uint8_t> wasm(gindent_mismatchData, gindent_mismatchData + gindent_mismatchSize);
+      set_code( "fuzzy"_n, wasm );
+   }
 
    produce_blocks(1);
-} FC_LOG_AND_RETHROW()
-
-BOOST_FIXTURE_TEST_CASE( getcode_checks, TESTER ) try {
-   vector<uint8_t> wasm(ggetcode_deepindentData, ggetcode_deepindentData + ggetcode_deepindentSize);
-   wasm_to_wast( wasm.data(), wasm.size(), true );
-   vector<uint8_t> wasmx(gindent_mismatchData, gindent_mismatchData + gindent_mismatchSize);
-   wasm_to_wast( wasmx.data(), wasmx.size(), true );
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE( big_maligned_host_ptr, TESTER ) try {


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/10819

Update cleos to not perform wasm to wast conversion.
Users can use standard WebAssembly tooling to convert from wasm to wast if needed.

Removal announcement: https://github.com/EOSIO/eos/issues/7597

Resolves https://github.com/eosnetworkfoundation/mandel/issues/274

