### PR TITLE
Add integration test for nodeos shutdown

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_retry_transaction_test.py ${CM
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_forked_test.py ${CMAKE_CURRENT_BINARY_DIR}/trx_finality_status_forked_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_contrl_c_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_contrl_c_test.py COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -149,6 +150,9 @@ set_property(TEST nodeos_remote_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_forked_chain_lr_test COMMAND tests/nodeos_forked_chain_test.py -v --wallet-port 9901 --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_forked_chain_lr_test PROPERTY LABELS long_running_tests)
+
+add_test(NAME nodeos_contrl_c_lr_test COMMAND tests/nodeos_contrl_c_test.py -v --wallet-port 9901 WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST nodeos_contrl_c_lr_test PROPERTY LABELS long_running_tests)
 
 add_test(NAME nodeos_voting_lr_test COMMAND tests/nodeos_voting_test.py -v --wallet-port 9902 --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_voting_lr_test PROPERTY LABELS long_running_tests)

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+from testUtils import Utils
+from datetime import datetime
+from datetime import timedelta
+import time
+from Cluster import Cluster
+import json
+from WalletMgr import WalletMgr
+from Node import Node
+from TestHelper import TestHelper
+
+import signal
+
+###############################################################
+# nodeos_contrl_c_lr_test
+#
+# This test sets up one producing nodes and one "bridge" node using test_control_api_plugin. We send
+# transactions to the bridge node. After the accounts are initialized and allocated with symbols, we
+# kill the producing node. Then we flood hundreds transactions to the bridge node. At the end, we
+# kill the bridge. It tests that no crashes happen when the nodes are killed.
+#
+###############################################################
+
+errorExit=Utils.errorExit
+
+args = TestHelper.parse_args({"--wallet-port", "-v"})
+
+cluster=Cluster(walletd=True)
+killAll=True
+totalProducerNodes=1
+totalNonProducerNodes=1
+totalNodes=totalProducerNodes+totalNonProducerNodes
+walletPort=args.wallet_port
+walletMgr=WalletMgr(True, port=walletPort)
+producerEndpoint = '127.0.0.1:8888'
+httpServerAddress = '127.0.0.1:8889'
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+    cluster.setWalletMgr(walletMgr)
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+
+    specificExtraNodeosArgs = {}
+    specificExtraNodeosArgs[0] = "--plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::http_plugin "
+    "--plugin eosio::txn_test_gen_plugin --plugin eosio::producer_api_plugin "
+    # producer nodes will be mapped to 0 through totalProducerNodes-1, so the number totalProducerNodes will be the non-producing node
+    specificExtraNodeosArgs[totalProducerNodes] = "--plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::http_plugin "
+    "--plugin eosio::txn_test_gen_plugin --plugin eosio::producer_api_plugin "
+
+    # ***   setup topogrophy   ***
+
+    # "bridge" shape connects defprocera through defproducerk (in node0) to each other and defproducerl through defproduceru (in node01)
+    # and the only connection between those 2 groups is through the bridge node
+
+    if cluster.launch(prodCount=1, topo="bridge", pnodes=totalProducerNodes,
+                      totalNodes=totalNodes, totalProducers=totalProducers,
+                      useBiosBootFile=False, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
+        Utils.cmdError("launcher")
+        Utils.errorExit("Failed to stand up eos cluster.")
+    Print("Validating system accounts after bootstrap")
+    cluster.validateAccounts(None)
+
+    prodNode = cluster.getNode(0)
+    nonProdNode = cluster.getNode(1)
+
+    accounts=cluster.createAccountKeys(2)
+    if accounts is None:
+        Utils.errorExit("FAILURE - create keys")
+
+    accounts[0].name="tester111111"
+    accounts[1].name="tester222222"
+
+    testWalletName="test"
+
+    Print("Creating wallet \"%s\"." % (testWalletName))
+    testWallet=walletMgr.create(testWalletName, [cluster.eosioAccount,accounts[0],accounts[1]])
+
+    # create accounts via eosio as otherwise a bid is needed
+    for account in accounts:
+        Print("Create new account %s via %s" % (account.name, cluster.eosioAccount.name))
+        trans=nonProdNode.createInitializeAccount(account, cluster.eosioAccount, stakedDeposit=0, waitForTransBlock=True, stakeNet=1000, stakeCPU=1000, buyRAM=1000, exitOnError=True)
+        transferAmount="100000000.0000 {0}".format(CORE_SYMBOL)
+        Print("Transfer funds %s from account %s to %s" % (transferAmount, cluster.eosioAccount.name, account.name))
+        nonProdNode.transferFunds(cluster.eosioAccount, account, transferAmount, "test transfer", waitForTransBlock=True)
+        trans=nonProdNode.delegatebw(account, 20000000.0000, 20000000.0000, waitForTransBlock=True, exitOnError=True)
+
+    testSuccessful = prodNode.kill(signal.SIGTERM)
+    if not testSuccessful:
+        TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
+        errorExit("Failed to kill the producer node")
+
+    transferAmount="1.0000 {0}".format(CORE_SYMBOL)
+    for _ in range(500):
+        nonProdNode.transferFunds(account[0], account[1], transferAmount, "test transfer", waitForTransBlock=False)
+
+    testSuccessful = nonProdNode.kill(signal.SIGTERM)
+
+    if not testSuccessful:
+        TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
+        errorExit("Failed to kill the seed node")
+
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=True, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
+    exit(0)

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -98,9 +98,12 @@ try:
         TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
         errorExit("Failed to kill the producer node")
 
+    #Reset test success flag for next check
+    testSuccessful=False
+
     for amt in range(1, 500, 1):
         xferAmount = Node.currencyIntToStr(amt, CORE_SYMBOL)
-        nonProdNode.transferFunds(accounts[0], accounts[1], xferAmount, "test transfer", waitForTransBlock=False)
+        nonProdNode.transferFundsAsync(accounts[0], accounts[1], xferAmount, "test transfer", exitOnError=False)
 
     testSuccessful = nonProdNode.kill(signal.SIGTERM)
 

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -103,4 +103,6 @@ try:
 
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=True, killEosInstances=True, killWallet=True, keepLogs=True, cleanRun=True, dumpErrorDetails=True)
-    exit(0)
+
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -49,8 +49,6 @@ try:
     cluster.cleanup()
 
     specificExtraNodeosArgs = {}
-    # specificExtraNodeosArgs[0] = "--plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::http_plugin "
-    # "--plugin eosio::txn_test_gen_plugin --plugin eosio::producer_api_plugin "
     # producer nodes will be mapped to 0 through totalProducerNodes-1, so the number totalProducerNodes will be the non-producing node
     specificExtraNodeosArgs[totalProducerNodes] = "--plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::http_plugin "
     "--plugin eosio::txn_test_gen_plugin --plugin eosio::producer_api_plugin "

--- a/tests/nodeos_contrl_c_test.py
+++ b/tests/nodeos_contrl_c_test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+from core_symbol import CORE_SYMBOL
 from testUtils import Utils
 from datetime import datetime
 from datetime import timedelta
@@ -22,6 +23,7 @@ import signal
 #
 ###############################################################
 
+Print = Utils.Print
 errorExit=Utils.errorExit
 
 args = TestHelper.parse_args({"--wallet-port", "-v"})
@@ -48,6 +50,7 @@ try:
     # producer nodes will be mapped to 0 through totalProducerNodes-1, so the number totalProducerNodes will be the non-producing node
     specificExtraNodeosArgs[totalProducerNodes] = "--plugin eosio::producer_plugin --plugin eosio::chain_api_plugin --plugin eosio::http_plugin "
     "--plugin eosio::txn_test_gen_plugin --plugin eosio::producer_api_plugin "
+    traceNodeosArgs = " --plugin eosio::trace_api_plugin --trace-no-abis "
 
     # ***   setup topogrophy   ***
 
@@ -55,8 +58,9 @@ try:
     # and the only connection between those 2 groups is through the bridge node
 
     if cluster.launch(prodCount=1, topo="bridge", pnodes=totalProducerNodes,
-                      totalNodes=totalNodes, totalProducers=totalProducers,
-                      useBiosBootFile=False, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
+                      totalNodes=totalNodes, totalProducers=totalProducerNodes,
+                      useBiosBootFile=False, specificExtraNodeosArgs=specificExtraNodeosArgs,
+                      extraNodeosArgs=traceNodeosArgs) is False:
         Utils.cmdError("launcher")
         Utils.errorExit("Failed to stand up eos cluster.")
     Print("Validating system accounts after bootstrap")


### PR DESCRIPTION
Add an integration of nodeos for crash when the nodes are killed.

Backports https://github.com/EOSIO/eos/pull/9494

Description:
Added a new integration test for nodeos. This test sets up one producing nodes and one "bridge" node using test_control_api_plugin. We send transactions to the bridge node. After the accounts are initialized and allocated with symbols, we kill the producing node. Then we flood hundreds transactions to the bridge node. At the end, we ill the bridge. It tests that no crashes happen when the nodes are killed.


Resolves https://github.com/eosnetworkfoundation/mandel/issues/242