### PR TITLE
Modified parameter to compute_transaction

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2632,13 +2632,13 @@ read_only::get_required_keys_result read_only::get_required_keys( const get_requ
    result.required_keys = required_keys_set;
    return result;
 }
-void read_only::compute_transaction(const fc::variant_object& params, next_function<compute_transaction_results> next) const {
+void read_only::compute_transaction(const compute_transaction_params& params, next_function<compute_transaction_results> next) const {
 
     try {
         auto pretty_input = std::make_shared<packed_transaction>();
         auto resolver = make_resolver(db, abi_serializer::create_yield_function( abi_serializer_max_time ));
         try {
-            abi_serializer::from_variant(params, *pretty_input, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
+            abi_serializer::from_variant(params.transaction, *pretty_input, resolver, abi_serializer::create_yield_function( abi_serializer_max_time ));
         } EOS_RETHROW_EXCEPTIONS(chain::packed_transaction_type_exception, "Invalid packed transaction")
 
         app().get_method<incoming::methods::transaction_async>()(pretty_input, false, true, true,

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -443,8 +443,12 @@ public:
        chain::transaction_id_type  transaction_id;
        fc::variant                 processed;
     };
-   using compute_transaction_params = fc::variant_object;
-   void compute_transaction(const fc::variant_object& params, chain::plugin_interface::next_function<compute_transaction_results> next ) const;
+
+   struct compute_transaction_params {
+      fc::variant transaction;
+   };
+
+   void compute_transaction(const compute_transaction_params& params, chain::plugin_interface::next_function<compute_transaction_results> next ) const;
 
    static void copy_inline_row(const chain::key_value_object& obj, vector<char>& data) {
       data.resize( obj.value.size() );
@@ -875,5 +879,6 @@ FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_params, (code)(action)
 FC_REFLECT( eosio::chain_apis::read_only::abi_bin_to_json_result, (args) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction)(available_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
+FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_params, (transaction))
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_results, (transaction_id)(processed) )
 

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -378,7 +378,9 @@ fc::variant push_transaction( signed_transaction& trx, packed_transaction::compr
             EOSC_ASSERT( !tx_retry_lib, "ERROR: --retry-irreversible can not be used with --read-only" );
             EOSC_ASSERT( !tx_retry_num_blocks, "ERROR: --retry-num-blocks can not be used with --read-only" );
             try {
-               return call( compute_txn_func, packed_transaction(trx, compression));
+               auto compute_txn_arg = fc::mutable_variant_object ("transaction",
+                                                                  packed_transaction(trx,compression));
+               return call( compute_txn_func, compute_txn_arg);
             } catch( chain::missing_chain_api_plugin_exception& ) {
                std::cerr << "New RPC compute_transaction may not be supported. Submit to a different node." << std::endl;
                throw;


### PR DESCRIPTION
Changed the parameter to the compute_transaction endpoint to be a struct in order to make it more extensible in the future.

Resolves https://github.com/eosnetworkfoundation/mandel/issues/335