### PR TITLE
Update to most recent version of the fc library.

### DIFF
--- a/programs/nodeos/logging.json
+++ b/programs/nodeos/logging.json
@@ -4,6 +4,7 @@
       "name": "stderr",
       "type": "console",
       "args": {
+        "format": "${timestamp} ${thread_name} ${context} ${file}:${line} ${method} ${level}]  ${message}",
         "stream": "std_error",
         "level_colors": [{
             "level": "debug",
@@ -43,7 +44,8 @@
       "type": "gelf",
       "args": {
         "endpoint": "10.10.10.10:12201",
-        "host": "host_name"
+        "host": "host_name",
+        "_network": "jungle"
       },
       "enabled": true
     }


### PR DESCRIPTION
Resolves #91.

From eosnetworkfoundation/mandel-fc#24:
The GELF appender now supports arbitrary fields and accompanying values in the logging.json configuration file, with some restrictions.  Per the GELF specification, user-defined field names must begin with an underscore and contain only letters, numbers, underscores, dashes, and dots.  The regular expression against which field names are checked is: `^_[\w\.\-]*$`.  Beyond the format check, there is also a list of reserved field names which are reserved by the specification or used by nodeos.  The list of reserved field names is:

- _id
- _timestamp_ns
- _log_id
- _line
- _file
- _method_name
- _thread_name
- _task_name

There is no enforced limit on the length of the field name nor the accompanying value.  However, by default, Graylog servers are configured to drop UDP GELF log messages which exceed 128 fragments.  The GELF appender limits its payload size to 512 bytes, so field names and values with a combined length of somewhat less than 65536 bytes may result in lost log messages.  The GELF protocol allows a maximum of 256 fragments, so a combined length exceeding 131072 bytes will always result in lost log messages.  There is also no enforced limit regarding the number of user-defined fields beyond those limits described above.

The Graylog server automatically elides the leading underscore in user-defined fields when displaying them in selectors and in the interface.

From eosnetworkfoundation/mandel-fc#25:
GELF appender handling of miniz output no longer required. The boost zlib filter generates the correct magic number. Also recent Graylog servers now support best speed as well as best compression if it's ever desirable to switch.