### PR TITLE
plugin_http_api_test - fix timing issue

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1394,7 +1394,7 @@ class Node(object):
             timeout = 6 + blocksToAdvance / 2
         def isHeadAdvancing():
             return self.getHeadBlockNum() >= currentHead + blocksToAdvance
-        return Utils.waitForTruth(isHeadAdvancing, timeout)
+        return Utils.waitForBool(isHeadAdvancing, timeout)
 
     def waitForLibToAdvance(self, timeout=30):
         currentLib = self.getIrreversibleBlockNum()

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1388,11 +1388,13 @@ class Node(object):
                     break
         return protocolFeatureDigestDict
 
-    def waitForHeadToAdvance(self, timeout=6):
+    def waitForHeadToAdvance(self, blocksToAdvance=1, timeout=None):
         currentHead = self.getHeadBlockNum()
+        if timeout is None:
+            timeout = 6 + blocksToAdvance / 2
         def isHeadAdvancing():
-            return self.getHeadBlockNum() > currentHead
-        return Utils.waitForBool(isHeadAdvancing, timeout)
+            return self.getHeadBlockNum() >= currentHead + blocksToAdvance
+        return Utils.waitForTruth(isHeadAdvancing, timeout)
 
     def waitForLibToAdvance(self, timeout=30):
         currentLib = self.getIrreversibleBlockNum()
@@ -1422,7 +1424,7 @@ class Node(object):
         self.scheduleProtocolFeatureActivations([preactivateFeatureDigest])
 
         # Wait for the next block to be produced so the scheduled protocol feature is activated
-        assert self.waitForHeadToAdvance(), "ERROR: TIMEOUT WAITING FOR PREACTIVATE"
+        assert self.waitForHeadToAdvance(blocksToAdvance=2), print("ERROR: TIMEOUT WAITING FOR PREACTIVATE")
 
     # Return an array of feature digests to be preactivated in a correct order respecting dependencies
     # Require producer_api_plugin
@@ -1449,7 +1451,7 @@ class Node(object):
             if trans is None or not trans[0]:
                 Utils.Print("ERROR: Failed to preactive digest {}".format(digest))
                 return None
-        self.waitForHeadToAdvance()
+        self.waitForHeadToAdvance(blocksToAdvance=2)
 
     # Require PREACTIVATE_FEATURE to be activated and require eosio.bios with preactivate_feature
     def preactivateAllBuiltinProtocolFeature(self):


### PR DESCRIPTION
Backports: https://github.com/EOSIO/eos/pull/10103

From https://github.com/EOSIO/eos/pull/10103:
Consider the following scenario:

The overall plan is to activate a total of 17 protocol features.

The first 5 protocol features are activated and added to some block (let's say block 18).
While still on block 18, the remaining 12 protocol features transactions are executed (and they will be added to block 19, and the features will be active on block 20), and the check for waitForHeadToAdvance also gets executed while we are still on this block 18.
When the chain advances to block 19, the waitForHeadToAdvance method returns, but only 5 protocol features are really activated, leading to a state on the chain where we return from this method, but the protocol features are in realityy still not activated, leading to some failure on some further asserts that assume that this is the case after we return from preactivateAllBuiltinProtocolFeature.
Solution:

To handle this edge case, we wait 2 blocks, instead of 1, to make sure that all the transactions for protocol feature activations are executed and activated, also modify the timeout of the check for head advance to be proportional to the number of blocks we want to wait to advance.

Resoves #386 