### PR TITLE
remove ccache from deps listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ To speed up development and reduce support overhead, we're initially only suppor
 apt-get update && apt-get install   \
         binaryen                    \
         build-essential             \
-        ccache                      \
         cmake                       \
         curl                        \
         git                         \


### PR DESCRIPTION
I'm 100% certain more deps are listed here than strictly required. But the ccache one worries me a little since libff does pick it up and the force usage of it automatically. Would like to remove it from this list users are likely to copy/paste