### PR TITLE
Print out warning only if platform is not Ubuntu and make build directory relative to where build starts

### DIFF
--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -2,7 +2,7 @@
 
 echo "Mandel Pinned Build"
 
-if [[ $NAME != "Ubuntu" ]]
+if [[ $(uname -v) != *Ubuntu* ]]
    then
       echo "Currently only supporting Ubuntu based builds. Proceed at your own risk."
 fi
@@ -112,6 +112,8 @@ pushdir ${DEP_DIR}
 install_clang ${DEP_DIR}/clang-${CLANG_VER}
 install_llvm ${DEP_DIR}/llvm-${LLVM_VER}
 install_boost ${DEP_DIR}/boost_${BOOST_VER//\./_}
+
+popdir ${SCRIPT_DIR}
 
 pushdir ${MANDEL_DIR}
 


### PR DESCRIPTION
https://github.com/eosnetworkfoundation/mandel/issues/363 reports `pinned_build.sh` always prints "Currently only supporting Ubuntu based builds. Proceed at your own risk.", even on Ubuntu platform.

https://github.com/eosnetworkfoundation/mandel/issues/364 reports the build directory is made relative to the dependency directory; it should have been relative to the directory where the script starts.

This PR fixes those two issues.