### PR TITLE
[3.2] log integrity hash on start/stop with integrity-hash-on-start & integrity-hash-on-stop options

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -247,7 +247,7 @@ struct controller_impl {
    named_thread_pool               thread_pool;
    platform_timer                  timer;
    deep_mind_handler*              deep_mind_logger = nullptr;
-   bool                            okay_to_print_integrity_hash_on_exit = false;
+   bool                            okay_to_print_integrity_hash_on_stop = false;
 #if defined(EOSIO_EOS_VM_RUNTIME_ENABLED) || defined(EOSIO_EOS_VM_JIT_RUNTIME_ENABLED)
    vm::wasm_allocator               wasm_alloc;
 #endif

--- a/libraries/chain/include/eosio/chain/controller.hpp
+++ b/libraries/chain/include/eosio/chain/controller.hpp
@@ -85,6 +85,8 @@ namespace eosio { namespace chain {
             uint32_t                 maximum_variable_signature_length = chain::config::default_max_variable_signature_length;
             bool                     disable_all_subjective_mitigations = false; //< for developer & testing purposes, can be configured using `disable-all-subjective-mitigations` when `EOSIO_DEVELOPER` build option is provided
             uint32_t                 terminate_at_block     = 0; //< primarily for testing purposes
+            bool                     integrity_hash_on_start= false;
+            bool                     integrity_hash_on_stop = false;
 
             wasm_interface::vm_type  wasm_runtime = chain::config::default_wasm_runtime;
             eosvmoc::config          eosvmoc_config;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -373,6 +373,8 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("terminate-at-block", bpo::value<uint32_t>()->default_value(0),
           "terminate after reaching this block number (if set to a non-zero number)")
          ("snapshot", bpo::value<bfs::path>(), "File to read Snapshot State from")
+         ("integrity-hash-on-start", bpo::bool_switch(), "Log the state integrity hash on startup")
+         ("integrity-hash-on-stop", bpo::bool_switch(), "Log the state integrity hash on shutdown")
          ;
 
 }
@@ -1078,6 +1080,9 @@ void chain_plugin::plugin_initialize(const variables_map& options) {
 #endif
 
       my->account_queries_enabled = options.at("enable-account-queries").as<bool>();
+
+      my->chain_config->integrity_hash_on_start = options.at("integrity-hash-on-start").as<bool>();
+      my->chain_config->integrity_hash_on_stop = options.at("integrity-hash-on-stop").as<bool>();
 
       my->chain.emplace( *my->chain_config, std::move(pfs), *chain_id );
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -331,7 +331,9 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("transaction-finality-status-success-duration-sec", bpo::value<uint64_t>()->default_value(config::default_max_transaction_finality_status_success_duration_sec),
           "Duration (in seconds) a successful transaction's Finality Status will remain available from being first identified.")
          ("transaction-finality-status-failure-duration-sec", bpo::value<uint64_t>()->default_value(config::default_max_transaction_finality_status_failure_duration_sec),
-          "Duration (in seconds) a failed transaction's Finality Status will remain available from being first identified.");
+          "Duration (in seconds) a failed transaction's Finality Status will remain available from being first identified.")
+         ("integrity-hash-on-start", bpo::bool_switch(), "Log the state integrity hash on startup")
+         ("integrity-hash-on-stop", bpo::bool_switch(), "Log the state integrity hash on shutdown");
 
    if(cfile::supports_hole_punching())
       cfg.add_options()("block-log-retain-blocks", bpo::value<uint32_t>(), "if set, periodically prune the block log to store only configured number of most recent blocks");
@@ -373,8 +375,6 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
          ("terminate-at-block", bpo::value<uint32_t>()->default_value(0),
           "terminate after reaching this block number (if set to a non-zero number)")
          ("snapshot", bpo::value<bfs::path>(), "File to read Snapshot State from")
-         ("integrity-hash-on-start", bpo::bool_switch(), "Log the state integrity hash on startup")
-         ("integrity-hash-on-stop", bpo::bool_switch(), "Log the state integrity hash on shutdown")
          ;
 
 }


### PR DESCRIPTION
Unequivocally logging the integrity hash after loading a snapshot increases start up time from a snapshot by nearly 33%. Most users probably don't even notice the log; let's not always do that.

Log integrity hash on start up and shut down via new `integrity-hash-on-start` & `integrity-hash-on-stop` options.