### PR TITLE
Refactor unapplied transaction queue

### DIFF
--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -191,14 +191,15 @@ public:
                { trx, expiry, persist_until_expired ? trx_enum_type::incoming_persisted : trx_enum_type::incoming, return_failure_trace, std::move( next ) } );
          if( insert_itr.second ) added( insert_itr.first );
       } else {
+         if( !(itr->trx_meta == trx) && next ) {
+            // next will be updated in modify() below, notify previous next of duplicate
+            next( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
+                  FC_LOG_MESSAGE( info, "duplicate transaction ${id}", ("id", trx->id()) ) ) ) );
+            return;
+         }
+
          if (itr->trx_type != trx_enum_type::incoming && itr->trx_type != trx_enum_type::incoming_persisted)
             ++incoming_count;
-
-         if( !(itr->trx_meta == trx) && itr->next ) {
-            // next will be updated in modify() below, notify previous next of duplicate
-            itr->next( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
-                  FC_LOG_MESSAGE( info, "duplicate transaction ${id}", ("id", itr->trx_meta->id())))));
-         }
 
          queue.get<by_trx_id>().modify( itr, [persist_until_expired, return_failure_trace, next{std::move(next)}](auto& un) mutable {
             un.trx_type = persist_until_expired ? trx_enum_type::incoming_persisted : trx_enum_type::incoming;

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -159,8 +159,7 @@ public:
       }
    }
 
-   void add_aborted( deque<transaction_metadata_ptr> aborted_trxs ) {
-      if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
+   void add_aborted( std::vector<transaction_metadata_ptr> aborted_trxs ) {
       for( auto& trx : aborted_trxs ) {
          fc::time_point expiry = trx->packed_trx()->expiration();
          auto insert_itr = queue.insert( { std::move( trx ), expiry, trx_enum_type::aborted } );

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <eosio/chain/transaction_metadata.hpp>
+#include <eosio/chain/trace.hpp>
 #include <eosio/chain/block_state.hpp>
 #include <eosio/chain/exceptions.hpp>
 
 #include <boost/multi_index_container.hpp>
-#include <boost/multi_index/sequenced_index.hpp>
 #include <boost/multi_index/hashed_index.hpp>
 #include <boost/multi_index/member.hpp>
 
@@ -23,13 +23,18 @@ enum class trx_enum_type {
    unknown = 0,
    persisted = 1,
    forked = 2,
-   aborted = 3
+   aborted = 3,
+   incoming_persisted = 4,
+   incoming = 5 // incoming_end() needs to be updated if this changes
 };
+
+using next_func_t = std::function<void(const std::variant<fc::exception_ptr, transaction_trace_ptr>&)>;
 
 struct unapplied_transaction {
    const transaction_metadata_ptr trx_meta;
    const fc::time_point           expiry;
    trx_enum_type                  trx_type = trx_enum_type::unknown;
+   next_func_t                    next;
 
    const transaction_id_type& id()const { return trx_meta->id(); }
 
@@ -68,8 +73,13 @@ private:
 
    unapplied_trx_queue_type queue;
    process_mode mode = process_mode::speculative_producer;
+   uint64_t max_transaction_queue_size = 1024*1024*1024; // enforced for incoming
+   uint64_t size_in_bytes = 0;
+   size_t incoming_count = 0;
 
 public:
+
+   void set_max_transaction_queue_size( uint64_t v ) { max_transaction_queue_size = v; }
 
    void set_mode( process_mode new_mode ) {
       if( new_mode != mode ) {
@@ -90,14 +100,8 @@ public:
       queue.clear();
    }
 
-   bool contains_persisted()const {
-      return queue.get<by_type>().find( trx_enum_type::persisted ) != queue.get<by_type>().end();
-   }
-
-   bool is_persisted(const transaction_metadata_ptr& trx)const {
-      auto itr = queue.get<by_trx_id>().find( trx->id() );
-      if( itr == queue.get<by_trx_id>().end() ) return false;
-      return itr->trx_type == trx_enum_type::persisted;
+   size_t incoming_size()const {
+      return incoming_count;
    }
 
    transaction_metadata_ptr get_trx( const transaction_id_type& id ) const {
@@ -109,12 +113,25 @@ public:
    template <typename Func>
    bool clear_expired( const time_point& pending_block_time, const time_point& deadline, Func&& callback ) {
       auto& persisted_by_expiry = queue.get<by_expiry>();
-      while(!persisted_by_expiry.empty() && persisted_by_expiry.begin()->expiry <= pending_block_time) {
-         if (deadline <= fc::time_point::now()) {
+      while( !persisted_by_expiry.empty() ) {
+         const auto& itr = persisted_by_expiry.begin();
+         if( itr->expiry > pending_block_time ) {
+            break;
+         }
+         if( deadline <= fc::time_point::now() ) {
             return false;
          }
-         callback( persisted_by_expiry.begin()->trx_meta->packed_trx(), persisted_by_expiry.begin()->trx_type );
-         persisted_by_expiry.erase( persisted_by_expiry.begin() );
+         callback( itr->trx_meta->packed_trx(), itr->trx_type );
+         if( itr->next ) {
+            itr->next( std::static_pointer_cast<fc::exception>(
+                  std::make_shared<expired_tx_exception>(
+                        FC_LOG_MESSAGE( error, "expired transaction ${id}, expiration ${e}, block time ${bt}",
+                                        ("id", itr->id())("e", itr->trx_meta->packed_trx()->expiration())
+                                        ("bt", pending_block_time) ) ) ) );
+         }
+
+         removed( itr );
+         persisted_by_expiry.erase( itr );
       }
       return true;
    }
@@ -127,8 +144,10 @@ public:
             const auto& pt = std::get<packed_transaction>(receipt.trx);
             auto itr = queue.get<by_trx_id>().find( pt.id() );
             if( itr != queue.get<by_trx_id>().end() ) {
-               if( itr->trx_type != trx_enum_type::persisted ) {
-                  idx.erase( pt.id() );
+               if( itr->trx_type != trx_enum_type::persisted &&
+                   itr->trx_type != trx_enum_type::incoming_persisted ) {
+                  removed( itr );
+                  idx.erase( itr );
                }
             }
          }
@@ -143,7 +162,8 @@ public:
          for( auto itr = bsptr->trxs_metas().begin(), end = bsptr->trxs_metas().end(); itr != end; ++itr ) {
             const auto& trx = *itr;
             fc::time_point expiry = trx->packed_trx()->expiration();
-            queue.insert( { trx, expiry, trx_enum_type::forked } );
+            auto insert_itr = queue.insert( { trx, expiry, trx_enum_type::forked } );
+            if( insert_itr.second ) added( insert_itr.first );
          }
       }
    }
@@ -152,7 +172,8 @@ public:
       if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       for( auto& trx : aborted_trxs ) {
          fc::time_point expiry = trx->packed_trx()->expiration();
-         queue.insert( { std::move( trx ), expiry, trx_enum_type::aborted } );
+         auto insert_itr = queue.insert( { std::move( trx ), expiry, trx_enum_type::aborted } );
+         if( insert_itr.second ) added( insert_itr.first );
       }
    }
 
@@ -161,10 +182,26 @@ public:
       auto itr = queue.get<by_trx_id>().find( trx->id() );
       if( itr == queue.get<by_trx_id>().end() ) {
          fc::time_point expiry = trx->packed_trx()->expiration();
-         queue.insert( { trx, expiry, trx_enum_type::persisted } );
+         auto insert_itr = queue.insert( { trx, expiry, trx_enum_type::persisted } );
+         if( insert_itr.second ) added( insert_itr.first );
       } else if( itr->trx_type != trx_enum_type::persisted ) {
          queue.get<by_trx_id>().modify( itr, [](auto& un){
             un.trx_type = trx_enum_type::persisted;
+         } );
+      }
+   }
+
+   void add_incoming( const transaction_metadata_ptr& trx, bool persist_until_expired, next_func_t next ) {
+      auto itr = queue.get<by_trx_id>().find( trx->id() );
+      if( itr == queue.get<by_trx_id>().end() ) {
+         fc::time_point expiry = trx->packed_trx()->expiration();
+         auto insert_itr = queue.insert(
+               { trx, expiry, persist_until_expired ? trx_enum_type::incoming_persisted : trx_enum_type::incoming, std::move( next ) } );
+         if( insert_itr.second ) added( insert_itr.first );
+      } else {
+         queue.get<by_trx_id>().modify( itr, [persist_until_expired, next{std::move(next)}](auto& un) mutable {
+            un.trx_type = persist_until_expired ? trx_enum_type::incoming_persisted : trx_enum_type::incoming;
+            un.next = std::move( next );
          } );
       }
    }
@@ -174,10 +211,48 @@ public:
    iterator begin() { return queue.get<by_type>().begin(); }
    iterator end() { return queue.get<by_type>().end(); }
 
+   // persisted, forked, aborted
+   iterator unapplied_begin() { return queue.get<by_type>().begin(); }
+   iterator unapplied_end() { return queue.get<by_type>().upper_bound( trx_enum_type::aborted ); }
+
    iterator persisted_begin() { return queue.get<by_type>().lower_bound( trx_enum_type::persisted ); }
    iterator persisted_end() { return queue.get<by_type>().upper_bound( trx_enum_type::persisted ); }
 
-   iterator erase( iterator itr ) { return queue.get<by_type>().erase( itr ); }
+   iterator incoming_begin() { return queue.get<by_type>().lower_bound( trx_enum_type::incoming_persisted ); }
+   iterator incoming_end() { return queue.get<by_type>().end(); } // if changed to upper_bound, verify usage performance
+
+   iterator erase( iterator itr ) {
+      removed( itr );
+      return queue.get<by_type>().erase( itr );
+   }
+
+private:
+   template<typename Itr>
+   void added( Itr itr ) {
+      auto size = calc_size( itr->trx_meta );
+      if( itr->trx_type == trx_enum_type::incoming || itr->trx_type == trx_enum_type::incoming_persisted ) {
+         ++incoming_count;
+         EOS_ASSERT( size_in_bytes + size < max_transaction_queue_size, tx_resource_exhaustion,
+                     "Transaction ${id}, size ${s} bytes would exceed configured "
+                     "incoming-transaction-queue-size-mb ${qs}, current queue size ${cs} bytes",
+                     ("id", itr->trx_meta->id())("s", size)("qs", max_transaction_queue_size/(1024*1024))
+                     ("cs", size_in_bytes) );
+      }
+      size_in_bytes += size;
+   }
+
+   template<typename Itr>
+   void removed( Itr itr ) {
+      if( itr->trx_type == trx_enum_type::incoming || itr->trx_type == trx_enum_type::incoming_persisted ) {
+         --incoming_count;
+      }
+      size_in_bytes -= calc_size( itr->trx_meta );
+   }
+
+   static uint64_t calc_size( const transaction_metadata_ptr& trx ) {
+      // packed_trx caches unpacked transaction so double
+      return (trx->packed_trx()->get_unprunable_size() + trx->packed_trx()->get_prunable_size()) * 2 + sizeof( *trx );
+   }
 
 };
 

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -141,16 +141,20 @@ public:
       for( const auto& receipt : bs->block->transactions ) {
          if( std::holds_alternative<packed_transaction>(receipt.trx) ) {
             const auto& pt = std::get<packed_transaction>(receipt.trx);
-            auto itr = queue.get<by_trx_id>().find( pt.id() );
-            if( itr != queue.get<by_trx_id>().end() ) {
+            auto itr = idx.find( pt.id() );
+            if( itr != idx.end() ) {
+               if( itr->next ) {
+                  itr->next( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
+                                FC_LOG_MESSAGE( info, "duplicate transaction ${id}", ("id", itr->trx_meta->id())))));
+               }
                if( itr->trx_type != trx_enum_type::persisted &&
                    itr->trx_type != trx_enum_type::incoming_persisted ) {
-                  if( itr->next ) {
-                     itr->next( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
-                                   FC_LOG_MESSAGE( info, "duplicate transaction ${id}", ("id", itr->trx_meta->id())))));
-                  }
                   removed( itr );
                   idx.erase( itr );
+               } else if( itr->next ) {
+                  idx.modify( itr, [](auto& un){
+                     un.next = nullptr;
+                  } );
                }
             }
          }

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -49,13 +49,6 @@ struct unapplied_transaction {
  * Persisted are first so that they can be applied in each block until expired.
  */
 class unapplied_transaction_queue {
-public:
-   enum class process_mode {
-      non_speculative,           // HEAD, READ_ONLY, IRREVERSIBLE
-      speculative_non_producer,  // will never produce
-      speculative_producer       // can produce
-   };
-
 private:
    struct by_trx_id;
    struct by_type;
@@ -72,7 +65,6 @@ private:
    > unapplied_trx_queue_type;
 
    unapplied_trx_queue_type queue;
-   process_mode mode = process_mode::speculative_producer;
    uint64_t max_transaction_queue_size = 1024*1024*1024; // enforced for incoming
    uint64_t size_in_bytes = 0;
    size_t incoming_count = 0;
@@ -80,13 +72,6 @@ private:
 public:
 
    void set_max_transaction_queue_size( uint64_t v ) { max_transaction_queue_size = v; }
-
-   void set_mode( process_mode new_mode ) {
-      if( new_mode != mode ) {
-         FC_ASSERT( empty(), "set_mode, queue required to be empty" );
-      }
-      mode = new_mode;
-   }
 
    bool empty() const {
       return queue.empty();
@@ -184,7 +169,6 @@ public:
    }
 
    void add_persisted( const transaction_metadata_ptr& trx ) {
-      if( mode == process_mode::non_speculative ) return;
       auto itr = queue.get<by_trx_id>().find( trx->id() );
       if( itr == queue.get<by_trx_id>().end() ) {
          fc::time_point expiry = trx->packed_trx()->expiration();

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -162,7 +162,6 @@ public:
    }
 
    void add_forked( const branch_type& forked_branch ) {
-      if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       // forked_branch is in reverse order
       for( auto ritr = forked_branch.rbegin(), rend = forked_branch.rend(); ritr != rend; ++ritr ) {
          const block_state_ptr& bsptr = *ritr;
@@ -175,7 +174,7 @@ public:
       }
    }
 
-   void add_aborted( std::vector<transaction_metadata_ptr> aborted_trxs ) {
+   void add_aborted( deque<transaction_metadata_ptr> aborted_trxs ) {
       if( mode == process_mode::non_speculative || mode == process_mode::speculative_non_producer ) return;
       for( auto& trx : aborted_trxs ) {
          fc::time_point expiry = trx->packed_trx()->expiration();

--- a/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
+++ b/libraries/chain/include/eosio/chain/unapplied_transaction_queue.hpp
@@ -129,8 +129,7 @@ public:
                                         ("id", itr->id())("e", itr->trx_meta->packed_trx()->expiration())
                                         ("bt", pending_block_time) ) ) ) );
          }
-
-         removed( itr, false );
+         removed( itr );
          persisted_by_expiry.erase( itr );
       }
       return true;
@@ -146,6 +145,10 @@ public:
             if( itr != queue.get<by_trx_id>().end() ) {
                if( itr->trx_type != trx_enum_type::persisted &&
                    itr->trx_type != trx_enum_type::incoming_persisted ) {
+                  if( itr->next ) {
+                     itr->next( std::static_pointer_cast<fc::exception>( std::make_shared<tx_duplicate>(
+                                   FC_LOG_MESSAGE( info, "duplicate transaction ${id}", ("id", itr->trx_meta->id())))));
+                  }
                   removed( itr );
                   idx.erase( itr );
                }
@@ -221,9 +224,9 @@ public:
    iterator incoming_begin() { return queue.get<by_type>().lower_bound( trx_enum_type::incoming_persisted ); }
    iterator incoming_end() { return queue.get<by_type>().end(); } // if changed to upper_bound, verify usage performance
 
-   /// callers responsibilty to call next() if applicable
+   /// caller's responsibilty to call next() if applicable
    iterator erase( iterator itr ) {
-      removed( itr, false );
+      removed( itr );
       return queue.get<by_type>().erase( itr );
    }
 
@@ -243,14 +246,9 @@ private:
    }
 
    template<typename Itr>
-   void removed( Itr itr, bool call_next = true ) {
+   void removed( Itr itr ) {
       if( itr->trx_type == trx_enum_type::incoming || itr->trx_type == trx_enum_type::incoming_persisted ) {
          --incoming_count;
-      }
-      if( call_next && itr->next ) {
-         transaction_trace_ptr trace = std::make_shared<transaction_trace>();
-         trace->id = itr->trx_meta->id();
-         itr->next( trace );
       }
       size_in_bytes -= calc_size( itr->trx_meta );
    }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2011,6 +2011,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                         _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
                   }
                   ++num_failed;
+                  if( itr->next ) itr->next( trace );
                   itr = _unapplied_transactions.erase( itr );
                   continue;
                }
@@ -2022,6 +2023,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                                                     chain.get_read_mode() == chain::db_read_mode::SPECULATIVE );
                ++num_applied;
                if( itr->trx_type != trx_enum_type::persisted ) {
+                  if( itr->next ) itr->next( trace );
                   itr = _unapplied_transactions.erase( itr );
                   continue;
                }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1978,6 +1978,11 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
             auto first_auth = trx->packed_trx()->get_transaction().first_authorizer();
             if( account_fails.failure_limit( first_auth ) ) {
                ++num_failed;
+               if( itr->next ) {
+                  itr->next( std::make_shared<tx_cpu_usage_exceeded>(
+                        FC_LOG_MESSAGE( error, "transaction ${id} exceeded failure limit for account ${a}",
+                                        ("id", trx->id())("a", resource_payer) ) ) );
+               }
                itr = _unapplied_transactions.erase( itr );
                continue;
             }
@@ -2020,7 +2025,13 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                         _subjective_billing.subjective_bill_failure( first_auth, trace->elapsed, fc::time_point::now() );
                   }
                   ++num_failed;
-                  if( itr->next ) itr->next( trace );
+                  if( itr->next ) {
+                     if( itr->return_failure_trace ) {
+                        itr->next( trace );
+                     } else {
+                        itr->next( trace->except->dynamic_copy_exception() );
+                     }
+                  }
                   itr = _unapplied_transactions.erase( itr );
                   continue;
                }

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1529,8 +1529,12 @@ fc::time_point producer_plugin_impl::calculate_pending_block_time() const {
 }
 
 fc::time_point producer_plugin_impl::calculate_block_deadline( const fc::time_point& block_time ) const {
-   bool last_block = ((block_timestamp_type(block_time).slot % config::producer_repetitions) == config::producer_repetitions - 1);
-   return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
+   if( _pending_block_mode == pending_block_mode::producing ) {
+      bool last_block = ((block_timestamp_type( block_time ).slot % config::producer_repetitions) == config::producer_repetitions - 1);
+      return block_time + fc::microseconds(last_block ? _last_block_time_offset_us : _produce_time_offset_us);
+   } else {
+      return block_time + fc::microseconds(_produce_time_offset_us);
+   }
 }
 
 producer_plugin_impl::start_block_result producer_plugin_impl::start_block() {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -861,11 +861,6 @@ void producer_plugin::plugin_initialize(const boost::program_options::variables_
    LOAD_VALUE_SET(options, "producer-name", my->_producers)
 
    chain::controller& chain = my->chain_plug->chain();
-   unapplied_transaction_queue::process_mode unapplied_mode =
-      (chain.get_read_mode() != chain::db_read_mode::SPECULATIVE) ? unapplied_transaction_queue::process_mode::non_speculative :
-         my->_producers.empty() ? unapplied_transaction_queue::process_mode::speculative_non_producer :
-            unapplied_transaction_queue::process_mode::speculative_producer;
-   my->_unapplied_transactions.set_mode( unapplied_mode );
 
    if( options.count("private-key") )
    {

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -1981,7 +1981,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                if( itr->next ) {
                   itr->next( std::make_shared<tx_cpu_usage_exceeded>(
                         FC_LOG_MESSAGE( error, "transaction ${id} exceeded failure limit for account ${a}",
-                                        ("id", trx->id())("a", resource_payer) ) ) );
+                                        ("id", trx->id())("a", first_auth) ) ) );
                }
                itr = _unapplied_transactions.erase( itr );
                continue;
@@ -2026,11 +2026,7 @@ bool producer_plugin_impl::process_unapplied_trxs( const fc::time_point& deadlin
                   }
                   ++num_failed;
                   if( itr->next ) {
-                     if( itr->return_failure_trace ) {
-                        itr->next( trace );
-                     } else {
-                        itr->next( trace->except->dynamic_copy_exception() );
-                     }
+                     itr->next( trace->except->dynamic_copy_exception() );
                   }
                   itr = _unapplied_transactions.erase( itr );
                   continue;

--- a/plugins/producer_plugin/producer_plugin.cpp
+++ b/plugins/producer_plugin/producer_plugin.cpp
@@ -2407,30 +2407,4 @@ void producer_plugin::log_failed_transaction(const transaction_id_type& trx_id, 
             ("entire_trx", packed_trx_ptr ? my->chain_plug->get_log_trx(packed_trx_ptr->get_transaction()) : fc::variant{trx_id}));
 }
 
-bool producer_plugin::execute_incoming_transaction(const chain::transaction_metadata_ptr& trx,
-                                                   next_function<chain::transaction_trace_ptr> next,
-                                                   retry_later_function_t retry_later )
-{
-   auto retry_later_func = [&retry_later](const transaction_metadata_ptr& trx, bool persist_until_expired, next_func_t& next ) {
-      retry_later( trx, next );
-   };
-
-   const bool persist_until_expired = false;
-   bool exhausted = !my->process_incoming_transaction_async( trx, persist_until_expired, std::move(next), retry_later_func );
-   if( exhausted ) {
-      if( my->_pending_block_mode == pending_block_mode::producing ) {
-         my->schedule_maybe_produce_block( true );
-      } else {
-         my->restart_speculative_block();
-      }
-   }
-   return !exhausted;
-}
-
-fc::microseconds producer_plugin::get_max_transaction_time() const {
-   const auto max_trx_time_ms = my->_max_transaction_time_ms.load();
-   fc::microseconds max_trx_cpu_usage = max_trx_time_ms < 0 ? fc::microseconds::maximum() : fc::milliseconds( max_trx_time_ms );
-   return max_trx_cpu_usage;
-}
-
 } // namespace eosio

--- a/plugins/producer_plugin/test/CMakeLists.txt
+++ b/plugins/producer_plugin/test/CMakeLists.txt
@@ -3,3 +3,7 @@ target_link_libraries( test_subjective_billing producer_plugin eosio_testing )
 
 add_test(NAME test_subjective_billing COMMAND plugins/producer_plugin/test/test_subjective_billing WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
+add_executable( test_trx_full test_trx_full.cpp )
+target_link_libraries( test_trx_full producer_plugin eosio_testing )
+
+add_test(NAME test_trx_full COMMAND plugins/producer_plugin/test/test_trx_full WORKING_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -1,0 +1,212 @@
+#define BOOST_TEST_MODULE full_producer_trxs
+#include <boost/test/included/unit_test.hpp>
+
+#include <eosio/producer_plugin/producer_plugin.hpp>
+
+#include <eosio/testing/tester.hpp>
+
+#include <eosio/chain/genesis_state.hpp>
+#include <eosio/chain/thread_utils.hpp>
+#include <eosio/chain/transaction_metadata.hpp>
+#include <eosio/chain/trace.hpp>
+#include <eosio/chain/name.hpp>
+
+#include <appbase/application.hpp>
+
+namespace eosio::test::detail {
+using namespace eosio::chain::literals;
+struct testit {
+   uint64_t      id;
+
+   testit( uint64_t id = 0 )
+         :id(id){}
+
+   static account_name get_account() {
+      return chain::config::system_account_name;
+   }
+
+   static action_name get_name() {
+      return "testit"_n;
+   }
+};
+}
+FC_REFLECT( eosio::test::detail::testit, (id) )
+
+namespace {
+
+using namespace eosio;
+using namespace eosio::chain;
+using namespace eosio::test::detail;
+
+auto make_unique_trx( const chain_id_type& chain_id ) {
+
+   static uint64_t nextid = 0;
+   ++nextid;
+
+   account_name creator = config::system_account_name;
+
+   signed_transaction trx;
+   // if a transaction expires after it was aborted then it will not be included in a block
+   trx.expiration = fc::time_point::now() + fc::seconds( nextid % 20 == 0 ? 0 : 60 ); // fail some transactions via expired
+   if( nextid % 15 == 0 ) { // fail some for invalid unlinkauth
+      trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}},
+                                unlinkauth{} );
+      trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}},
+                                testit{nextid} );
+   } else {
+      trx.actions.emplace_back( vector<permission_level>{{creator, config::active_name}},
+                                testit{ nextid % 7 == 0 ? 0 : nextid} ); // fail some for duplicates
+   }
+   if( nextid % 13 == 0 ) { // fail some for invalid signature
+      auto bad_priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("kevin")));
+      trx.sign( bad_priv_key, chain_id );
+   } else {
+      auto priv_key = private_key_type::regenerate<fc::ecc::private_key_shim>(fc::sha256::hash(std::string("nathan")));
+      trx.sign( priv_key, chain_id );
+   }
+
+   return std::make_shared<packed_transaction>( std::move(trx), true, packed_transaction::compression_type::none);
+}
+
+// verify all trxs are in blocks only once
+bool verify_equal( const std::deque<packed_transaction_ptr>& trxs, const std::deque<block_state_ptr>& all_blocks) {
+   std::set<transaction_id_type> trxs_ids; // trx can appear more than once if they were aborted
+   std::set<transaction_id_type> blk_trxs_ids;
+
+   for( const auto& trx : trxs ) {
+      trxs_ids.emplace( trx->id() );
+   }
+   for( const auto& bs : all_blocks ) {
+      for( const auto& trx_receipt : bs->block->transactions ) {
+         const auto& trx = std::get<packed_transaction>( trx_receipt.trx ).get_transaction();
+         blk_trxs_ids.emplace( trx.id() );
+      }
+   }
+   BOOST_CHECK_EQUAL( trxs_ids.size(), blk_trxs_ids.size() );
+
+   for( const auto& trx : trxs ) {
+      BOOST_CHECK( blk_trxs_ids.count( trx->id() ) == 1 );
+   }
+
+   return true;
+}
+
+
+}
+
+BOOST_AUTO_TEST_SUITE(ordered_trxs_full)
+
+// Integration test of producer_plugin
+// Test verifies that transactions are processed, reported to caller, and not lost
+// even when blocks are aborted and some transactions fail.
+BOOST_AUTO_TEST_CASE(producer) {
+   boost::filesystem::path temp = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path();
+
+   try {
+      std::promise<std::tuple<producer_plugin*, chain_plugin*>> plugin_promise;
+      std::future<std::tuple<producer_plugin*, chain_plugin*>> plugin_fut = plugin_promise.get_future();
+      std::thread app_thread( [&]() {
+         fc::logger::get(DEFAULT_LOGGER).set_log_level(fc::log_level::debug);
+         std::vector<const char*> argv =
+               {"test", "--data-dir", temp.c_str(), "--config-dir", temp.c_str(),
+                "-p", "eosio", "-e", "--max-transaction-time", "475", "--disable-subjective-billing=true" };
+         appbase::app().initialize<chain_plugin, producer_plugin>( argv.size(), (char**) &argv[0] );
+         appbase::app().startup();
+         plugin_promise.set_value(
+               {appbase::app().find_plugin<producer_plugin>(), appbase::app().find_plugin<chain_plugin>()} );
+         appbase::app().exec();
+      } );
+
+      auto[prod_plug, chain_plug] = plugin_fut.get();
+      auto chain_id = chain_plug->get_chain_id();
+
+      std::deque<block_state_ptr> all_blocks;
+      std::promise<void> empty_blocks_promise;
+      std::future<void> empty_blocks_fut = empty_blocks_promise.get_future();
+      std::atomic<size_t> num_aborts = 0;
+      auto ab = chain_plug->chain().accepted_block.connect( [&](const block_state_ptr& bsp) {
+         static int num_empty = std::numeric_limits<int>::max();
+         all_blocks.push_back( bsp );
+         if( bsp->block->transactions.empty() ) {
+            --num_empty;
+            if( num_empty == 0 ) empty_blocks_promise.set_value();
+         } else { // we want a few empty blocks after we have some non-empty blocks
+            num_empty = 10;
+         }
+      } );
+      auto ba = chain_plug->chain().block_abort.connect( [&]( uint32_t bn ) {
+         ++num_aborts;
+      } );
+      auto bs = chain_plug->chain().block_start.connect( [&]( uint32_t bn ) {
+      } );
+
+      std::deque<packed_transaction_ptr> trxs;
+      std::atomic<size_t> next_calls = 0;
+      std::atomic<size_t> num_posts = 0;
+      std::atomic<size_t> trace_with_except = 0;
+      std::atomic<bool> trx_match = true;
+      const size_t num_pushes = 4242;
+      for( size_t i = 1; i <= num_pushes; ++i ) {
+         auto ptrx = make_unique_trx( chain_id );
+         dlog( "posting ${id}", ("id", ptrx->id()) );
+         app().post( priority::low, [ptrx, &next_calls, &num_posts, &trace_with_except, &trx_match, &trxs]() {
+            ++num_posts;
+            bool return_failure_traces = num_posts % 2 == 0;
+            app().get_method<plugin_interface::incoming::methods::transaction_async>()(ptrx,
+               false, // persist_until_expiried
+               false, // read_only
+               return_failure_traces == true, // return_failure_traces
+               [ptrx, &next_calls, &trace_with_except, &trx_match, &trxs, return_failure_traces]
+               (const std::variant<fc::exception_ptr, transaction_trace_ptr>& result) {
+                  if( !std::holds_alternative<fc::exception_ptr>( result ) && !std::get<chain::transaction_trace_ptr>( result )->except ) {
+                     if( std::get<chain::transaction_trace_ptr>( result )->id == ptrx->id() ) {
+                        trxs.push_back( ptrx );
+                     } else {
+                        elog( "trace not for trx ${id}: ${t}",
+                              ("id", ptrx->id())("t", fc::json::to_pretty_string(*std::get<chain::transaction_trace_ptr>(result))) );
+                        trx_match = false;
+                     }
+                  } else if( !return_failure_traces && !std::holds_alternative<fc::exception_ptr>( result ) && std::get<chain::transaction_trace_ptr>( result )->except ) {
+                     elog( "trace with except ${e}",
+                           ("e", fc::json::to_pretty_string( *std::get<chain::transaction_trace_ptr>( result ) )) );
+                     ++trace_with_except;
+                  }
+                  ++next_calls;
+           });
+         });
+         if( i % (num_pushes/3) == 0 ) {
+            // need to sleep or a fast machine might put all trxs in one block
+            usleep( config::block_interval_us / 2 );
+         }
+         if( i % 500 == 0 && num_aborts <= 3 ) {
+            // get_integrity_hash aborts block and places aborted trxs into unapplied_transaction_queue
+            // verifying that aborting block does not lose transactions
+            app().post(priority::high, [](){
+               app().find_plugin<producer_plugin>()->get_integrity_hash();
+            });
+         }
+      }
+
+      empty_blocks_fut.wait_for(std::chrono::seconds(15));
+
+      BOOST_CHECK_EQUAL( trace_with_except, 0 ); // should not have any traces with except in it
+      BOOST_CHECK( all_blocks.size() > 3 ); // should have a few blocks otherwise test is running too fast
+      BOOST_CHECK( num_aborts > 3 ); // should have a few abort_blocks or maybe get_integrity_hash has changed
+      BOOST_CHECK_EQUAL( num_pushes, num_posts );
+      BOOST_CHECK_EQUAL( num_pushes, next_calls );
+      BOOST_CHECK( trx_match.load() );
+
+      appbase::app().quit();
+      app_thread.join();
+
+      BOOST_REQUIRE( verify_equal(trxs, all_blocks ) );
+
+   } catch ( ... ) {
+      bfs::remove_all( temp );
+      throw;
+   }
+   bfs::remove_all( temp );
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/plugins/producer_plugin/test/test_trx_full.cpp
+++ b/plugins/producer_plugin/test/test_trx_full.cpp
@@ -65,7 +65,7 @@ auto make_unique_trx( const chain_id_type& chain_id ) {
       trx.sign( priv_key, chain_id );
    }
 
-   return std::make_shared<packed_transaction>( std::move(trx), true, packed_transaction::compression_type::none);
+   return std::make_shared<packed_transaction>( std::move(trx) );
 }
 
 // verify all trxs are in blocks only once
@@ -150,8 +150,8 @@ BOOST_AUTO_TEST_CASE(producer) {
             bool return_failure_traces = false; // 2.2.x+ = num_posts % 2 == 0;
             app().get_method<plugin_interface::incoming::methods::transaction_async>()(ptrx,
                false, // persist_until_expiried
-               // 2.2.x+ false, // read_only
-               // 2.2.x+ return_failure_traces == true, // return_failure_traces
+               false, // read_only
+               false, // return_failure_traces
                [ptrx, &next_calls, &trace_with_except, &trx_match, &trxs, return_failure_traces]
                (const std::variant<fc::exception_ptr, transaction_trace_ptr>& result) {
                   if( !std::holds_alternative<fc::exception_ptr>( result ) && !std::get<chain::transaction_trace_ptr>( result )->except ) {

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -448,5 +448,49 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
 
 } FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_test
 
+BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
+
+   unapplied_transaction_queue q;
+   BOOST_CHECK( q.empty() );
+   BOOST_CHECK( q.size() == 0 );
+
+   auto trx1 = unique_trx_meta_data();
+   auto trx2 = unique_trx_meta_data();
+   auto trx3 = unique_trx_meta_data();
+   auto trx4 = unique_trx_meta_data();
+   auto trx5 = unique_trx_meta_data();
+   auto trx6 = unique_trx_meta_data();
+
+   q.add_incoming( trx1, false, [](auto){} );
+   q.add_incoming( trx2, false, [](auto){} );
+   q.add_incoming( trx3, false, [](auto){} );
+   q.add_incoming( trx4, false, [](auto){} );
+   q.add_incoming( trx5, false, [](auto){} );
+   q.add_incoming( trx6, false, [](auto){} );
+
+   auto count = q.incoming_size();
+   auto expected = q.size();
+
+   BOOST_CHECK( count == expected );
+
+   auto itr = q.unapplied_begin();
+   auto end = q.unapplied_end();
+
+   while( itr != end ) {
+      q.add_persisted( itr->trx_meta );
+      --expected;
+      BOOST_CHECK( count == expected );
+   }
+
+   itr = q.unapplied_begin();
+   end = q.unapplied_end();
+
+   while( itr != end ) {
+      q.add_incoming( itr->trx_meta, false, [](auto){} );
+      ++expected;
+      BOOST_CHECK( count == expected );
+   }
+
+} FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_test
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -490,6 +490,6 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
       BOOST_CHECK( q.incoming_size() == expected );
    }
 
-} FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_test
+} FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_incoming_count
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -8,13 +8,14 @@ using namespace eosio::chain;
 
 BOOST_AUTO_TEST_SUITE(unapplied_transaction_queue_tests)
 
-auto unique_trx_meta_data() {
+auto unique_trx_meta_data( fc::time_point expire = fc::time_point::now() + fc::seconds( 120 ) ) {
 
    static uint64_t nextid = 0;
    ++nextid;
 
    signed_transaction trx;
    account_name creator = config::system_account_name;
+   trx.expiration = expire;
    trx.actions.emplace_back( vector<permission_level>{{creator,config::active_name}},
                              onerror{ nextid, "test", 4 });
    return transaction_metadata::create_no_recover_keys( std::make_shared<packed_transaction>( std::move(trx) ),
@@ -297,6 +298,19 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
    BOOST_REQUIRE( next( q ) == nullptr );
    BOOST_CHECK( q.empty() );
 
+   auto trx20 = unique_trx_meta_data( fc::time_point::now() - fc::seconds( 1 ) );
+   auto trx21 = unique_trx_meta_data( fc::time_point::now() - fc::seconds( 1 ) );
+   auto trx22 = unique_trx_meta_data( fc::time_point::now() + fc::seconds( 120 ) );
+   auto trx23 = unique_trx_meta_data( fc::time_point::now() + fc::seconds( 120 ) );
+   q.add_aborted( { trx20, trx22 } );
+   q.add_persisted( trx21 );
+   q.add_persisted( trx23 );
+   q.clear_expired( fc::time_point::now(), fc::time_point::now() + fc::seconds( 300 ), [](auto, auto){} );
+   BOOST_CHECK( q.size() == 2 );
+   BOOST_REQUIRE( next( q ) == trx23 );
+   BOOST_REQUIRE( next( q ) == trx22 );
+   BOOST_CHECK( q.empty() );
+
    q.add_forked( { bs3, bs2, bs1 } );
    q.add_aborted( { trx9, trx11 } );
    q.add_persisted( trx8 );
@@ -304,6 +318,133 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_test ) try {
    BOOST_CHECK( q.empty() );
    BOOST_CHECK( q.size() == 0 );
    BOOST_REQUIRE( next( q ) == nullptr );
+
+} FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_test
+
+
+BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
+
+   unapplied_transaction_queue q;
+   BOOST_CHECK( q.empty() );
+   BOOST_CHECK( q.size() == 0 );
+
+   auto trx1 = unique_trx_meta_data();
+   auto trx2 = unique_trx_meta_data();
+   auto trx3 = unique_trx_meta_data();
+   auto trx4 = unique_trx_meta_data();
+   auto trx5 = unique_trx_meta_data();
+   auto trx6 = unique_trx_meta_data();
+   auto trx7 = unique_trx_meta_data();
+   auto trx8 = unique_trx_meta_data();
+   auto trx9 = unique_trx_meta_data();
+
+   q.add_incoming( trx1, false, [](auto){} );
+   q.add_incoming( trx2, false, [](auto){} );
+   q.add_incoming( trx3, false, [](auto){} );
+   q.add_incoming( trx4, false, [](auto){} );
+   q.add_incoming( trx5, false, [](auto){} );
+   q.add_incoming( trx6, false, [](auto){} );
+
+   auto itr = q.incoming_begin();
+   auto end = q.incoming_end();
+
+   auto count = q.incoming_size();
+
+   // count required to avoid infinite loop
+   while( count && itr != end ) {
+      auto trx_meta = itr->trx_meta;
+      if( count == 6 ) BOOST_CHECK( trx_meta == trx1 );
+      if( count == 5 ) BOOST_CHECK( trx_meta == trx2 );
+      if( count == 4 ) BOOST_CHECK( trx_meta == trx3 );
+      if( count == 3 ) BOOST_CHECK( trx_meta == trx4 );
+      if( count == 2 ) BOOST_CHECK( trx_meta == trx5 );
+      if( count == 1 ) BOOST_CHECK( trx_meta == trx6 );
+      itr = q.erase( itr );
+      q.add_incoming( trx_meta, false, [](auto){} );
+      --count;
+   }
+
+   BOOST_CHECK( q.size() == 6 );
+   BOOST_REQUIRE( next( q ) == trx1 );
+   BOOST_REQUIRE( next( q ) == trx2 );
+   BOOST_REQUIRE( next( q ) == trx3 );
+   BOOST_REQUIRE( next( q ) == trx4 );
+   BOOST_REQUIRE( next( q ) == trx5 );
+   BOOST_REQUIRE( next( q ) == trx6 );
+   BOOST_CHECK( q.empty() );
+
+   // incoming ++itr w/ erase
+   q.add_incoming( trx1, false, [](auto){} );
+   q.add_incoming( trx2, false, [](auto){} );
+   q.add_incoming( trx3, false, [](auto){} );
+   q.add_incoming( trx4, false, [](auto){} );
+   q.add_incoming( trx5, false, [](auto){} );
+   q.add_incoming( trx6, false, [](auto){} );
+
+   itr = q.incoming_begin();
+   end = q.incoming_end();
+
+   count = q.incoming_size();
+   while( itr != end ) {
+      if( count % 2 == 0) {
+         itr = q.erase( itr );
+      } else {
+         ++itr;
+      }
+      --count;
+   }
+   BOOST_REQUIRE( count == 0 );
+   q.clear();
+
+   // persisted
+   q.add_persisted( trx1 );
+   q.add_persisted( trx2 );
+   q.add_persisted( trx3 );
+   q.add_persisted( trx4 );
+   q.add_persisted( trx5 );
+   q.add_persisted( trx6 );
+   q.add_incoming( trx7, false, [](auto){} );
+
+   itr = q.persisted_begin();
+   end = q.persisted_end();
+   count = q.size() - 1;
+
+   while( count > 0 && itr != end ) {
+      auto trx_meta = itr->trx_meta;
+      if( count == 6 ) BOOST_CHECK( trx_meta == trx1 );
+      if( count == 5 ) BOOST_CHECK( trx_meta == trx2 );
+      if( count == 4 ) BOOST_CHECK( trx_meta == trx3 );
+      if( count == 3 ) BOOST_CHECK( trx_meta == trx4 );
+      if( count == 2 ) BOOST_CHECK( trx_meta == trx5 );
+      if( count == 1 ) BOOST_CHECK( trx_meta == trx6 );
+      itr = q.erase( itr );
+      q.add_persisted( trx_meta );
+      --count;
+   }
+   q.clear();
+
+   q.add_persisted( trx1 );
+   q.add_persisted( trx2 );
+   q.add_persisted( trx3 );
+   q.add_persisted( trx4 );
+   q.add_persisted( trx5 );
+   q.add_persisted( trx6 );
+   q.add_incoming( trx7, false, [](auto){} );
+
+   itr = q.unapplied_begin();
+   end = q.unapplied_end();
+
+   count = q.size() - 1;
+   while( itr != end ) {
+      if( count % 2 == 0) {
+         itr = q.erase( itr );
+      } else {
+         ++itr;
+      }
+      --count;
+   }
+   BOOST_REQUIRE( count == 0 );
+   q.clear();
 
 } FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_test
 

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -338,12 +338,12 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    auto trx8 = unique_trx_meta_data();
    auto trx9 = unique_trx_meta_data();
 
-   q.add_incoming( trx1, false, [](auto){} );
-   q.add_incoming( trx2, false, [](auto){} );
-   q.add_incoming( trx3, false, [](auto){} );
-   q.add_incoming( trx4, false, [](auto){} );
-   q.add_incoming( trx5, false, [](auto){} );
-   q.add_incoming( trx6, false, [](auto){} );
+   q.add_incoming( trx1, false, false, [](auto){} );
+   q.add_incoming( trx2, false, false, [](auto){} );
+   q.add_incoming( trx3, false, false, [](auto){} );
+   q.add_incoming( trx4, false, false, [](auto){} );
+   q.add_incoming( trx5, false, false, [](auto){} );
+   q.add_incoming( trx6, false, false, [](auto){} );
 
    auto itr = q.incoming_begin();
    auto end = q.incoming_end();
@@ -360,7 +360,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
       if( count == 2 ) BOOST_CHECK( trx_meta == trx5 );
       if( count == 1 ) BOOST_CHECK( trx_meta == trx6 );
       itr = q.erase( itr );
-      q.add_incoming( trx_meta, false, [](auto){} );
+      q.add_incoming( trx_meta, false, false, [](auto){} );
       --count;
    }
 
@@ -374,12 +374,12 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    BOOST_CHECK( q.empty() );
 
    // incoming ++itr w/ erase
-   q.add_incoming( trx1, false, [](auto){} );
-   q.add_incoming( trx2, false, [](auto){} );
-   q.add_incoming( trx3, false, [](auto){} );
-   q.add_incoming( trx4, false, [](auto){} );
-   q.add_incoming( trx5, false, [](auto){} );
-   q.add_incoming( trx6, false, [](auto){} );
+   q.add_incoming( trx1, false, false, [](auto){} );
+   q.add_incoming( trx2, false, false, [](auto){} );
+   q.add_incoming( trx3, false, false, [](auto){} );
+   q.add_incoming( trx4, false, false, [](auto){} );
+   q.add_incoming( trx5, false, false, [](auto){} );
+   q.add_incoming( trx6, false, false, [](auto){} );
 
    itr = q.incoming_begin();
    end = q.incoming_end();
@@ -403,7 +403,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    q.add_persisted( trx4 );
    q.add_persisted( trx5 );
    q.add_persisted( trx6 );
-   q.add_incoming( trx7, false, [](auto){} );
+   q.add_incoming( trx7, false, false, [](auto){} );
 
    itr = q.persisted_begin();
    end = q.persisted_end();
@@ -429,7 +429,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_erase_add ) try {
    q.add_persisted( trx4 );
    q.add_persisted( trx5 );
    q.add_persisted( trx6 );
-   q.add_incoming( trx7, false, [](auto){} );
+   q.add_incoming( trx7, false, false, [](auto){} );
 
    itr = q.unapplied_begin();
    end = q.unapplied_end();
@@ -461,12 +461,12 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    auto trx5 = unique_trx_meta_data();
    auto trx6 = unique_trx_meta_data();
 
-   q.add_incoming( trx1, false, [](auto){} );
-   q.add_incoming( trx2, false, [](auto){} );
-   q.add_incoming( trx3, false, [](auto){} );
-   q.add_incoming( trx4, false, [](auto){} );
-   q.add_incoming( trx5, false, [](auto){} );
-   q.add_incoming( trx6, false, [](auto){} );
+   q.add_incoming( trx1, false, false, [](auto){} );
+   q.add_incoming( trx2, false, false, [](auto){} );
+   q.add_incoming( trx3, false, false, [](auto){} );
+   q.add_incoming( trx4, false, false, [](auto){} );
+   q.add_incoming( trx5, false, false, [](auto){} );
+   q.add_incoming( trx6, false, false, [](auto){} );
 
    auto expected = q.size();
 
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    end = q.unapplied_end();
 
    while( itr != end ) {
-      q.add_incoming( itr->trx_meta, false, [](auto){} );
+      q.add_incoming( itr->trx_meta, false, false, [](auto){} );
       ++expected;
       BOOST_CHECK( q.incoming_size() == expected );
    }

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -468,10 +468,9 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    q.add_incoming( trx5, false, [](auto){} );
    q.add_incoming( trx6, false, [](auto){} );
 
-   auto count = q.incoming_size();
    auto expected = q.size();
 
-   BOOST_CHECK( count == expected );
+   BOOST_CHECK( q.incoming_size() == expected );
 
    auto itr = q.unapplied_begin();
    auto end = q.unapplied_end();
@@ -479,7 +478,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    while( itr != end ) {
       q.add_persisted( itr->trx_meta );
       --expected;
-      BOOST_CHECK( count == expected );
+      BOOST_CHECK( q.incoming_size() == expected );
    }
 
    itr = q.unapplied_begin();
@@ -488,7 +487,7 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
    while( itr != end ) {
       q.add_incoming( itr->trx_meta, false, [](auto){} );
       ++expected;
-      BOOST_CHECK( count == expected );
+      BOOST_CHECK( q.incoming_size() == expected );
    }
 
 } FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_test

--- a/unittests/unapplied_transaction_queue_tests.cpp
+++ b/unittests/unapplied_transaction_queue_tests.cpp
@@ -472,22 +472,26 @@ BOOST_AUTO_TEST_CASE( unapplied_transaction_queue_incoming_count ) try {
 
    BOOST_CHECK( q.incoming_size() == expected );
 
-   auto itr = q.unapplied_begin();
-   auto end = q.unapplied_end();
+   auto itr = q.begin();
+   auto end = q.end();
 
    while( itr != end ) {
       q.add_persisted( itr->trx_meta );
       --expected;
       BOOST_CHECK( q.incoming_size() == expected );
+      ++itr;
    }
 
-   itr = q.unapplied_begin();
-   end = q.unapplied_end();
+   BOOST_CHECK( q.incoming_size() == 0 );
+
+   itr = q.begin();
+   end = q.end();
 
    while( itr != end ) {
       q.add_incoming( itr->trx_meta, false, false, [](auto){} );
       ++expected;
       BOOST_CHECK( q.incoming_size() == expected );
+      ++itr;
    }
 
 } FC_LOG_AND_RETHROW() /// unapplied_transaction_queue_incoming_count


### PR DESCRIPTION
* Refactor incoming transaction handling to use `unapplied_transaction_queue`.
* Incoming transactions are now stored in the same queue as aborted, forked, and persistent transactions. This allows all expired and applied transactions to be handled together.
* `unapplied_transaction_queue` used to have a `process_mode` where it would not store aborted or forked-out transactions when in knew that the node would never produce a block. This was an optimization because there seemed to be no reason to cache aborted or forked-out transactions. Since the trx has been validated locally and will not be validated again, why keep it around? If you are producing you need to keep it so on a fork-switch the trxs are not lost. But there seemed to be no reason to keep them for speculative mode. However, the `unapplied_transaction_queue` is also used when validating a block to look up already validated and constructed `transaction_metadata`. Keeping the already validated trxs in the queue allows for faster validation of received blocks for all the transactions already received by the node.
* Before this change, when a speculative node's speculative block ran out of cpu or net, it would stop validating transactions until it received a block -- which would cause it to start a new speculative block after processing the received block. With this PR, a new speculative block is created anytime a block is exhausted during speculative transaction processing.
* Before this change speculative 12th blocks would use the `last-block-time-offset-us` which doesn't really make any sense since the block is only speculative and will not be broadcast on the network. With this PR, all speculative blocks use the `produce-time-offset-us` including the 12th block.

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/205

