### PR TITLE
mark the deb & rpm packages as conflicting with 'eosio' package

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -19,6 +19,9 @@ set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/eosnetworkfoundation/mandel")
 set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
 
+set(CPACK_DEBIAN_PACKAGE_CONFLICTS "eosio")
+set(CPACK_RPM_PACKAGE_CONFLICTS "eosio")
+
 #turn some knobs to try and make package paths cooperate with GNUInstallDirs a little better
 set(CPACK_SET_DESTDIR ON)
 set(CPACK_PACKAGE_RELOCATABLE OFF)


### PR DESCRIPTION
Packages are currently being named "mandel"; these won't upgrade old pre-ENF "eosio" packages, so mark them as a conflict to prevent installation.