### PR TITLE
resolve a few warnings including a chainbase one that generated lots of spam

### DIFF
--- a/libraries/chain/include/eosio/chain/name.hpp
+++ b/libraries/chain/include/eosio/chain/name.hpp
@@ -23,7 +23,7 @@ namespace eosio::chain {
 
    inline constexpr uint64_t string_to_uint64_t( std::string_view str ) {
       uint64_t n = 0;
-      int i = 0;
+      size_t i = 0;
       for ( ; i < str.size() && i < 12; ++i) {
          // NOTE: char_to_symbol() returns char type, and without this explicit
          // expansion to uint64 type, the compilation fails at the point of usage

--- a/plugins/resource_monitor_plugin/test/test_add_file_system.cpp
+++ b/plugins/resource_monitor_plugin/test/test_add_file_system.cpp
@@ -67,7 +67,7 @@ struct add_file_system_fixture {
 
       set_threshold(80, 75);
 
-      for (auto k = 0; k < capacity.size(); k++) {
+      for (size_t k = 0; k < capacity.size(); k++) {
          add_file_system("/test" + std::to_string(k));
       }
    }

--- a/plugins/resource_monitor_plugin/test/test_resmon_plugin.cpp
+++ b/plugins/resource_monitor_plugin/test/test_resmon_plugin.cpp
@@ -30,7 +30,7 @@ struct resmon_fixture {
       EOS_ASSERT(args.size() < 10, chain::plugin_exception, "number of arguments  (${size}) must be less than 10", ("size", args.size()));
 
       // argv[0] is program name, no need to fill in
-      for (auto i=0; i<args.size(); ++i) {
+      for (size_t i=0; i<args.size(); ++i) {
          argv[i+1] = args[i].c_str();
       }
 

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -10,7 +10,7 @@ namespace {
       static constexpr const char* _trace_trx_id_prefix = "trace_trx_id_";
       static constexpr const char* _trace_ext = ".log";
       static constexpr const char* _compressed_trace_ext = ".clog";
-      static constexpr uint _max_filename_size = std::char_traits<char>::length(_trace_index_prefix) + 10 + 1 + 10 + std::char_traits<char>::length(_compressed_trace_ext) + 1; // "trace_index_" + 10-digits + '-' + 10-digits + ".clog" + null-char
+      static constexpr int _max_filename_size = std::char_traits<char>::length(_trace_index_prefix) + 10 + 1 + 10 + std::char_traits<char>::length(_compressed_trace_ext) + 1; // "trace_index_" + 10-digits + '-' + 10-digits + ".clog" + null-char
 
       std::string make_filename(const char* slice_prefix, const char* slice_ext, uint32_t slice_number, uint32_t slice_width) {
          char filename[_max_filename_size] = {};

--- a/plugins/trace_api_plugin/test/test_compressed_file.cpp
+++ b/plugins/trace_api_plugin/test/test_compressed_file.cpp
@@ -116,7 +116,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(random_access_test, T, test_types, temp_file_fi
    BOOST_TEST(compressed_file::process(uncompressed_filename, compressed_filename, 512));
 
    // test that you can read all of the offsets from the compressed form by opening and seeking to them
-   for (int i = 0; i < data.size(); i++) {
+   for (size_t i = 0; i < data.size(); i++) {
       const auto& entry = data.at(i);
       auto compf = compressed_file(compressed_filename);
       compf.open();
@@ -166,7 +166,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(blob_access, T, test_types, temp_file_fixture) 
    BOOST_TEST(compressed_file::process(uncompressed_filename, compressed_filename, 512));
 
    // test that you can read all of the offsets from the compressed form through the end of the file
-   for (int i = 0; i < data.size(); i++) {
+   for (size_t i = 0; i < data.size(); i++) {
       auto actual_data = std::vector<T>(128);
       auto compf = compressed_file(compressed_filename);
       compf.open();
@@ -202,7 +202,7 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(blob_access_no_seek_points, T, test_types, temp
    BOOST_REQUIRE_EQUAL(expected_seek_point_count, actual_seek_point_count);
 
    // test that you can read all of the offsets from the compressed form through the end of the file
-   for (int i = 0; i < data.size(); i++) {
+   for (size_t i = 0; i < data.size(); i++) {
       auto actual_data = std::vector<T>(32);
       auto compf = compressed_file(compressed_filename);
       compf.open();

--- a/unittests/producer_schedule_tests.cpp
+++ b/unittests/producer_schedule_tests.cpp
@@ -630,7 +630,7 @@ BOOST_AUTO_TEST_CASE( large_authority_overflow_test ) try {
       const size_t pre_overflow_count = 65'537UL; // enough for weights of 0xFFFF to add up to 0xFFFFFFFF
       auth.keys.reserve(pre_overflow_count + 1);
 
-      for (int i = 0; i < pre_overflow_count; i++) {
+      for (size_t i = 0; i < pre_overflow_count; i++) {
          auto key_str = std::to_string(i) + "_bsk";
          auth.keys.emplace_back(key_weight{get_public_key("alice"_n, key_str), 0xFFFFU});
       }


### PR DESCRIPTION
Resolves a few warnings. Absolutely not exhaustive effort by any stretch, just trying to stave off the fire hose a little so I can see the trees in the forest.

The chainbase fix needs eosnetworkfoundation/mandel-chainbase#4 and its by far the biggest improvement to warnings (along with #322). The others in here are just low effort obvious `int` to `size_t` changes on for() loops, except for one that was `uint` to `int` when checking against the return of `snprintf()`. 

Also picked up eosnetworkfoundation/mandel-chainbase#3 since #277 continues to be wedged.