### PR TITLE
add cpack support to easily build .deb & .rpm packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required( VERSION 3.8 )
 
-project( EOSIO )
+project( mandel )
 include(CTest) # suppresses DartConfiguration.tcl error
 enable_testing()
 
@@ -236,3 +236,6 @@ get_property(_CTEST_CUSTOM_TESTS_IGNORE GLOBAL PROPERTY CTEST_CUSTOM_TESTS_IGNOR
 file(WRITE "${CMAKE_BINARY_DIR}/CTestCustom.cmake" "SET(CTEST_CUSTOM_TESTS_IGNORE ${_CTEST_CUSTOM_TESTS_IGNORE})")
 
 include(doxygen)
+
+include(package.cmake)
+include(CPack)

--- a/package.cmake
+++ b/package.cmake
@@ -17,6 +17,7 @@ set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "daemon and CLI tools for Mandel blockchai
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/eosnetworkfoundation/mandel")
 
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 
 #turn some knobs to try and make package paths cooperate with GNUInstallDirs a little better
 set(CPACK_SET_DESTDIR ON)

--- a/package.cmake
+++ b/package.cmake
@@ -1,0 +1,16 @@
+#DEB & RPM are known to work, but don't enable them by default
+set(CPACK_GENERATOR "TGZ")
+
+set(CPACK_PACKAGE_VERSION "${VERSION_FULL}")
+set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${VERSION_FULL}")
+
+set(CPACK_PACKAGE_CONTACT "EOS Network Foundation")
+set(CPACK_PACKAGE_VENDOR "EOS Network Foundation")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "daemon and CLI tools for Mandel blockchain protocol")
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/eosnetworkfoundation/mandel")
+
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
+
+#turn some knobs to try and make package paths cooperate with GNUInstallDirs a little better
+set(CPACK_SET_DESTDIR ON)
+set(CPACK_PACKAGE_RELOCATABLE OFF)

--- a/package.cmake
+++ b/package.cmake
@@ -1,5 +1,12 @@
-#DEB & RPM are known to work, but don't enable them by default
 set(CPACK_GENERATOR "TGZ")
+find_program(DPKG_FOUND "dpkg")
+find_program(RPMBUILD_FOUND "rpmbuild")
+if(DPKG_FOUND)
+   list(APPEND CPACK_GENERATOR "DEB")
+endif()
+if(RPMBUILD_FOUND)
+   list(APPEND CPACK_GENERATOR "RPM")
+endif()
 
 set(CPACK_PACKAGE_VERSION "${VERSION_FULL}")
 set(CPACK_PACKAGE_FILE_NAME "${CMAKE_PROJECT_NAME}-${VERSION_FULL}")

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -16,6 +16,3 @@ add_subdirectory(db_size_api_plugin)
 add_subdirectory(login_plugin)
 add_subdirectory(test_control_plugin)
 add_subdirectory(test_control_api_plugin)
-
-# Forward variables to top level so packaging picks them up
-set(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} PARENT_SCOPE)


### PR DESCRIPTION
Adds support for building .deb and .rpm packages (and binary tarballs). This is very basic support but I have validated that packages build and install cleanly.

I've never been able to figure out how to to get `GNUInstallDirs` and `cpack` to fully cooperate with each other (a bit of a conflict due to absolute vs relative paths in `install()` commands). So when building a package you probably want to `-DCMAKE_INSTALL_PREFIX=/usr` as I believe it's generally a faux pas to have a package place files in `/usr/local`.

~Also, I have only enabled tarballs by default since if I enable `TGZ;DEB;RPM` as the default users may get confused when they can't build an .rpm on Ubuntu (it does work if you have the tools installed, it just may be a little weirdly unexpected). Maybe the default should be based on the platform discovered during cmake configure or something?~ Now there is dpkg/rpmbuild detection.

So most likely, if you're building packages for Ubuntu, you'd want to do something like
```
cmake -DCMAKE_INSTALL_PREFIX=/usr ....
make package
```
I have _not_ made any changes to the CI to pop out packages yet pending further decisions.

.deb info for a build on Ubuntu 20.04
```
Architecture: amd64
Depends: libc6 (>= 2.29), libcurl4 (>= 7.16.2), libgcc-s1 (>= 3.4), libssl1.1 (>= 1.1.0), libstdc++6 (>= 9), libtinfo6 (>= 6), libusb-1.0-0 (>= 2:1.0.16), zlib1g (>= 1:1.2.0)
Description: daemon and CLI tools for Mandel blockchain protocol
Maintainer: EOS Network Foundation
Package: mandel
Priority: optional
Section: utils
Version: 3.1.0-dev
Installed-Size: 361276
```
Bundled files for said package
```
./usr/
./usr/bin/
./usr/bin/cleos
./usr/bin/eosio-blocklog
./usr/bin/keosd
./usr/bin/nodeos
./usr/bin/trace_api_util
./usr/share/
./usr/share/licenses/
./usr/share/licenses/eosio/
./usr/share/licenses/eosio/LICENSE
./usr/share/licenses/eosio/LICENSE.eos-vm
./usr/share/licenses/eosio/LICENSE.go
./usr/share/licenses/eosio/LICENSE.rapidjson
./usr/share/licenses/eosio/LICENSE.secp256k1
./usr/share/licenses/eosio/LICENSE.softfloat
./usr/share/licenses/eosio/LICENSE.wavm
./usr/share/licenses/eosio/LICENSE.yubihsm
```

.rpm info
```
Name        : mandel
Version     : 3.1.0_dev
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : unknown
Size        : 373390093
License     : unknown
Signature   : (none)
Source RPM  : mandel-3.1.0_dev-1.src.rpm
Build Date  : Thu 19 May 2022 01:30:22 PM EDT
Build Host  : zen
Vendor      : EOS Network Foundation
URL         : https://github.com/eosnetworkfoundation/mandel
Summary     : daemon and CLI tools for Mandel blockchain protocol
Description :
DESCRIPTION
===========

This is an installer created using CPack (https://cmake.org). No additional installation instructions provided.
```