### PR TITLE
Fix nodeos forked chain test

### DIFF
--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -401,7 +401,7 @@ try:
     Print("Tracking block producers from %d till divergence or %d. Head block is %d and lowest LIB is %d" % (preKillBlockNum, lastBlockNum, headBlockNum, libNumAroundDivergence))
     transitionCount=0
     missedTransitionBlock=None
-    for blockNum in range(preKillBlockNum,lastBlockNum):
+    for blockNum in range(preKillBlockNum,lastBlockNum + 1):
         #avoiding getting LIB until my current block passes the head from the last time I checked
         if blockNum>headBlockNum:
             (headBlockNum, libNumAroundDivergence)=getMinHeadAndLib(prodNodes)

--- a/tests/nodeos_forked_chain_test.py
+++ b/tests/nodeos_forked_chain_test.py
@@ -300,6 +300,7 @@ try:
     producerToSlot={}
     slot=-1
     inRowCountPerProducer=12
+    minNumBlocksPerProducer=10
     lastTimestamp=timestamp
     headBlockNum=node.getBlockNum()
     firstBlockForWindowMissedSlot=None
@@ -320,6 +321,7 @@ try:
         if firstBlockForWindowMissedSlot is not None:
             missedSlotAfter.append(firstBlockForWindowMissedSlot)
             firstBlockForWindowMissedSlot=None
+
         while blockProducer==lastBlockProducer:
             producerToSlot[blockProducer]["count"]+=1
             blockNum+=1
@@ -340,13 +342,16 @@ try:
                 missedSlotAfter.append("%d (%s)" % (blockNum-1, missed))
             lastTimestamp=timestamp
 
-        if producerToSlot[lastBlockProducer]["count"]!=inRowCountPerProducer:
+        if producerToSlot[lastBlockProducer]["count"] < minNumBlocksPerProducer or producerToSlot[lastBlockProducer]["count"] > inRowCountPerProducer:
             Utils.errorExit("Producer %s, in slot %d, expected to produce %d blocks but produced %d blocks.  At block number %d. " %
                             (lastBlockProducer, slot, inRowCountPerProducer, producerToSlot[lastBlockProducer]["count"], blockNum-1) +
                             "Slots were missed after the following blocks: %s" % (", ".join(missedSlotAfter)))
-        elif len(missedSlotAfter) > 0:
-            # if there was a full round, then the most recent producer missed a slot
-            firstBlockForWindowMissedSlot=missedSlotAfter[0]
+
+        if len(missedSlotAfter) > 0:
+            # it may be the most recent producer missed a slot
+            possibleMissed=missedSlotAfter[-1]
+            if possibleMissed == blockNum - 1:
+                firstBlockForWindowMissedSlot=possibleMissed
 
         if blockProducer==productionCycle[0]:
             break

--- a/tests/nodeos_high_transaction_test.py
+++ b/tests/nodeos_high_transaction_test.py
@@ -26,7 +26,7 @@ Print=Utils.Print
 
 appArgs = AppArgs()
 minTotalAccounts = 20
-extraArgs = appArgs.add(flag="--transaction-time-delta", type=int, help="How many seconds seconds behind an earlier sent transaction should be received after a later one", default=5)
+extraArgs = appArgs.add(flag="--transaction-time-delta", type=int, help="How many seconds seconds behind an earlier sent transaction should be received after a later one", default=7)
 extraArgs = appArgs.add(flag="--num-transactions", type=int, help="How many total transactions should be sent", default=10000)
 extraArgs = appArgs.add(flag="--max-transactions-per-second", type=int, help="How many transactions per second should be sent", default=500)
 extraArgs = appArgs.add(flag="--total-accounts", type=int, help="How many accounts should be involved in sending transfers.  Must be greater than %d" % (minTotalAccounts), default=100)

--- a/tests/nodeos_short_fork_take_over_test.py
+++ b/tests/nodeos_short_fork_take_over_test.py
@@ -251,7 +251,7 @@ try:
     Print("Tracking block producers from %d till divergence or %d. Head block is %d and lowest LIB is %d" % (preKillBlockNum, lastBlockNum, headBlockNum, libNumAroundDivergence))
     transitionCount=0
     missedTransitionBlock=None
-    for blockNum in range(preKillBlockNum,lastBlockNum):
+    for blockNum in range(preKillBlockNum,lastBlockNum + 1):
         #avoiding getting LIB until my current block passes the head from the last time I checked
         if blockNum>headBlockNum:
             (headBlockNum, libNumAroundDivergence)=getMinHeadAndLib(prodNodes)


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/9211 and https://github.com/EOSIO/eos/pull/9930.
Resolve https://github.com/eosnetworkfoundation/mandel/issues/405 and https://github.com/eosnetworkfoundation/mandel/issues/437.

From https://github.com/EOSIO/eos/pull/9211:
No longer require a producer to have to produce 12 blocks per round to allow for VMs not always getting time slices. Also, changed the default maximum time that successive transactions could be separated by. (It is a corner case, that resulted in a transaction not being processed for a whole production window. I added a comment to the Jira task to ensure it gets turned back on when that is fixed)

From https://github.com/EOSIO/eos/pull/9930:
When building the list of blocks to search for forking, the range was
`for blockNum in range(preKillBlockNum, lastBlockNum)`. In Python, the range is half closed. This results in an off by one problem if the forking block was the exact lastBlockNum. In EPE-465, lastBlockNum and the forked block number both ware 166, but the search ended t 165. This is also why the problem occurs rarely. The fix is for blockNum in `range(preKillBlockNum, lastBlockNum + 1)`