### PR TITLE
fix linking of c++ SHIP tests on boost versions prior to 1.69 - 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ set(Boost_USE_MULTITHREADED      ON)
 set( Boost_USE_STATIC_LIBS ON CACHE STRING "ON or OFF" )
 # Most boost deps get implictly picked up via fc, as just about everything links to fc. In addition we pick up
 # the pthread dependency through fc.
-find_package(Boost 1.67 REQUIRED COMPONENTS program_options unit_test_framework)
+find_package(Boost 1.67 REQUIRED COMPONENTS program_options unit_test_framework system)
 
 if( APPLE AND UNIX )
 # Apple Specific Options Here

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,9 +88,9 @@ endif()
 
 find_package(Threads)
 add_executable(ship_client ship_client.cpp)
-target_link_libraries(ship_client abieos Boost::program_options Threads::Threads)
+target_link_libraries(ship_client abieos Boost::program_options Boost::system Threads::Threads)
 add_executable(ship_streamer ship_streamer.cpp)
-target_link_libraries(ship_streamer abieos Boost::program_options Threads::Threads)
+target_link_libraries(ship_streamer abieos Boost::program_options Boost::system Threads::Threads)
 
 add_test(NAME ship_test COMMAND tests/ship_test.py -v --num-clients 1 --num-requests 5000 --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST ship_test PROPERTY LABELS nonparallelizable_tests)


### PR DESCRIPTION
asio depends on boost system and prior to boost 1.69 boost system is an actual library that needs to be linked with. Since we do claim support for boost 1.67+, this is clearly a defect, and this is the only problem using boost 1.67 (on Debian 10), let's fix it.