### PR TITLE
fix libff in 3.1 tester cmakes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,11 +193,14 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/eosio.version.hpp DESTINATION ${CMAKE_
 
 set(EOS_ROOT_DIR ${CMAKE_BINARY_DIR})
 configure_file(${CMAKE_SOURCE_DIR}/CMakeModules/eosio-config.cmake.in ${CMAKE_BINARY_DIR}/lib/cmake/eosio/eosio-config.cmake @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/CMakeModules/eosio-config.cmake.in ${CMAKE_BINARY_DIR}/lib/cmake/eosio/mandel-config.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/CMakeModules/EosioTesterBuild.cmake.in ${CMAKE_BINARY_DIR}/lib/cmake/eosio/EosioTester.cmake @ONLY)
 
 set(EOS_ROOT_DIR ${CMAKE_INSTALL_PREFIX})
 configure_file(${CMAKE_SOURCE_DIR}/CMakeModules/eosio-config.cmake.in ${CMAKE_BINARY_DIR}/modules/eosio-config.cmake @ONLY)
+configure_file(${CMAKE_SOURCE_DIR}/CMakeModules/eosio-config.cmake.in ${CMAKE_BINARY_DIR}/modules/mandel-config.cmake @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/modules/eosio-config.cmake DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/eosio COMPONENT dev EXCLUDE_FROM_ALL)
+install(FILES ${CMAKE_BINARY_DIR}/modules/mandel-config.cmake DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/mandel COMPONENT dev EXCLUDE_FROM_ALL)
 configure_file(${CMAKE_SOURCE_DIR}/CMakeModules/EosioTester.cmake.in ${CMAKE_BINARY_DIR}/modules/EosioTester.cmake @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/modules/EosioTester.cmake DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/eosio COMPONENT dev EXCLUDE_FROM_ALL)
 

--- a/CMakeModules/EosioTesterBuild.cmake.in
+++ b/CMakeModules/EosioTesterBuild.cmake.in
@@ -60,7 +60,7 @@ else()
    find_library(libsecp256k1 secp256k1 @CMAKE_BINARY_DIR@/libraries/fc/secp256k1 NO_DEFAULT_PATH)
 endif()
 
-find_library(libff ff @CMAKE_BINARY_DIR@/libraries/fc/libraries/ff NO_DEFAULT_PATH)
+find_library(libff ff @CMAKE_BINARY_DIR@/libraries/fc/libraries/ff/libff NO_DEFAULT_PATH)
 find_library(libwasm WASM @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/WASM NO_DEFAULT_PATH)
 find_library(libwast WAST @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/WAST NO_DEFAULT_PATH)
 find_library(libir IR     @CMAKE_BINARY_DIR@/libraries/wasm-jit/Source/IR NO_DEFAULT_PATH)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ We support the following CMake options:
 
 I highly recommend the ccache options. They don't speed up the first clean build, but they speed up future clean builds after the first build.
 
+### Installing for use with mandel.cdt (or others)
+
+```
+git submodule update --init --recursive
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j $(nproc)
+make install
+cmake --install . --component dev
+```
+
 ### Running tests
 
 ```

--- a/README.md
+++ b/README.md
@@ -71,9 +71,7 @@ git submodule update --init --recursive
 mkdir build
 cd build
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/local ..
-make -j $(nproc)
-make install
-cmake --install . --component dev
+make -j $(nproc) dev-install
 ```
 
 ### Running tests

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ I highly recommend the ccache options. They don't speed up the first clean build
 git submodule update --init --recursive
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/local ..
 make -j $(nproc)
 make install
 cmake --install . --component dev

--- a/README.md
+++ b/README.md
@@ -64,13 +64,17 @@ We support the following CMake options:
 
 I highly recommend the ccache options. They don't speed up the first clean build, but they speed up future clean builds after the first build.
 
-### Installing for use with mandel.cdt (or others)
+### Installing mandel dev for use with mandel.cdt (or others)
+
+The following instructions will install mandel and the development packages.  Installing is not strictly necessary. Instructions are provided, for example, in `mandel.cdt` for development and testing against a `mandel` source build directory (which may be preferable).
+
+**Warning:** It is highly recommended to select a `CMAKE_INSTALL_PREFIX` location different than the default `/usr/local`.  Here, `$HOME/mandeldev` is used as an example that should be safe for most dev systems, but each developer should determine if another location is better suited to their specific needs.
 
 ```
 git submodule update --init --recursive
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr/local ..
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/mandeldev ..
 make -j $(nproc) dev-install
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,20 +64,6 @@ We support the following CMake options:
 
 I highly recommend the ccache options. They don't speed up the first clean build, but they speed up future clean builds after the first build.
 
-### Installing mandel dev for use with mandel.cdt (or others)
-
-The following instructions will install mandel and the development packages.  Installing is not strictly necessary. Instructions are provided, for example, in `mandel.cdt` for development and testing against a `mandel` source build directory (which may be preferable).
-
-**Warning:** It is highly recommended to select a `CMAKE_INSTALL_PREFIX` location different than the default `/usr/local`.  Here, `$HOME/mandeldev` is used as an example that should be safe for most dev systems, but each developer should determine if another location is better suited to their specific needs.
-
-```
-git submodule update --init --recursive
-mkdir build
-cd build
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=$HOME/mandeldev ..
-make -j $(nproc) dev-install
-```
-
 ### Running tests
 
 ```


### PR DESCRIPTION
Fix issues seen with libff when trying to use mandel with mandel.cdt.

Update CMakeLists.txt to create a parallel mandel-config.cmake for use until mandel goes through renaming.

Update path to libff in fc libraries when using build from src.

Add install directions for current mandel use with mandel.cdt (or others).

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/426
Resolves: https://github.com/eosnetworkfoundation/mandel/issues/420

Supersedes: https://github.com/eosnetworkfoundation/mandel/pull/421

Relates to mandel.cdt issue/PR:
https://github.com/eosnetworkfoundation/mandel.cdt/issues/25
https://github.com/eosnetworkfoundation/mandel.cdt/pull/26