### PR TITLE
Bump up successful trx cache expiration to 60s in integration test.

### DIFF
--- a/tests/trx_finality_status_test.py
+++ b/tests/trx_finality_status_test.py
@@ -67,7 +67,7 @@ try:
     cluster.killall(allInstances=killAll)
     cluster.cleanup()
     Print("Stand up cluster")
-    successDuration = 25
+    successDuration = 60
     failure_duration = 40
     extraNodeosArgs=" --transaction-finality-status-max-storage-size-gb 1 " + \
                    f"--transaction-finality-status-success-duration-sec {successDuration} --transaction-finality-status-failure-duration-sec {failure_duration}"


### PR DESCRIPTION
The integration test `trx_finality_status_test` will sometimes fail if the timing of the submitted transaction falls too close to the beginning of a producer's series.  The extra time required to achieve finality in the test network could exceed the expiration time for the successful transaction status cache being used in the test.  Increase the test expiration to compensate.