### PR TITLE
before enabling Secure Enclave wallet require code be signed with a certificate

### DIFF
--- a/plugins/wallet_plugin/se_wallet.cpp
+++ b/plugins/wallet_plugin/se_wallet.cpp
@@ -269,7 +269,11 @@ static void check_signed() {
    CFNumberRef pidnumber = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &pid);
    CFDictionaryRef piddict = CFDictionaryCreate(kCFAllocatorDefault, (const void**)&kSecGuestAttributePid, (const void**)&pidnumber, 1, nullptr, nullptr);
    if(!SecCodeCopyGuestWithAttributes(nullptr, piddict, kSecCSDefaultFlags, &code)) {
-      is_valid = SecCodeCheckValidity(code, kSecCSDefaultFlags, 0);
+      SecRequirementRef sec_requirement = nullptr;
+      if(!SecRequirementCreateWithString(CFSTR("anchor trusted"), kSecCSDefaultFlags, &sec_requirement)) {
+         is_valid = SecCodeCheckValidity(code, kSecCSDefaultFlags, sec_requirement);
+         CFRelease(sec_requirement);
+      }
       CFRelease(code);
    }
    CFRelease(piddict);

--- a/plugins/wallet_plugin/se_wallet.cpp
+++ b/plugins/wallet_plugin/se_wallet.cpp
@@ -313,6 +313,10 @@ se_wallet::se_wallet() : my(new detail::se_wallet_impl()) {
          my->populate_existing_keys();
          return;
       }
+      if(sscanf(model, "MacPro%u", &major) == 1 && major >= 7) {
+         my->populate_existing_keys();
+         return;
+      }
       if(sscanf(model, "Mac%u", &major) == 1 && major >= 13) { //Mac Studio
          my->populate_existing_keys();
          return;

--- a/plugins/wallet_plugin/se_wallet.cpp
+++ b/plugins/wallet_plugin/se_wallet.cpp
@@ -309,6 +309,10 @@ se_wallet::se_wallet() : my(new detail::se_wallet_impl()) {
          my->populate_existing_keys();
          return;
       }
+      if(sscanf(model, "Mac%u", &major) == 1 && major >= 13) { //Mac Studio
+         my->populate_existing_keys();
+         return;
+      }
    }
 
    EOS_THROW(secure_enclave_exception, "Secure Enclave not supported on this hardware");


### PR DESCRIPTION
On ARM macOS, every application must be signed. And Apple really means that: when you `cc hello.c -o hello` the linker adds an "ad-hoc" code signature to the output (this is not to be confused with Ad Hoc Distribution Profiles; something else entirely in the Apple code signing space).

When the Secure Enclave wallet code starts up (which is included in every macOS build), it performs a simple check to see if the executable is signed before granting access to the Secure Enclave wallet (an application needs to be signed to have proper entitlements to access the Secure Enclave). Well, this ad-hoc code signature is indeed _a_ code signature so this check passes and shows the Secure Enclave wallet in keosd even when you can't use it (because an ad-hoc signature isn't going to have the proper entitlements).

Extend the check a little further to check that the executable isn't just signed but that the code signature is made with a valid certificate. [Apple states](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/RequirementLang/RequirementLang.html)

> If the code was signed using an ad-hoc signature, there are no certificates at all **and all certificate constraints evaluate to false**. An ad-hoc signature is created by signing with the pseudo-identity - (a dash). An ad-hoc signature does not use or record a cryptographic identity, and thus identifies exactly and only the one program being signed.

(emphasis mine), and indeed in my testing this simple change worked as expected: ad-hoc signed applications will not pass this new check but even a self signed developer application (the "lowest tier" of signed applications that can get Secure Enclave access) passed this check.

Also add Mac Studio ids to the whitelist since I'm still unaware how to query for Secure Enclave support. (I did no recent research though)

Of course, our Secure Enclave support feels more like a tech demo as a signed keosd has never been shipped by B1 nor ENF, and signing it yourself requires considerable knowledge. But it's not really getting in the way at the moment so might as well leave it in for now.