### PR TITLE
disable resmon shutdown for plugin_http_api_test

### DIFF
--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -57,7 +57,7 @@ class PluginHttpTest(unittest.TestCase):
                                                                                    "eosio::db_size_api_plugin")
         nodeos_flags = (" --data-dir=%s --trace-dir=%s --trace-no-abis --access-control-allow-origin=%s "
                         "--contracts-console --http-validate-host=%s --verbose-http-errors "
-                        "--p2p-peer-address localhost:9011 ") % (self.data_dir, self.data_dir, "\'*\'", "false")
+                        "--p2p-peer-address localhost:9011 --resource-monitor-not-shutdown-on-threshold-exceeded ") % (self.data_dir, self.data_dir, "\'*\'", "false")
         start_nodeos_cmd = ("%s -e -p eosio %s %s ") % (Utils.EosServerPath, nodeos_plugins, nodeos_flags)
         self.nodeos.launchCmd(start_nodeos_cmd, self.node_id)
         time.sleep(self.sleep_s)


### PR DESCRIPTION
### Prevent the Plugin HTTP API Test from shutting down when space limitations are approached for the resource monitor plugin
Resolves #334