### PR TITLE
net_plugin delay connecting to peers [main]

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -1388,10 +1388,12 @@ class Node(object):
                     break
         return protocolFeatureDigestDict
 
-    def waitForHeadToAdvance(self, timeout=6):
+    def waitForHeadToAdvance(self, blocksToAdvance=1, timeout=None):
         currentHead = self.getHeadBlockNum()
+        if timeout is None:
+            timeout = 6 + blocksToAdvance / 2
         def isHeadAdvancing():
-            return self.getHeadBlockNum() > currentHead
+            return self.getHeadBlockNum() >= currentHead + blocksToAdvance
         return Utils.waitForBool(isHeadAdvancing, timeout)
 
     def waitForLibToAdvance(self, timeout=30):
@@ -1422,7 +1424,7 @@ class Node(object):
         self.scheduleProtocolFeatureActivations([preactivateFeatureDigest])
 
         # Wait for the next block to be produced so the scheduled protocol feature is activated
-        assert self.waitForHeadToAdvance(), "ERROR: TIMEOUT WAITING FOR PREACTIVATE"
+        assert self.waitForHeadToAdvance(blocksToAdvance=2), print("ERROR: TIMEOUT WAITING FOR PREACTIVATE")
 
     # Return an array of feature digests to be preactivated in a correct order respecting dependencies
     # Require producer_api_plugin
@@ -1449,7 +1451,7 @@ class Node(object):
             if trans is None or not trans[0]:
                 Utils.Print("ERROR: Failed to preactive digest {}".format(digest))
                 return None
-        self.waitForHeadToAdvance()
+        self.waitForHeadToAdvance(blocksToAdvance=2)
 
     # Require PREACTIVATE_FEATURE to be activated and require eosio.bios with preactivate_feature
     def preactivateAllBuiltinProtocolFeature(self):


### PR DESCRIPTION
* Delay `net_plugin` connecting to its peers until after all plugins have started. This allows replay to finish first before attempting to connect.
* Close connection on sync timeout, with immediate re-connect, since something is likely wrong with the connection.

Merges #381 to main.

