### PR TITLE
trace_api_plugin eosio/eos 2.1 compatibility

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/chain_extraction.hpp
@@ -85,7 +85,7 @@ private:
          using transaction_trace_t = transaction_trace_v3;
          auto bt = create_block_trace( block_state );
 
-         std::vector<transaction_trace_t>& traces = std::get<std::vector<transaction_trace_t>>(bt.transactions);
+         std::vector<transaction_trace_t> traces;
          traces.reserve( block_state->block->transactions.size() + 1 );
          block_trxs_entry tt;
          tt.ids.reserve(block_state->block->transactions.size() + 1);
@@ -104,6 +104,7 @@ private:
             }
             tt.ids.emplace_back(id);
          }
+         bt.transactions = std::move( traces );
          clear_caches();
 
          // tt entry acts as a placeholder in a trx id slice if this block has no transaction

--- a/plugins/trace_api_plugin/include/eosio/trace_api/trace.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/trace.hpp
@@ -82,7 +82,7 @@ namespace eosio { namespace trace_api {
      chain::checksum256_type            transaction_mroot = {};
      chain::checksum256_type            action_mroot = {};
      uint32_t                           schedule_version = {};
-     std::variant<std::vector<transaction_trace_v3>, std::vector<transaction_trace_v2>>  transactions = {};
+     std::variant<std::vector<transaction_trace_v2>, std::vector<transaction_trace_v3>>  transactions = {};
   };
 
   struct cache_trace {


### PR DESCRIPTION
Unlike `eosio/eos 2.2`, correctly handle backward compatibility with `eosio/eos 2.1`.

Resolves #337 