### PR TITLE
Make /v1/chain/get_accounts_by_authorizers multi-threaded

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -141,7 +141,7 @@ void chain_api_plugin::plugin_startup() {
    }
 
    if (chain.transaction_finality_status_enabled()) {
-      _http_plugin.add_async_api({
+      _http_plugin.add_api({
          CHAIN_RO_CALL_WITH_400(get_transaction_status, 200, http_params_types::params_required),
       });
    }

--- a/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
+++ b/plugins/http_plugin/include/eosio/http_plugin/http_plugin.hpp
@@ -87,7 +87,7 @@ namespace eosio {
         void add_async_handler(const string& url, const url_handler& handler);
         void add_async_api(const api_description& api) {
            for (const auto& call : api)
-              add_handler(call.first, call.second);
+              add_async_handler(call.first, call.second);
         }
 
         // standard exception handling for api handlers


### PR DESCRIPTION
`/v1/chain/get_accounts_by_authorizers` was designed to support multi-threaded calls. However, it was not hooked up to the http thread handling code, but instead was hooked up to the normal app thread handling.

Fixed `http_plugin.hpp add_async_api` to actually call `add_async_handler`.
Added a multi-threaded test to verify `get_accounts_by_authorizers` works from different thread.

Moved `/v1/chain/get_transaction_status` from `add_async_api` to `add_api` since it does not support multi-threaded reads.

Resolves #204 