### PR TITLE
Fix all python tests to correctly report failure exit code on failure including any exception thrown.

### DIFF
--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -209,4 +209,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/compute_transaction_test.py
+++ b/tests/compute_transaction_test.py
@@ -184,4 +184,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/distributed-transactions-remote-test.py
+++ b/tests/distributed-transactions-remote-test.py
@@ -90,4 +90,5 @@ finally:
     os.remove(nodesFile)
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, False, False, killAll, dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/distributed-transactions-test.py
+++ b/tests/distributed-transactions-test.py
@@ -122,4 +122,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/http_plugin_test.py
+++ b/tests/http_plugin_test.py
@@ -53,4 +53,7 @@ try:
     testSuccessful = True
 finally:
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, True, keepLogs, killAll, dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)
         

--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -241,4 +241,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -572,4 +572,5 @@ finally:
         cluster.printBlockLog()
         Print(Utils.FileDivider)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/nodeos_producer_watermark_test.py
+++ b/tests/nodeos_producer_watermark_test.py
@@ -255,4 +255,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/nodeos_run_remote_test.py
+++ b/tests/nodeos_run_remote_test.py
@@ -70,4 +70,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, False, False, killAll, dumpErrorDetails)
 
-exit(0)
+errorCode = 0 if testSuccessful else 1 
+exit(errorCode) 

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -662,4 +662,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -437,4 +437,5 @@ finally:
         cluster.printBlockLog()
         Print(Utils.FileDivider)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/nodeos_startup_catchup.py
+++ b/tests/nodeos_startup_catchup.py
@@ -193,4 +193,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/nodeos_under_min_avail_ram.py
+++ b/tests/nodeos_under_min_avail_ram.py
@@ -313,4 +313,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/nodeos_voting_test.py
+++ b/tests/nodeos_voting_test.py
@@ -255,4 +255,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/p2p_high_latency_test.py
+++ b/tests/p2p_high_latency_test.py
@@ -109,4 +109,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, False, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/p2p_network_test.py
+++ b/tests/p2p_network_test.py
@@ -25,6 +25,8 @@ parser = argparse.ArgumentParser(add_help=False)
 Print=testUtils.Utils.Print
 cmdError=Utils.cmdError
 errorExit=Utils.errorExit
+testSuccessful=False
+
 
 # Override default help argument so that only --help (and not -h) can call help
 parser.add_argument('-?', action='help', default=argparse.SUPPRESS,
@@ -186,7 +188,11 @@ try:
                 if failedcount == 0:
                     successhosts.append(host)
         Print("%d host(s) passed, %d host(s) failed" % (len(successhosts), len(hosts) - len(successhosts)))
+
+    testSuccessful = True
 finally:
     Print("\nfinally: restore everything")
     module.on_exit()
-exit(0)
+
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/prod_preactivation_test.py
+++ b/tests/prod_preactivation_test.py
@@ -174,4 +174,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/restart-scenarios-test.py
+++ b/tests/restart-scenarios-test.py
@@ -136,4 +136,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killEosInstances, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/subjective_billing_test.py
+++ b/tests/subjective_billing_test.py
@@ -195,4 +195,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
 
-exit(0)
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/terminate-scenarios-test.py
+++ b/tests/terminate-scenarios-test.py
@@ -88,4 +88,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killEosInstances, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/trx_finality_status_forked_test.py
+++ b/tests/trx_finality_status_forked_test.py
@@ -259,4 +259,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+errorCode = 0 if testSuccessful else 1
+exit(errorCode)

--- a/tests/trx_finality_status_test.py
+++ b/tests/trx_finality_status_test.py
@@ -223,4 +223,5 @@ try:
 finally:
     TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killWallet, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
 
-exit(0)
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/validate-dirty-db.py
+++ b/tests/validate-dirty-db.py
@@ -114,4 +114,6 @@ finally:
     TestHelper.shutdown(cluster, None, testSuccessful, killEosInstances, False, keepLogs, killAll, dumpErrorDetails)
 
 if debug: Print("Exiting test, exit value 0.")
-exit(0)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)


### PR DESCRIPTION
Working through python tests to update them to properly report failure exit code on failure including when an exception is thrown.

Resolves https://github.com/eosnetworkfoundation/mandel/issues/282