### PR TITLE
Update Bios Boot Tutorial

### DIFF
--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -67,7 +67,7 @@ The command line to launch the script, make sure you replace `EOSIO_OLD_CONTRACT
 $ cd ~
 $ git clone https://github.com/EOSIO/eos.git
 $ cd ./eos/tutorials/bios-boot-tutorial/
-$ python3 bios-boot-tutorial.py --cleos=" --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="EOSIO_CONTRACTS_DIRECTORY" -w -a
+$ python3 bios-boot-tutorial.py --cleos=cleos --nodeos=nodeos --keosd=keosd --contracts-dir="EOSIO_CONTRACTS_DIRECTORY" -w -a
 
 ```
 

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -67,9 +67,8 @@ The command line to launch the script, make sure you replace `EOSIO_OLD_CONTRACT
 $ cd ~
 $ git clone https://github.com/EOSIO/eos.git
 $ cd ./eos/tutorials/bios-boot-tutorial/
-$ python3 bios-boot-tutorial.py --cleos="cleos --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="EOSIO_CONTRACTS_DIRECTORY" --old-contracts-dir="EOSIO_OLD_CONTRACTS_DIRECTORY" -w -a
-```
+$ python3 bios-boot-tutorial.py --cleos=" --wallet-url http://127.0.0.1:6666 " --nodeos=nodeos --keosd=keosd --contracts-dir="EOSIO_CONTRACTS_DIRECTORY" -w -a
 
-6. At this point, when the script has finished running without error, you have a functional EOSIO based blockchain running locally with an latest version of `eosio.system` contract, 31 block producers out of which 21 active, `eosio` account resigned, 200k+ accounts with staked tokens, and votes allocated to each block producer. Enjoy exploring your freshly booted blockchain.
+```
 
 See [EOSIO Documentation Wiki: Tutorial - Bios Boot](https://github.com/EOSIO/eos/wiki/Tutorial-Bios-Boot-Sequence) for additional information.

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -95,14 +95,17 @@ def startNode(nodeIndex, account):
     dir = args.nodes_dir + ('%02d-' % nodeIndex) + account['name'] + '/'
     run('rm -rf ' + dir)
     run('mkdir -p ' + dir)
-    otherOpts = ''.join(list(map(lambda i: '    --p2p-peer-address localhost:' + str(19000 + i), range(nodeIndex))))
+    otherOpts = ''.join(list(map(lambda i: '    --p2p-peer-address localhost:' + str(9000 + i), range(nodeIndex))))
     if not nodeIndex: otherOpts += (
         '    --plugin eosio::trace_api_plugin --trace-no-abis'
     )
     cmd = (
         args.nodeos +
         '    --max-irreversible-block-age -1'
-        '    --max-transaction-time=1000'
+        # max-transaction-time must be less than block time
+        # (which is defined in .../chain/include/eosio/chain/config.hpp
+        # as block_interval_ms = 500)
+        '    --max-transaction-time=200'
         '    --contracts-console'
         '    --genesis-json ' + os.path.abspath(args.genesis) +
         '    --blocks-dir ' + os.path.abspath(dir) + '/blocks'
@@ -110,7 +113,7 @@ def startNode(nodeIndex, account):
         '    --data-dir ' + os.path.abspath(dir) +
         '    --chain-state-db-size-mb 1024'
         '    --http-server-address 127.0.0.1:' + str(8000 + nodeIndex) +
-        '    --p2p-listen-endpoint 127.0.0.1:' + str(19000 + nodeIndex) +
+        '    --p2p-listen-endpoint 127.0.0.1:' + str(9000 + nodeIndex) +
         '    --max-clients ' + str(maxClients) +
         '    --p2p-max-nodes-per-host ' + str(maxClients) +
         '    --enable-stale-production'

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -288,7 +288,7 @@ def stepStartWallet():
     importKeys()
 def stepStartBoot():
     startNode(0, {'name': 'eosio', 'pvt': args.private_key, 'pub': args.public_key})
-    sleep(1.5)
+    sleep(10.0)
 def stepInstallSystemContracts():
     run(args.cleos + 'set contract eosio.token ' + args.contracts_dir + '/eosio.token/')
     run(args.cleos + 'set contract eosio.msig ' + args.contracts_dir + '/eosio.msig/')

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -95,7 +95,7 @@ def startNode(nodeIndex, account):
     dir = args.nodes_dir + ('%02d-' % nodeIndex) + account['name'] + '/'
     run('rm -rf ' + dir)
     run('mkdir -p ' + dir)
-    otherOpts = ''.join(list(map(lambda i: '    --p2p-peer-address localhost:' + str(9000 + i), range(nodeIndex))))
+    otherOpts = ''.join(list(map(lambda i: '    --p2p-peer-address localhost:' + str(19000 + i), range(nodeIndex))))
     if not nodeIndex: otherOpts += (
         '    --plugin eosio::trace_api_plugin --trace-no-abis'
     )
@@ -110,7 +110,7 @@ def startNode(nodeIndex, account):
         '    --data-dir ' + os.path.abspath(dir) +
         '    --chain-state-db-size-mb 1024'
         '    --http-server-address 127.0.0.1:' + str(8000 + nodeIndex) +
-        '    --p2p-listen-endpoint 127.0.0.1:' + str(9000 + nodeIndex) +
+        '    --p2p-listen-endpoint 127.0.0.1:' + str(19000 + nodeIndex) +
         '    --max-clients ' + str(maxClients) +
         '    --p2p-max-nodes-per-host ' + str(maxClients) +
         '    --enable-stale-production'
@@ -314,11 +314,11 @@ def stepSetSystemContract():
 
     # activate remaining features
     # GET_SENDER
-    retry(args.cleos + 'push action eosio activate \'["f0af56d2c5a48d60a4a5b5c903edfb7db3a736a94ed589d0b797df33ff9d3e1d"]\' -p eosio')
+    retry(args.cleos + 'push action eosio activate \'["f0af56d2c5a48d60a4a5b5c903edfb7db3a736a94ed589d0b797df33ff9d3e1d"]\' -p eosio@active')
     # FORWARD_SETCODE
-    retry(args.cleos + 'push action eosio activate \'["2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25"]\' -p eosio')
+    retry(args.cleos + 'push action eosio activate \'["2652f5f96006294109b3dd0bbde63693f55324af452b799ee137a81a905eed25"]\' -p eosio@active')
     # ONLY_BILL_FIRST_AUTHORIZER
-    retry(args.cleos + 'push action eosio activate \'["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"]\' -p eosio')
+    retry(args.cleos + 'push action eosio activate \'["8ba52fe7a3956c5cd3a656a3174b931d3bb2abb45578befc59f283ecd816a405"]\' -p eosio@active')
     # RESTRICT_ACTION_TO_SELF
     retry(args.cleos + 'push action eosio activate \'["ad9e3d8f650687709fd68f4b90b41f7d825a365b02c23a636cef88ac2ac00c43"]\' -p eosio@active')
     # DISALLOW_EMPTY_PRODUCER_SCHEDULE

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -316,12 +316,10 @@ def stepSetSystemContract():
     sleep(3)
 
     # activate remaining features
-    # KV_DATABASE
-    retry(args.cleos + 'push action eosio activate \'["825ee6288fb1373eab1b5187ec2f04f6eacb39cb3a97f356a07c91622dd61d16"]\' -p eosio@active')
     # ACTION_RETURN_VALUE
     retry(args.cleos + 'push action eosio activate \'["c3a6138c5061cf291310887c0b5c71fcaffeab90d5deb50d3b9e687cead45071"]\' -p eosio@active')
-    # CONFIGURABLE_WASM_LIMITS
-    retry(args.cleos + 'push action eosio activate \'["bf61537fd21c61a60e542a5d66c3f6a78da0589336868307f94a82bccea84e88"]\' -p eosio@active')
+    # CONFIGURABLE_WASM_LIMITS2
+    retry(args.cleos + 'push action eosio activate \'["218036d611869ca2a3f66f96003ad652d80a8eda847a74af45e70c265fe5558c"]\' -p eosio@active')
     # BLOCKCHAIN_PARAMETERS
     retry(args.cleos + 'push action eosio activate \'["5443fcf88330c586bc0e5f3dee10e7f63c76c00249c87fe4fbf7f38c082006b4"]\' -p eosio@active')
     # GET_SENDER

--- a/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
+++ b/tutorials/bios-boot-tutorial/bios-boot-tutorial.py
@@ -316,6 +316,14 @@ def stepSetSystemContract():
     sleep(3)
 
     # activate remaining features
+    # KV_DATABASE
+    retry(args.cleos + 'push action eosio activate \'["825ee6288fb1373eab1b5187ec2f04f6eacb39cb3a97f356a07c91622dd61d16"]\' -p eosio@active')
+    # ACTION_RETURN_VALUE
+    retry(args.cleos + 'push action eosio activate \'["c3a6138c5061cf291310887c0b5c71fcaffeab90d5deb50d3b9e687cead45071"]\' -p eosio@active')
+    # CONFIGURABLE_WASM_LIMITS
+    retry(args.cleos + 'push action eosio activate \'["bf61537fd21c61a60e542a5d66c3f6a78da0589336868307f94a82bccea84e88"]\' -p eosio@active')
+    # BLOCKCHAIN_PARAMETERS
+    retry(args.cleos + 'push action eosio activate \'["5443fcf88330c586bc0e5f3dee10e7f63c76c00249c87fe4fbf7f38c082006b4"]\' -p eosio@active')
     # GET_SENDER
     retry(args.cleos + 'push action eosio activate \'["f0af56d2c5a48d60a4a5b5c903edfb7db3a736a94ed589d0b797df33ff9d3e1d"]\' -p eosio@active')
     # FORWARD_SETCODE

--- a/tutorials/bios-boot-tutorial/genesis.json
+++ b/tutorials/bios-boot-tutorial/genesis.json
@@ -11,7 +11,7 @@
     "context_free_discount_net_usage_den": 100,
     "max_block_cpu_usage": 100000,
     "target_block_cpu_usage_pct": 500,
-    "max_transaction_cpu_usage": 50000,
+    "max_transaction_cpu_usage": 90000,
     "min_transaction_cpu_usage": 100,
     "max_transaction_lifetime": 3600,
     "deferred_trx_expiration_window": 600,


### PR DESCRIPTION
### Updates the bios_boot_tutorial and fixes some problems with it

The boot tutorial previously relied on two versions of contracts, which was not ideal.  This PR's backports fix it to only need one version of contracts.

To implement these changes, a new contract, `boot` is needed, which will be added to  mandel-contracts.

Backports
https://github.com/EOSIO/eos/pull/9403
https://github.com/EOSIO/eos/pull/9581

Partially Backports
https://github.com/EOSIO/eos/pull/9732


Resolves: https://github.com/eosnetworkfoundation/mandel/issues/262