### PR TITLE
Remove confusing error message - main

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -269,7 +269,6 @@ fc::variant call( const std::string& url,
          exec_name = key_store_executable_name;
       }
       std::cerr << localized( "Failed http request to ${n} at ${u}; is ${n} running?\n"
-                              "  Common issue is message size too large. Check the log of ${n}.\n"
                               "  Error: ${e}",
                               ("n", exec_name)("u", url)("e", e.what()) ) << std::endl;
       throw connection_exception(fc::log_messages{FC_LOG_MESSAGE(error, e.what())});


### PR DESCRIPTION
Example error now:

```
./cleos -u http://127.0.0.1:8882 get info
Failed http request to nodeos at http://127.0.0.1:8882; is nodeos running?
  Error: connect: Connection refused
```

Merges #480 into main.