### PR TITLE
Add additional CPU/NET usage data to get_account results

### DIFF
--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -4,6 +4,7 @@
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/trace.hpp>
 #include <eosio/chain/snapshot.hpp>
+#include <eosio/chain/block_timestamp.hpp>
 #include <chainbase/chainbase.hpp>
 #include <set>
 
@@ -58,6 +59,11 @@ namespace eosio { namespace chain {
       int64_t max = 0; ///< max per window under current congestion
    };
 
+   struct account_resource_usage {
+      chain::block_timestamp_type last_usage_update_time; ///< the time of the block of the account was last updated
+      uint64_t current_used; ///< the current resource usage value would be for current head block time
+   };
+
    class resource_limits_manager {
       public:
 
@@ -99,6 +105,8 @@ namespace eosio { namespace chain {
          uint64_t get_block_cpu_limit() const;
          uint64_t get_block_net_limit() const;
 
+         // return <optional<net>, optional<cpu>>
+         std::tuple<optional<account_resource_usage>, optional<account_resource_usage>> get_account_current_usages( const account_name& account) const;
          std::pair<int64_t, bool> get_account_cpu_limit( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
          std::pair<int64_t, bool> get_account_net_limit( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
 
@@ -114,5 +122,6 @@ namespace eosio { namespace chain {
 } } } /// eosio::chain
 
 FC_REFLECT( eosio::chain::resource_limits::account_resource_limit, (used)(available)(max) )
+FC_REFLECT( eosio::chain::resource_limits::account_resource_usage, (last_usage_update_time)(current_used) )
 FC_REFLECT( eosio::chain::resource_limits::ratio, (numerator)(denominator))
 FC_REFLECT( eosio::chain::resource_limits::elastic_limit_parameters, (target)(max)(periods)(max_multiplier)(contract_rate)(expand_rate))

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -57,11 +57,8 @@ namespace eosio { namespace chain {
       int64_t used = 0; ///< quantity used in current window
       int64_t available = 0; ///< quantity available in current window (based upon fractional reserve)
       int64_t max = 0; ///< max per window under current congestion
-   };
-
-   struct account_resource_usage {
-      chain::block_timestamp_type last_usage_update_time; ///< the time of the block of the account was last updated
-      uint64_t current_used; ///< the current resource usage value would be for current head block time
+      fc::optional<block_timestamp_type> last_updated_time_stamp; ///< last updated timestamp, optional for backward compatibility in Json
+      fc::optional<uint64_t> current_used;  ///< current usage according to the given timestamp, optional for backward compatibility in Json
    };
 
    class resource_limits_manager {
@@ -105,13 +102,13 @@ namespace eosio { namespace chain {
          uint64_t get_block_cpu_limit() const;
          uint64_t get_block_net_limit() const;
 
-         // return <optional<net>, optional<cpu>>
-         std::tuple<optional<account_resource_usage>, optional<account_resource_usage>> get_account_current_usages( const account_name& account) const;
          std::pair<int64_t, bool> get_account_cpu_limit( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
          std::pair<int64_t, bool> get_account_net_limit( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
 
-         std::pair<account_resource_limit, bool> get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
-         std::pair<account_resource_limit, bool> get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
+         std::pair<account_resource_limit, bool>
+         get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<time_point>& time_slot={} ) const;
+         std::pair<account_resource_limit, bool>
+         get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<time_point>& time_slot={} ) const;
 
          int64_t get_account_ram_usage( const account_name& name ) const;
 
@@ -121,7 +118,6 @@ namespace eosio { namespace chain {
    };
 } } } /// eosio::chain
 
-FC_REFLECT( eosio::chain::resource_limits::account_resource_limit, (used)(available)(max) )
-FC_REFLECT( eosio::chain::resource_limits::account_resource_usage, (last_usage_update_time)(current_used) )
+FC_REFLECT( eosio::chain::resource_limits::account_resource_limit, (used)(available)(max)(last_updated_time_stamp)(current_used) )
 FC_REFLECT( eosio::chain::resource_limits::ratio, (numerator)(denominator))
 FC_REFLECT( eosio::chain::resource_limits::elastic_limit_parameters, (target)(max)(periods)(max_multiplier)(contract_rate)(expand_rate))

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -57,8 +57,8 @@ namespace eosio { namespace chain {
       int64_t used = 0; ///< quantity used in current window
       int64_t available = 0; ///< quantity available in current window (based upon fractional reserve)
       int64_t max = 0; ///< max per window under current congestion
-      fc::optional<block_timestamp_type> last_updated_time_stamp; ///< last updated timestamp, optional for backward compatibility in Json
-      fc::optional<int64_t> current_used;  ///< current usage according to the given timestamp, optional for backward compatibility in Json
+      block_timestamp_type last_usage_update_time; ///< last usage timestamp
+      int64_t current_used = 0;  ///< current usage according to the given timestamp
    };
 
    class resource_limits_manager {
@@ -106,9 +106,9 @@ namespace eosio { namespace chain {
          std::pair<int64_t, bool> get_account_net_limit( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
 
          std::pair<account_resource_limit, bool>
-         get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<time_point>& time_slot={} ) const;
+         get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<block_timestamp_type>& current_time={} ) const;
          std::pair<account_resource_limit, bool>
-         get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<time_point>& time_slot={} ) const;
+         get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<block_timestamp_type>& current_time={} ) const;
 
          int64_t get_account_ram_usage( const account_name& name ) const;
 
@@ -118,6 +118,6 @@ namespace eosio { namespace chain {
    };
 } } } /// eosio::chain
 
-FC_REFLECT( eosio::chain::resource_limits::account_resource_limit, (used)(available)(max)(last_updated_time_stamp)(current_used) )
+FC_REFLECT( eosio::chain::resource_limits::account_resource_limit, (used)(available)(max)(last_usage_update_time)(current_used) )
 FC_REFLECT( eosio::chain::resource_limits::ratio, (numerator)(denominator))
 FC_REFLECT( eosio::chain::resource_limits::elastic_limit_parameters, (target)(max)(periods)(max_multiplier)(contract_rate)(expand_rate))

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -106,9 +106,9 @@ namespace eosio { namespace chain {
          std::pair<int64_t, bool> get_account_net_limit( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier ) const;
 
          std::pair<account_resource_limit, bool>
-         get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<block_timestamp_type>& current_time={} ) const;
+         get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const std::optional<block_timestamp_type>& current_time={} ) const;
          std::pair<account_resource_limit, bool>
-         get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const fc::optional<block_timestamp_type>& current_time={} ) const;
+         get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit = config::maximum_elastic_resource_multiplier, const std::optional<block_timestamp_type>& current_time={} ) const;
 
          int64_t get_account_ram_usage( const account_name& name ) const;
 

--- a/libraries/chain/include/eosio/chain/resource_limits.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits.hpp
@@ -58,7 +58,7 @@ namespace eosio { namespace chain {
       int64_t available = 0; ///< quantity available in current window (based upon fractional reserve)
       int64_t max = 0; ///< max per window under current congestion
       fc::optional<block_timestamp_type> last_updated_time_stamp; ///< last updated timestamp, optional for backward compatibility in Json
-      fc::optional<uint64_t> current_used;  ///< current usage according to the given timestamp, optional for backward compatibility in Json
+      fc::optional<int64_t> current_used;  ///< current usage according to the given timestamp, optional for backward compatibility in Json
    };
 
    class resource_limits_manager {

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -429,7 +429,7 @@ resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uin
    get_account_limits( name, x, y, cpu_weight );
 
    if( cpu_weight < 0 || state.total_cpu_weight == 0 ) {
-      return {{ -1, -1, -1, block_timestamp_type(usage.cpu_usage.last_ordinal),-1 }, false};
+      return {{ -1, -1, -1, block_timestamp_type(usage.cpu_usage.last_ordinal), -1 }, false};
    }
 
    account_resource_limit arl;
@@ -491,7 +491,7 @@ resource_limits_manager::get_account_net_limit_ex( const account_name& name, uin
    get_account_limits( name, x, net_weight, y );
 
    if( net_weight < 0 || state.total_net_weight == 0) {
-      return {{ -1, -1, -1, block_timestamp_type(usage.cpu_usage.last_ordinal), -1 }, false};
+      return {{ -1, -1, -1, block_timestamp_type(usage.net_usage.last_ordinal), -1 }, false};
    }
 
    account_resource_limit arl;

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -419,7 +419,7 @@ std::pair<int64_t, bool> resource_limits_manager::get_account_cpu_limit( const a
 }
 
 std::pair<account_resource_limit, bool>
-resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<block_timestamp_type>& current_time) const {
+resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit, const std::optional<block_timestamp_type>& current_time) const {
 
    const auto& state = _db.get<resource_limits_state_object>();
    const auto& usage = _db.get<resource_usage_object, by_owner>(name);
@@ -465,7 +465,7 @@ resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uin
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
    arl.last_usage_update_time = block_timestamp_type(usage.cpu_usage.last_ordinal);
    arl.current_used = arl.used;
-   if ( current_time.valid() ) {
+   if ( current_time ) {
       if (current_time->slot > usage.cpu_usage.last_ordinal) {
          auto history_usage = usage.cpu_usage;
          history_usage.add(0, current_time->slot, window_size);
@@ -481,7 +481,7 @@ std::pair<int64_t, bool> resource_limits_manager::get_account_net_limit( const a
 }
 
 std::pair<account_resource_limit, bool>
-resource_limits_manager::get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<block_timestamp_type>& current_time) const {
+resource_limits_manager::get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit, const std::optional<block_timestamp_type>& current_time) const {
    const auto& config = _db.get<resource_limits_config_object>();
    const auto& state  = _db.get<resource_limits_state_object>();
    const auto& usage  = _db.get<resource_usage_object, by_owner>(name);
@@ -526,7 +526,7 @@ resource_limits_manager::get_account_net_limit_ex( const account_name& name, uin
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
    arl.last_usage_update_time = block_timestamp_type(usage.net_usage.last_ordinal);
    arl.current_used = arl.used;
-   if ( current_time.valid() ) {
+   if ( current_time ) {
       if (current_time->slot > usage.net_usage.last_ordinal) {
          auto history_usage = usage.net_usage;
          history_usage.add(0, current_time->slot, window_size);

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -429,7 +429,7 @@ resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uin
    get_account_limits( name, x, y, cpu_weight );
 
    if( cpu_weight < 0 || state.total_cpu_weight == 0 ) {
-      return {{ -1, -1, -1 }, false};
+      return {{ -1, -1, -1, block_timestamp_type(usage.cpu_usage.last_ordinal),-1 }, false};
    }
 
    account_resource_limit arl;
@@ -470,7 +470,7 @@ resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uin
       if (current_time.slot > usage.cpu_usage.last_ordinal) {
          auto history_usage = usage.cpu_usage;
          history_usage.add(0, current_time.slot, window_size);
-         arl.current_used = impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
+         arl.current_used = impl::downgrade_cast<int64_t>(impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision));
       }
    }
    return {arl, greylisted};
@@ -491,7 +491,7 @@ resource_limits_manager::get_account_net_limit_ex( const account_name& name, uin
    get_account_limits( name, x, net_weight, y );
 
    if( net_weight < 0 || state.total_net_weight == 0) {
-      return {{ -1, -1, -1 }, false};
+      return {{ -1, -1, -1, block_timestamp_type(usage.cpu_usage.last_ordinal), -1 }, false};
    }
 
    account_resource_limit arl;
@@ -526,13 +526,14 @@ resource_limits_manager::get_account_net_limit_ex( const account_name& name, uin
    arl.used = impl::downgrade_cast<int64_t>(net_used_in_window);
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
    arl.last_updated_time_stamp = block_timestamp_type(usage.net_usage.last_ordinal);
+
    arl.current_used = arl.used;
    if ( time_slot.valid() ) {
       block_timestamp_type current_time(*time_slot);
       if (current_time.slot > usage.net_usage.last_ordinal) {
          auto history_usage = usage.net_usage;
          history_usage.add(0, current_time.slot, window_size);
-         arl.current_used = impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
+         arl.current_used = impl::downgrade_cast<int64_t>(impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision));
       }
    }
    return {arl, greylisted};

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -419,7 +419,7 @@ std::pair<int64_t, bool> resource_limits_manager::get_account_cpu_limit( const a
 }
 
 std::pair<account_resource_limit, bool>
-resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<time_point>& time_slot) const {
+resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<block_timestamp_type>& current_time) const {
 
    const auto& state = _db.get<resource_limits_state_object>();
    const auto& usage = _db.get<resource_usage_object, by_owner>(name);
@@ -463,13 +463,12 @@ resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uin
 
    arl.used = impl::downgrade_cast<int64_t>(cpu_used_in_window);
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
-   arl.last_updated_time_stamp = block_timestamp_type(usage.cpu_usage.last_ordinal);
+   arl.last_usage_update_time = block_timestamp_type(usage.cpu_usage.last_ordinal);
    arl.current_used = arl.used;
-   if ( time_slot.valid() ) {
-      block_timestamp_type current_time(*time_slot);
-      if (current_time.slot > usage.cpu_usage.last_ordinal) {
+   if ( current_time.valid() ) {
+      if (current_time->slot > usage.cpu_usage.last_ordinal) {
          auto history_usage = usage.cpu_usage;
-         history_usage.add(0, current_time.slot, window_size);
+         history_usage.add(0, current_time->slot, window_size);
          arl.current_used = impl::downgrade_cast<int64_t>(impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision));
       }
    }
@@ -482,7 +481,7 @@ std::pair<int64_t, bool> resource_limits_manager::get_account_net_limit( const a
 }
 
 std::pair<account_resource_limit, bool>
-resource_limits_manager::get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<time_point>& time_slot) const {
+resource_limits_manager::get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<block_timestamp_type>& current_time) const {
    const auto& config = _db.get<resource_limits_config_object>();
    const auto& state  = _db.get<resource_limits_state_object>();
    const auto& usage  = _db.get<resource_usage_object, by_owner>(name);
@@ -525,14 +524,12 @@ resource_limits_manager::get_account_net_limit_ex( const account_name& name, uin
 
    arl.used = impl::downgrade_cast<int64_t>(net_used_in_window);
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
-   arl.last_updated_time_stamp = block_timestamp_type(usage.net_usage.last_ordinal);
-
+   arl.last_usage_update_time = block_timestamp_type(usage.net_usage.last_ordinal);
    arl.current_used = arl.used;
-   if ( time_slot.valid() ) {
-      block_timestamp_type current_time(*time_slot);
-      if (current_time.slot > usage.net_usage.last_ordinal) {
+   if ( current_time.valid() ) {
+      if (current_time->slot > usage.net_usage.last_ordinal) {
          auto history_usage = usage.net_usage;
-         history_usage.add(0, current_time.slot, window_size);
+         history_usage.add(0, current_time->slot, window_size);
          arl.current_used = impl::downgrade_cast<int64_t>(impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision));
       }
    }

--- a/libraries/chain/resource_limits.cpp
+++ b/libraries/chain/resource_limits.cpp
@@ -418,7 +418,8 @@ std::pair<int64_t, bool> resource_limits_manager::get_account_cpu_limit( const a
    return {arl.available, greylisted};
 }
 
-std::pair<account_resource_limit, bool> resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit ) const {
+std::pair<account_resource_limit, bool>
+resource_limits_manager::get_account_cpu_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<time_point>& time_slot) const {
 
    const auto& state = _db.get<resource_limits_state_object>();
    const auto& usage = _db.get<resource_usage_object, by_owner>(name);
@@ -462,6 +463,16 @@ std::pair<account_resource_limit, bool> resource_limits_manager::get_account_cpu
 
    arl.used = impl::downgrade_cast<int64_t>(cpu_used_in_window);
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
+   arl.last_updated_time_stamp = block_timestamp_type(usage.cpu_usage.last_ordinal);
+   arl.current_used = arl.used;
+   if ( time_slot.valid() ) {
+      block_timestamp_type current_time(*time_slot);
+      if (current_time.slot > usage.cpu_usage.last_ordinal) {
+         auto history_usage = usage.cpu_usage;
+         history_usage.add(0, current_time.slot, window_size);
+         arl.current_used = impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
+      }
+   }
    return {arl, greylisted};
 }
 
@@ -470,7 +481,8 @@ std::pair<int64_t, bool> resource_limits_manager::get_account_net_limit( const a
    return {arl.available, greylisted};
 }
 
-std::pair<account_resource_limit, bool> resource_limits_manager::get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit ) const {
+std::pair<account_resource_limit, bool>
+resource_limits_manager::get_account_net_limit_ex( const account_name& name, uint32_t greylist_limit, const fc::optional<time_point>& time_slot) const {
    const auto& config = _db.get<resource_limits_config_object>();
    const auto& state  = _db.get<resource_limits_state_object>();
    const auto& usage  = _db.get<resource_usage_object, by_owner>(name);
@@ -513,6 +525,16 @@ std::pair<account_resource_limit, bool> resource_limits_manager::get_account_net
 
    arl.used = impl::downgrade_cast<int64_t>(net_used_in_window);
    arl.max = impl::downgrade_cast<int64_t>(max_user_use_in_window);
+   arl.last_updated_time_stamp = block_timestamp_type(usage.net_usage.last_ordinal);
+   arl.current_used = arl.used;
+   if ( time_slot.valid() ) {
+      block_timestamp_type current_time(*time_slot);
+      if (current_time.slot > usage.net_usage.last_ordinal) {
+         auto history_usage = usage.net_usage;
+         history_usage.add(0, current_time.slot, window_size);
+         arl.current_used = impl::integer_divide_ceil((uint128_t)history_usage.value_ex * window_size, (uint128_t)config::rate_limiting_precision);
+      }
+   }
    return {arl, greylisted};
 }
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2442,14 +2442,14 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    result.created          = accnt_obj.creation_date;
 
    uint32_t greylist_limit = db.is_resource_greylisted(result.account_name) ? 1 : config::maximum_elastic_resource_multiplier;
-   const auto current_usage_time = db.head_block_time();
-   result.net_limit = rm.get_account_net_limit_ex( result.account_name, greylist_limit, current_usage_time).first;
-   if ( result.net_limit.last_updated_time_stamp.valid() && (result.net_limit.last_updated_time_stamp->slot == 0) ) {   // account has no action yet
-      result.net_limit.last_updated_time_stamp = accnt_obj.creation_date;
+   const block_timestamp_type current_usage_time (db.head_block_time());
+   result.net_limit.set( rm.get_account_net_limit_ex( result.account_name, greylist_limit, current_usage_time).first );
+   if ( result.net_limit.last_usage_update_time.valid() && (result.net_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
+      result.net_limit.last_usage_update_time = accnt_obj.creation_date;
    }
-   result.cpu_limit = rm.get_account_cpu_limit_ex( result.account_name, greylist_limit, current_usage_time).first;
-   if ( result.cpu_limit.last_updated_time_stamp.valid() && (result.cpu_limit.last_updated_time_stamp->slot == 0) ) {   // account has no action yet
-      result.cpu_limit.last_updated_time_stamp = accnt_obj.creation_date;
+   result.cpu_limit.set( rm.get_account_cpu_limit_ex( result.account_name, greylist_limit, current_usage_time).first );
+   if ( result.cpu_limit.last_usage_update_time.valid() && (result.cpu_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
+      result.cpu_limit.last_usage_update_time = accnt_obj.creation_date;
    }
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
 

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2442,10 +2442,10 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    result.created          = accnt_obj.creation_date;
 
    uint32_t greylist_limit = db.is_resource_greylisted(result.account_name) ? 1 : config::maximum_elastic_resource_multiplier;
-   result.net_info.limit = rm.get_account_net_limit_ex( result.account_name, greylist_limit).first;
-   result.cpu_info.limit = rm.get_account_cpu_limit_ex( result.account_name, greylist_limit).first;
+   const auto current_usage_time = db.head_block_time();
+   result.net_limit = rm.get_account_net_limit_ex( result.account_name, greylist_limit, current_usage_time).first;
+   result.cpu_limit = rm.get_account_cpu_limit_ex( result.account_name, greylist_limit, current_usage_time).first;
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
-   std::tie(result.net_info.usage, result.cpu_info.usage) = rm.get_account_current_usages(result.account_name);
 
    if ( producer_plug ) {  // producer_plug is null when called from chain_plugin_tests.cpp and get_table_tests.cpp
       account_resource_limit subjective_cpu_bill_limit;

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2444,17 +2444,17 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    uint32_t greylist_limit = db.is_resource_greylisted(result.account_name) ? 1 : config::maximum_elastic_resource_multiplier;
    const block_timestamp_type current_usage_time (db.head_block_time());
    result.net_limit.set( rm.get_account_net_limit_ex( result.account_name, greylist_limit, current_usage_time).first );
-   if ( result.net_limit.last_usage_update_time.valid() && (result.net_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
+   if ( result.net_limit.last_usage_update_time && (result.net_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
       result.net_limit.last_usage_update_time = accnt_obj.creation_date;
    }
    result.cpu_limit.set( rm.get_account_cpu_limit_ex( result.account_name, greylist_limit, current_usage_time).first );
-   if ( result.cpu_limit.last_usage_update_time.valid() && (result.cpu_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
+   if ( result.cpu_limit.last_usage_update_time && (result.cpu_limit.last_usage_update_time->slot == 0) ) {   // account has no action yet
       result.cpu_limit.last_usage_update_time = accnt_obj.creation_date;
    }
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
 
    if ( producer_plug ) {  // producer_plug is null when called from chain_plugin_tests.cpp and get_table_tests.cpp
-      account_resource_limit subjective_cpu_bill_limit;
+      eosio::chain::resource_limits::account_resource_limit subjective_cpu_bill_limit;
       subjective_cpu_bill_limit.used = producer_plug->get_subjective_bill( result.account_name, fc::time_point::now() );
       result.subjective_cpu_bill_limit = subjective_cpu_bill_limit;
    }

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2444,7 +2444,13 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    uint32_t greylist_limit = db.is_resource_greylisted(result.account_name) ? 1 : config::maximum_elastic_resource_multiplier;
    const auto current_usage_time = db.head_block_time();
    result.net_limit = rm.get_account_net_limit_ex( result.account_name, greylist_limit, current_usage_time).first;
+   if ( result.net_limit.last_updated_time_stamp.valid() && (result.net_limit.last_updated_time_stamp->slot == 0) ) {   // account has no action yet
+      result.net_limit.last_updated_time_stamp = accnt_obj.creation_date;
+   }
    result.cpu_limit = rm.get_account_cpu_limit_ex( result.account_name, greylist_limit, current_usage_time).first;
+   if ( result.cpu_limit.last_updated_time_stamp.valid() && (result.cpu_limit.last_updated_time_stamp->slot == 0) ) {   // account has no action yet
+      result.cpu_limit.last_updated_time_stamp = accnt_obj.creation_date;
+   }
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
 
    if ( producer_plug ) {  // producer_plug is null when called from chain_plugin_tests.cpp and get_table_tests.cpp

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2442,9 +2442,10 @@ read_only::get_account_results read_only::get_account( const get_account_params&
    result.created          = accnt_obj.creation_date;
 
    uint32_t greylist_limit = db.is_resource_greylisted(result.account_name) ? 1 : config::maximum_elastic_resource_multiplier;
-   result.net_limit = rm.get_account_net_limit_ex( result.account_name, greylist_limit).first;
-   result.cpu_limit = rm.get_account_cpu_limit_ex( result.account_name, greylist_limit).first;
+   result.net_info.limit = rm.get_account_net_limit_ex( result.account_name, greylist_limit).first;
+   result.cpu_info.limit = rm.get_account_cpu_limit_ex( result.account_name, greylist_limit).first;
    result.ram_usage = rm.get_account_ram_usage( result.account_name );
+   std::tie(result.net_info.usage, result.cpu_info.usage) = rm.get_account_current_usages(result.account_name);
 
    if ( producer_plug ) {  // producer_plug is null when called from chain_plugin_tests.cpp and get_table_tests.cpp
       account_resource_limit subjective_cpu_bill_limit;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -12,7 +12,6 @@
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/fixed_bytes.hpp>
-#include <eosio/chain/resource_limits.hpp>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -178,13 +177,6 @@ public:
 
    using account_resource_limit = chain::resource_limits::account_resource_limit;
 
-   struct account_resource_info
-   {
-      chain::resource_limits::account_resource_limit limit;
-      // optional for backward compatibility
-      optional<chain::resource_limits::account_resource_usage> usage;
-   };
-
    struct get_account_results {
       name                       account_name;
       uint32_t                   head_block_num = 0;
@@ -200,8 +192,8 @@ public:
       int64_t                    net_weight = 0;
       int64_t                    cpu_weight = 0;
 
-      account_resource_info      net_info;
-      account_resource_info      cpu_info;
+      account_resource_limit     net_limit;
+      account_resource_limit     cpu_limit;
       int64_t                    ram_usage = 0;
 
       vector<permission>         permissions;
@@ -863,7 +855,6 @@ FC_REFLECT( eosio::chain_apis::read_only::get_producer_schedule_result, (active)
 FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_result, (transactions)(more) );
 
-FC_REFLECT( eosio::chain_apis::read_only::account_resource_info, (limit)(usage))
 FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
             (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
             (core_liquid_balance)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -180,9 +180,9 @@ public:
       int64_t used = 0;
       int64_t available = 0;
       int64_t max = 0;
-      optional<chain::block_timestamp_type> last_usage_update_time;    // optional for backward nodeos support
-      optional<int64_t> current_used;  // optional for backward nodeos support
-      void set( const chain::resource_limits::account_resource_limit& arl)
+      std::optional<chain::block_timestamp_type> last_usage_update_time;    // optional for backward nodeos support
+      std::optional<int64_t> current_used;  // optional for backward nodeos support
+      void set( const eosio::chain::resource_limits::account_resource_limit& arl)
       {
          used = arl.used;
          available = arl.available;
@@ -219,7 +219,7 @@ public:
       fc::variant                voter_info;
       fc::variant                rex_info;
 
-      std::optional<account_resource_limit> subjective_cpu_bill_limit;
+      std::optional<eosio::chain::resource_limits::account_resource_limit> subjective_cpu_bill_limit;
       std::vector<linked_action> eosio_any_linked_actions;
    };
 

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -175,7 +175,22 @@ public:
       name                       producer_name;
    };
 
-   using account_resource_limit = chain::resource_limits::account_resource_limit;
+   // account_resource_info holds similar data members as in account_resource_limit, but decoupling making them independently to be refactored in future
+   struct account_resource_info {
+      int64_t used = 0;
+      int64_t available = 0;
+      int64_t max = 0;
+      optional<chain::block_timestamp_type> last_usage_update_time;    // optional for backward nodeos support
+      optional<int64_t> current_used;  // optional for backward nodeos support
+      void set( const chain::resource_limits::account_resource_limit& arl)
+      {
+         used = arl.used;
+         available = arl.available;
+         max = arl.max;
+         last_usage_update_time = arl.last_usage_update_time;
+         current_used = arl.current_used;
+      }
+   };
 
    struct get_account_results {
       name                       account_name;
@@ -192,8 +207,8 @@ public:
       int64_t                    net_weight = 0;
       int64_t                    cpu_weight = 0;
 
-      account_resource_limit     net_limit;
-      account_resource_limit     cpu_limit;
+      account_resource_info      net_limit;
+      account_resource_info      cpu_limit;
       int64_t                    ram_usage = 0;
 
       vector<permission>         permissions;
@@ -855,6 +870,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_producer_schedule_result, (active)
 FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_result, (transactions)(more) );
 
+FC_REFLECT( eosio::chain_apis::read_only::account_resource_info, (used)(available)(max)(last_usage_update_time)(current_used) )
 FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
             (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
             (core_liquid_balance)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -12,6 +12,7 @@
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/fixed_bytes.hpp>
+#include <eosio/chain/resource_limits.hpp>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -177,6 +178,13 @@ public:
 
    using account_resource_limit = chain::resource_limits::account_resource_limit;
 
+   struct account_resource_info
+   {
+      chain::resource_limits::account_resource_limit limit;
+      // optional for backward compatibility
+      optional<chain::resource_limits::account_resource_usage> usage;
+   };
+
    struct get_account_results {
       name                       account_name;
       uint32_t                   head_block_num = 0;
@@ -192,8 +200,8 @@ public:
       int64_t                    net_weight = 0;
       int64_t                    cpu_weight = 0;
 
-      account_resource_limit     net_limit;
-      account_resource_limit     cpu_limit;
+      account_resource_info      net_info;
+      account_resource_info      cpu_info;
       int64_t                    ram_usage = 0;
 
       vector<permission>         permissions;
@@ -855,6 +863,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_producer_schedule_result, (active)
 FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_params, (json)(lower_bound)(limit) )
 FC_REFLECT( eosio::chain_apis::read_only::get_scheduled_transactions_result, (transactions)(more) );
 
+FC_REFLECT( eosio::chain_apis::read_only::account_resource_info, (limit)(usage))
 FC_REFLECT( eosio::chain_apis::read_only::get_account_results,
             (account_name)(head_block_num)(head_block_time)(privileged)(last_code_update)(created)
             (core_liquid_balance)(ram_quota)(net_weight)(cpu_weight)(net_limit)(cpu_limit)(ram_usage)(permissions)

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2380,11 +2380,11 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          return ss.str();
       };
 
-
+      const std::string net_current_usage_str = "    ( " + (res.net_info.usage.valid() ? to_pretty_net(res.net_info.usage->current_used) : "out of date") + " )";
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_net( res.net_limit.used ) << "\n";
-      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_net( res.net_limit.available ) << "\n";
-      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_net( res.net_limit.max ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_net( res.net_info.limit.used ) << net_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_net( res.net_info.limit.available ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_net( res.net_info.limit.max ) << "\n";
       std::cout << std::endl;
 
       std::cout << "cpu bandwidth:" << std::endl;
@@ -2409,10 +2409,12 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          }
       }
 
+
+      const std::string cpu_current_usage_str = "    ( " + (res.cpu_info.usage.valid() ? to_pretty_time(res.cpu_info.usage->current_used) : "out of date") + " )";
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.used ) << "\n";
-      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.available ) << "\n";
-      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.max ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_time( res.cpu_info.limit.used ) << cpu_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_info.limit.available ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_info.limit.max ) << "\n";
       std::cout << std::endl;
 
       if( res.subjective_cpu_bill_limit ) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2416,9 +2416,9 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
       std::cout << std::fixed << setprecision(3);
       std::cout << indent << std::left << std::setw(11) << "used:" << std::right << std::setw(18);
       if( res.cpu_limit.current_used ) {
-         std::cout << to_pretty_net(*res.cpu_limit.current_used) << "\n";
+         std::cout << to_pretty_time(*res.cpu_limit.current_used) << "\n";
       } else {
-         std::cout << to_pretty_net(res.cpu_limit.used) << "    ( out of date )\n";
+         std::cout << to_pretty_time(res.cpu_limit.used) << "    ( out of date )\n";
       }
       std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.available ) << "\n";
       std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.max ) << "\n";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2380,9 +2380,10 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          return ss.str();
       };
 
-      const std::string net_current_usage_str = "    ( " + (res.net_limit.current_used.valid() ? to_pretty_net(*res.net_limit.current_used) : "out of date") + " )";
+      const std::string out_of_date_str = "    ( out of date )";
+      const std::string net_current_usage_str = (res.net_limit.current_used.valid() ? to_pretty_net(*res.net_limit.current_used) : (to_pretty_net( res.net_limit.used ) + out_of_date_str) );
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_net( res.net_limit.used ) << net_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << net_current_usage_str << "\n";
       std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_net( res.net_limit.available ) << "\n";
       std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_net( res.net_limit.max ) << "\n";
       std::cout << std::endl;
@@ -2409,10 +2410,9 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          }
       }
 
-
-      const std::string cpu_current_usage_str = "    ( " + (res.cpu_limit.current_used.valid() ? to_pretty_time(*res.cpu_limit.current_used) : "out of date") + " )";
+      const std::string cpu_current_usage_str = (res.cpu_limit.current_used.valid() ? to_pretty_time(*res.cpu_limit.current_used) : (to_pretty_time( res.cpu_limit.used ) + out_of_date_str) );
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.used ) << cpu_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << cpu_current_usage_str << "\n";
       std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.available ) << "\n";
       std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.max ) << "\n";
       std::cout << std::endl;

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2380,11 +2380,11 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          return ss.str();
       };
 
-      const std::string net_current_usage_str = "    ( " + (res.net_info.usage.valid() ? to_pretty_net(res.net_info.usage->current_used) : "out of date") + " )";
+      const std::string net_current_usage_str = "    ( " + (res.net_limit.current_used.valid() ? to_pretty_net(*res.net_limit.current_used) : "out of date") + " )";
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_net( res.net_info.limit.used ) << net_current_usage_str << "\n";
-      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_net( res.net_info.limit.available ) << "\n";
-      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_net( res.net_info.limit.max ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_net( res.net_limit.used ) << net_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_net( res.net_limit.available ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_net( res.net_limit.max ) << "\n";
       std::cout << std::endl;
 
       std::cout << "cpu bandwidth:" << std::endl;
@@ -2410,11 +2410,11 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
       }
 
 
-      const std::string cpu_current_usage_str = "    ( " + (res.cpu_info.usage.valid() ? to_pretty_time(res.cpu_info.usage->current_used) : "out of date") + " )";
+      const std::string cpu_current_usage_str = "    ( " + (res.cpu_limit.current_used.valid() ? to_pretty_time(*res.cpu_limit.current_used) : "out of date") + " )";
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_time( res.cpu_info.limit.used ) << cpu_current_usage_str << "\n";
-      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_info.limit.available ) << "\n";
-      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_info.limit.max ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.used ) << cpu_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.available ) << "\n";
+      std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.max ) << "\n";
       std::cout << std::endl;
 
       if( res.subjective_cpu_bill_limit ) {

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -2380,10 +2380,13 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          return ss.str();
       };
 
-      const std::string out_of_date_str = "    ( out of date )";
-      const std::string net_current_usage_str = (res.net_limit.current_used.valid() ? to_pretty_net(*res.net_limit.current_used) : (to_pretty_net( res.net_limit.used ) + out_of_date_str) );
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << net_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:" << std::right << std::setw(18);
+      if( res.net_limit.current_used ) {
+         std::cout << to_pretty_net(*res.net_limit.current_used) << "\n";
+      } else {
+         std::cout << to_pretty_net(res.net_limit.used) << "    ( out of date )\n";
+      }
       std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_net( res.net_limit.available ) << "\n";
       std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_net( res.net_limit.max ) << "\n";
       std::cout << std::endl;
@@ -2410,9 +2413,13 @@ void get_account( const string& accountName, const string& coresym, bool json_fo
          }
       }
 
-      const std::string cpu_current_usage_str = (res.cpu_limit.current_used.valid() ? to_pretty_time(*res.cpu_limit.current_used) : (to_pretty_time( res.cpu_limit.used ) + out_of_date_str) );
       std::cout << std::fixed << setprecision(3);
-      std::cout << indent << std::left << std::setw(11) << "used:"      << std::right << std::setw(18) << cpu_current_usage_str << "\n";
+      std::cout << indent << std::left << std::setw(11) << "used:" << std::right << std::setw(18);
+      if( res.cpu_limit.current_used ) {
+         std::cout << to_pretty_net(*res.cpu_limit.current_used) << "\n";
+      } else {
+         std::cout << to_pretty_net(res.cpu_limit.used) << "    ( out of date )\n";
+      }
       std::cout << indent << std::left << std::setw(11) << "available:" << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.available ) << "\n";
       std::cout << indent << std::left << std::setw(11) << "limit:"     << std::right << std::setw(18) << to_pretty_time( res.cpu_limit.max ) << "\n";
       std::cout << std::endl;

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -2,8 +2,8 @@
 
 #include <eosio/chain/config.hpp>
 #include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/config.hpp>
 #include <eosio/testing/chainbase_fixture.hpp>
-
 #include <boost/test/unit_test.hpp>
 
 using namespace eosio::chain::resource_limits;
@@ -334,4 +334,67 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
       add_transaction_usage( {"dan"_n}, 34, 0, 2 + blocks_per_day );
    } FC_LOG_AND_RETHROW()
 
-BOOST_AUTO_TEST_SUITE_END()
+   /**
+     * Test to make sure that get_account_net_limit_ex and get_account_cpu_limit_ex returns proper results, including
+     * 1. the last updated timestamp is always same as the time slot on accumulator.
+     * 2. when no timestamp is given, the current_used should be same as used.
+     * 3. when timestamp is given, if it is earlier than last_updated_time_stamp, current_used is same as used,
+     *    otherwise, current_used should be the decay value (will be 0 after 1 day)
+    */
+   BOOST_FIXTURE_TEST_CASE(get_account_net_limit_ex_and_get_account_cpu_limit_ex, resource_limits_fixture) try {
+
+      const account_name cpu_test_account("cpuacc");
+      const account_name net_test_account("netacc");
+      const uint32_t delta_slot = 100;
+
+      const uint32_t net_window = eosio::chain::config::account_net_usage_average_window_ms / eosio::chain::config::block_interval_ms;
+      const uint32_t cpu_window = eosio::chain::config::account_cpu_usage_average_window_ms / eosio::chain::config::block_interval_ms;
+
+      const int64_t unlimited = -1;
+
+      using get_account_limit_ex_func = std::function<std::pair<account_resource_limit, bool>(const resource_limits_manager, const account_name&, uint32_t, const fc::optional<time_point>&)>;
+      auto test_get_account_limit_ex = [&, this](const account_name& test_account, const uint32_t window, get_account_limit_ex_func get_account_limit_ex)
+      {
+         initialize_account(test_account);
+         set_account_limits(test_account, unlimited, unlimited, unlimited);
+         process_account_limit_updates();
+         // unlimited
+         const auto ret_unlimited_wo_time_stamp =  get_account_limit_ex(*this, test_account, 0, {});
+         const auto ret_unlimited_with_time_stamp =  get_account_limit_ex(*this, test_account, 0, fc::time_point::now());
+         BOOST_CHECK_EQUAL(*ret_unlimited_wo_time_stamp.first.current_used, (int64_t)-1 );
+         BOOST_CHECK_EQUAL(*ret_unlimited_with_time_stamp.first.current_used, (int64_t)-1);
+         BOOST_CHECK_EQUAL(ret_unlimited_wo_time_stamp.first.last_updated_time_stamp->slot, ret_unlimited_with_time_stamp.first.last_updated_time_stamp->slot);
+         // limited no usage
+         const int64_t cpu_limit = 2048;
+         const int64_t net_limit = 1024;
+         const block_timestamp_type timestamp_now(fc::time_point::now());
+         set_account_limits(test_account, -1, net_limit, cpu_limit);
+         process_account_limit_updates();
+         const auto ret_limited_init_wo_time_stamp =  get_account_limit_ex(*this, test_account, 0, {});
+         const auto ret_limited_init_with_time_stamp =  get_account_limit_ex(*this, test_account, 0, timestamp_now.to_time_point());
+         BOOST_CHECK_EQUAL(*ret_limited_init_wo_time_stamp.first.current_used, ret_limited_init_wo_time_stamp.first.used );
+         BOOST_CHECK_EQUAL(*ret_limited_init_with_time_stamp.first.current_used, ret_limited_init_with_time_stamp.first.used);
+         BOOST_CHECK_EQUAL(ret_unlimited_wo_time_stamp.first.last_updated_time_stamp->slot, 0 );
+         BOOST_CHECK_EQUAL( ret_unlimited_with_time_stamp.first.last_updated_time_stamp->slot, 0 );
+         // limited with some usages
+         const int64_t cpu_usage = 100;
+         const int64_t net_usage = 200;
+         const uint32_t update_slot = timestamp_now.slot - delta_slot;
+
+         add_transaction_usage({test_account}, cpu_usage, net_usage, update_slot );
+         const auto ret_limited_1st_usg_wo_time_stamp =  get_account_limit_ex(*this, test_account, 0, {});
+         const auto ret_limited_1st_usg_with_time_stamp =  get_account_limit_ex(*this, test_account, 0, timestamp_now.to_time_point());
+         BOOST_CHECK_EQUAL(*ret_limited_1st_usg_wo_time_stamp.first.current_used, ret_limited_1st_usg_wo_time_stamp.first.used );
+         BOOST_CHECK_LT(*ret_limited_1st_usg_with_time_stamp.first.current_used, ret_limited_1st_usg_with_time_stamp.first.used);
+         BOOST_CHECK_EQUAL(*ret_limited_1st_usg_with_time_stamp.first.current_used,
+                           ret_limited_1st_usg_with_time_stamp.first.used * (window - delta_slot) / window);
+         BOOST_CHECK_EQUAL(ret_limited_1st_usg_wo_time_stamp.first.last_updated_time_stamp->slot, update_slot);
+         BOOST_CHECK_EQUAL(ret_limited_1st_usg_with_time_stamp.first.last_updated_time_stamp->slot, update_slot);
+      };
+      test_get_account_limit_ex(net_test_account, net_window, &resource_limits_manager::get_account_net_limit_ex);
+      test_get_account_limit_ex(cpu_test_account, cpu_window, &resource_limits_manager::get_account_cpu_limit_ex);
+
+   } FC_LOG_AND_RETHROW()
+
+
+   BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
             BOOST_CHECK_EQUAL(ret_limited_init_wo_time_stamp.first.current_used, ret_limited_init_wo_time_stamp.first.used);
             BOOST_CHECK_EQUAL(ret_limited_init_wo_time_stamp.first.current_used, 0);
             BOOST_CHECK_EQUAL(ret_limited_init_with_time_stamp.first.current_used, ret_limited_init_with_time_stamp.first.used);
-            BOOST_CHECK_EQUAL(ret_limited_init_wo_time_stamp.first.current_used, 0);
+            BOOST_CHECK_EQUAL(ret_limited_init_with_time_stamp.first.current_used, 0);
             BOOST_CHECK_EQUAL(ret_limited_init_wo_time_stamp.first.last_usage_update_time.slot, 0 );
             BOOST_CHECK_EQUAL( ret_limited_init_with_time_stamp.first.last_usage_update_time.slot, 0 );
          }

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -4,6 +4,7 @@
 #include <eosio/chain/resource_limits.hpp>
 #include <eosio/chain/config.hpp>
 #include <eosio/testing/chainbase_fixture.hpp>
+
 #include <boost/test/unit_test.hpp>
 
 using namespace eosio::chain::resource_limits;
@@ -362,12 +363,11 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
          // unlimited
          {
             const auto ret_unlimited_wo_time_stamp = get_account_limit_ex(*this, test_account, 0, {});
-            const auto ret_unlimited_with_time_stamp = get_account_limit_ex(*this, test_account, 0,
-                                                                            timestamp_now.to_time_point());
+            const auto ret_unlimited_with_time_stamp = get_account_limit_ex(*this, test_account, 0, timestamp_now.to_time_point());
             BOOST_CHECK_EQUAL(*ret_unlimited_wo_time_stamp.first.current_used, (int64_t) -1);
             BOOST_CHECK_EQUAL(*ret_unlimited_with_time_stamp.first.current_used, (int64_t) -1);
             BOOST_CHECK_EQUAL(ret_unlimited_wo_time_stamp.first.last_updated_time_stamp->slot,
-                              ret_unlimited_with_time_stamp.first.last_updated_time_stamp->slot);\
+                              ret_unlimited_with_time_stamp.first.last_updated_time_stamp->slot);
 
          }
          const int64_t cpu_limit = 2048;

--- a/unittests/resource_limits_test.cpp
+++ b/unittests/resource_limits_test.cpp
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_SUITE(resource_limits_test)
 
       constexpr int64_t unlimited = -1;
 
-      using get_account_limit_ex_func = std::function<std::pair<account_resource_limit, bool>(const resource_limits_manager*, const account_name&, uint32_t, const fc::optional<block_timestamp_type>&)>;
+      using get_account_limit_ex_func = std::function<std::pair<account_resource_limit, bool>(const resource_limits_manager*, const account_name&, uint32_t, const std::optional<block_timestamp_type>&)>;
       auto test_get_account_limit_ex = [this](const account_name& test_account, const uint32_t window, get_account_limit_ex_func get_account_limit_ex)
       {
          constexpr uint32_t delta_slot = 100;


### PR DESCRIPTION
Updated `/v1/chain/get_account`. See https://github.com/eosnetworkfoundation/mandel/issues/398 for complete details.

> For issue https://github.com/EOSIO/eos/issues/8708,
> Added last_updated_time_stamp and current_used (according to the head block timestamp) to get_account results.
> 
> The current_used is shown on the same line following used ( in parenthesis).
> The last_updated_time_stamp will only be printed in the json result.
> 
> Note:
> 
> The old cleos (w/o this fix) prints the same info on screen with no matter of new or old version of nodeos , but json format has those two fields from new nodeos.
> The new cleos (with this fix) displays (out-of-date) for current_used with the old version of nodeos.
> When an account has unlimited cpu/net usage, (unlimited) is displayed for current_used.
> When an account has no activity after being created, the account creation time is used as the last_updated_time_stamp in json result.
> If the user no activity for a day, the current_used will be 0.

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/398