### PR TITLE
Suppress "End of file" error reporting in SHiP

### DIFF
--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -288,7 +288,7 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       void on_fail(boost::system::error_code ec, const char* what) {
          try {
-            if (ec.message() == "End of file") {
+            if (ec == boost::asio::error::eof) {
                dlog("${w}: ${m}", ("w", what)("m", ec.message()));
             } else {
                elog("${w}: ${m}", ("w", what)("m", ec.message()));

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -288,7 +288,11 @@ struct state_history_plugin_impl : std::enable_shared_from_this<state_history_pl
 
       void on_fail(boost::system::error_code ec, const char* what) {
          try {
-            elog("${w}: ${m}", ("w", what)("m", ec.message()));
+            if (ec.message() == "End of file") {
+               dlog("${w}: ${m}", ("w", what)("m", ec.message()));
+            } else {
+               elog("${w}: ${m}", ("w", what)("m", ec.message()));
+            }
             close();
          } catch (...) {
             elog("uncaught exception on close");


### PR DESCRIPTION
### SHiP is incorrectly reporting an "End of file" error from async_read, which in actuality isn't an error
As such, this error is now being suppressed. It will still be logged, but not as an error. This "End of file" came through when a connection (socket) was being closed. 