### PR TITLE
Boost.Test to report the last checkpoint location

### DIFF
--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -517,8 +517,8 @@ namespace eosio { namespace testing {
          try {
             if( num_blocks_to_producer_before_shutdown > 0 )
                produce_blocks( num_blocks_to_producer_before_shutdown );
-            if (!skip_validate)
-               BOOST_REQUIRE_EQUAL( validate(), true );
+            if (!skip_validate && std::uncaught_exceptions() == 0)
+               BOOST_CHECK_EQUAL( validate(), true );
          } catch( const fc::exception& e ) {
             wdump((e.to_detail_string()));
          }

--- a/unittests/main.cpp
+++ b/unittests/main.cpp
@@ -12,7 +12,7 @@
 
 void translate_fc_exception(const fc::exception &e) {
    std::cerr << "\033[33m" <<  e.to_detail_string() << "\033[0m" << std::endl;
-   BOOST_TEST_FAIL("Caught Unexpected Exception");
+   throw std::runtime_error("Caught Unexpected Exception");
 }
 
 static bool is_verbose = false;


### PR DESCRIPTION
> Allow Boost.Test to report the last checkpoint location when an exception is thrown.

backports https://github.com/EOSIO/eos/pull/8677

Resolves https://github.com/eosnetworkfoundation/mandel/issues/380