### PR TITLE
fix path for eosio.token.abi in tests

### DIFF
--- a/tests/launcher_test.py
+++ b/tests/launcher_test.py
@@ -54,7 +54,7 @@ try:
         cluster.cleanup()
         Print("Stand up cluster")
         pnodes=4
-        abs_path = os.path.abspath(os.getcwd() + '/../unittests/contracts/eosio.token/eosio.token.abi')
+        abs_path = os.path.abspath(os.getcwd() + '/unittests/contracts/eosio.token/eosio.token.abi')
         traceNodeosArgs=" --plugin eosio::trace_api_plugin --trace-rpc-abi eosio.token=" + abs_path
         if cluster.launch(pnodes=pnodes, totalNodes=pnodes, extraNodeosArgs=traceNodeosArgs) is False:
             cmdError("launcher")

--- a/tests/nodeos_run_remote_test.py
+++ b/tests/nodeos_run_remote_test.py
@@ -46,7 +46,7 @@ try:
            (pnodes, total_nodes-pnodes, topo, delay))
     Print("Stand up cluster")
 
-    abs_path = os.path.abspath(os.getcwd() + '/../unittests/contracts/eosio.token/eosio.token.abi')
+    abs_path = os.path.abspath(os.getcwd() + '/unittests/contracts/eosio.token/eosio.token.abi')
     traceNodeosArgs = " --plugin eosio::trace_api_plugin --trace-rpc-abi eosio.token=" + abs_path
     if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, prodCount=prodCount, topo=topo, delay=delay, onlyBios=onlyBios, extraNodeosArgs=traceNodeosArgs) is False:
         errorExit("Failed to stand up eos cluster.")

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -68,7 +68,7 @@ try:
         cluster.cleanup()
         Print("Stand up cluster")
 
-        abs_path = os.path.abspath(os.getcwd() + '/../unittests/contracts/eosio.token/eosio.token.abi')
+        abs_path = os.path.abspath(os.getcwd() + '/unittests/contracts/eosio.token/eosio.token.abi')
         traceNodeosArgs=" --http-max-response-time-ms 990000 --plugin eosio::trace_api_plugin --trace-rpc-abi eosio.token=" + abs_path
         if cluster.launch(prodCount=prodCount, onlyBios=onlyBios, dontBootstrap=dontBootstrap, extraNodeosArgs=traceNodeosArgs) is False:
             cmdError("launcher")

--- a/tests/trace_plugin_test.py
+++ b/tests/trace_plugin_test.py
@@ -31,7 +31,7 @@ class TraceApiPluginTest(unittest.TestCase):
     # start keosd and nodeos
     def startEnv(self) :
         account_names = ["alice", "bob", "charlie"]
-        abs_path = os.path.abspath(os.getcwd() + '/../unittests/contracts/eosio.token/eosio.token.abi')
+        abs_path = os.path.abspath(os.getcwd() + '/unittests/contracts/eosio.token/eosio.token.abi')
         traceNodeosArgs = " --plugin eosio::trace_api_plugin --trace-rpc-abi eosio.token=" + abs_path
         self.cluster.launch(totalNodes=1, extraNodeosArgs=traceNodeosArgs)
         self.walletMgr.launch()


### PR DESCRIPTION
Tests are run with the working directory set to the build directory (`CMAKE_BUILD_DIR`). These four tests were erroneously looking for eosio.token.abi in, effectively, `CMAKE_BUILD_DIR/../unittests/contracts/eosio.token/eosio.token.abi`. That is only valid when the build directory is a subdirectory of the source directory; not the case for my environment, for example.

Fix these tests to look in `CMAKE_BUILD_DIR/unittests/contracts/eosio.token/eosio.token.abi` instead.