### PR TITLE
add missing BOOST_AUTO_TEST_SUITE_END() to chain_plugin_tests.cpp

### DIFF
--- a/tests/chain_plugin_tests.cpp
+++ b/tests/chain_plugin_tests.cpp
@@ -205,4 +205,5 @@ BOOST_FIXTURE_TEST_CASE( get_account, TESTER ) try {
       }
    }
 } FC_LOG_AND_RETHROW() /// get_account
-}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
chain_plugin_tests.cpp is missing this, which causes the test tree to get a little messed up.

Before:
```
chain_plugin_tests*
    get_block_with_invalid_abi*
    get_account*
    get_producers_tests*
        get_producers*
        get_producers_from_table*
    get_table_tests*
        get_scope_test*
        get_table_test*
        get_table_by_seckey_test*
        get_table_next_key_test*
    wallet_tests*
        wallet_test*
        wallet_manager_test*
        wallet_manager_create_test*
```
After
```
chain_plugin_tests*
    get_block_with_invalid_abi*
    get_account*
get_producers_tests*
    get_producers*
    get_producers_from_table*
get_table_tests*
    get_scope_test*
    get_table_test*
    get_table_by_seckey_test*
    get_table_next_key_test*
wallet_tests*
    wallet_test*
    wallet_manager_test*
    wallet_manager_create_test*
```