### PR TITLE
change which() for public_key & signature to return size_t silencing some warnings

### DIFF
--- a/libraries/chain/webassembly/crypto.cpp
+++ b/libraries/chain/webassembly/crypto.cpp
@@ -16,9 +16,9 @@ namespace eosio { namespace chain { namespace webassembly {
       fc::raw::unpack( ds, s );
       fc::raw::unpack( pubds, p );
 
-      EOS_ASSERT(static_cast<unsigned>(s.which()) < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_signature_type,
+      EOS_ASSERT(s.which() < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_signature_type,
         "Unactivated signature type used during assert_recover_key");
-      EOS_ASSERT(static_cast<unsigned>(p.which()) < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_key_type,
+      EOS_ASSERT(p.which() < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_key_type,
         "Unactivated key type used when creating assert_recover_key");
 
       if(context.control.is_producing_block())
@@ -36,7 +36,7 @@ namespace eosio { namespace chain { namespace webassembly {
       datastream<const char*> ds( sig.data(), sig.size() );
       fc::raw::unpack(ds, s);
 
-      EOS_ASSERT(static_cast<unsigned>(s.which()) < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_signature_type,
+      EOS_ASSERT(s.which() < context.db.get<protocol_state_object>().num_supported_key_types, unactivated_signature_type,
                  "Unactivated signature type used during recover_key");
 
       if(context.control.is_producing_block())
@@ -47,7 +47,7 @@ namespace eosio { namespace chain { namespace webassembly {
       auto recovered = fc::crypto::public_key(s, *digest, false);
 
       // the key types newer than the first 2 may be varible in length
-      if (static_cast<unsigned>(s.which()) >= config::genesis_num_supported_key_types ) {
+      if (s.which() >= config::genesis_num_supported_key_types ) {
          EOS_ASSERT(pub.size() >= 33, wasm_execution_error,
                     "destination buffer must at least be able to hold an ECC public key");
          auto packed_pubkey = fc::raw::pack(recovered);

--- a/libraries/chain/webassembly/privileged.cpp
+++ b/libraries/chain/webassembly/privileged.cpp
@@ -44,7 +44,7 @@ namespace eosio { namespace chain { namespace webassembly {
                   "Producer schedule cannot be empty"
       );
 
-      const int64_t num_supported_key_types = context.db.get<protocol_state_object>().num_supported_key_types;
+      const size_t num_supported_key_types = context.db.get<protocol_state_object>().num_supported_key_types;
 
       // check that producers are unique
       std::set<account_name> unique_producers;


### PR DESCRIPTION
change `fc::public_key::which()` & `fc::signature::which()` to return a `size_t` which is what the underlying storage (`std::variant`) is going to return anyways. No reason to convert to `int` on return. Silences some warnings.

Back out some preexisting casts to `unsigned` that were likely squelching warnings in the past that are no longer needed.

Needs eosnetworkfoundation/mandel-fc#33 and apparently eosnetworkfoundation/mandel-fc#32 & eosnetworkfoundation/mandel-fc#30 are coming along for the ride.