### PR TITLE
Print out warning only if the platorm is not Ubuntu and make build directory relative to where the build starts - 3.1

### DIFF
--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -2,9 +2,18 @@
 
 echo "Mandel Pinned Build"
 
-if [[ $NAME != "Ubuntu" ]]
-   then
-      echo "Currently only supporting Ubuntu based builds. Proceed at your own risk."
+if [[ "$(uname)" == "Linux" ]]; then
+   if [[ -e /etc/os-release ]]; then
+      # obtain NAME and other information
+      . /etc/os-release
+      if [[ ${NAME} != "Ubuntu" ]]; then
+         echo "Currently only supporting Ubuntu based builds. Proceed at your own risk."
+      fi
+   else
+       echo "Currently only supporting Ubuntu based builds. /etc/os-release not found. Your Linux distribution is not supported. Proceed at your own risk."
+   fi
+else
+    echo "Currently only supporting Ubuntu based builds. Your architecture is not supported. Proceed at your own risk."
 fi
 
 if [ $# -eq 0 ] || [ -z "$1" ]
@@ -25,6 +34,7 @@ LLVM_VER=7.1.0
 LIBPQXX_VER=7.2.1
 ARCH=`uname -m`
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+START_DIR="$(pwd)"
 
 
 pushdir() {
@@ -112,6 +122,9 @@ pushdir ${DEP_DIR}
 install_clang ${DEP_DIR}/clang-${CLANG_VER}
 install_llvm ${DEP_DIR}/llvm-${LLVM_VER}
 install_boost ${DEP_DIR}/boost_${BOOST_VER//\./_}
+
+# go back to the directory where the script starts
+popdir ${START_DIR}
 
 pushdir ${MANDEL_DIR}
 


### PR DESCRIPTION
https://github.com/eosnetworkfoundation/mandel/issues/363 reports `pinned_build.sh` always prints "Currently only supporting Ubuntu based builds. Proceed at your own risk.", even on Ubuntu platform.

https://github.com/eosnetworkfoundation/mandel/issues/364 reports the build directory is made relative to the dependency directory; it should have been relative to the directory where the script starts.

This PR fixes those two issues.

Tested in two different directories:
```
scripts/pinned_build.sh ~/dep build 16
./pinned_build.sh ~/dep build 16

```