### PR TITLE
Backport: added a new option fix-irreversible-blocks to eosio-blocklog

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -307,15 +307,6 @@ namespace eosio { namespace chain {
             my->block_file.skip(-sizeof(uint32_t));
          }
 
-         auto reconstruct_index = [&]() {
-            if (config.fix_irreversible_blocks) {
-               block_log::repair_log(block_file.get_file_path().parent_path(), UINT32_MAX);
-               block_log::construct_index(block_file.get_file_path(), index_file.get_file_path());
-            } else {
-               log_data.construct_index(index_file.get_file_path());
-            }
-         };
-
          if (index_size) {
             ilog("Index is nonempty");
             uint64_t block_pos;
@@ -333,12 +324,9 @@ namespace eosio { namespace chain {
                ilog("Index is incomplete");
                construct_index();
             }
-            else {
-               reconstruct_index();
-            } 
          } else {
-            ilog("Index is empty. Reconstructing index...");
-            reconstruct_index();
+            ilog("Index is empty");
+            construct_index();
          }
 
          if(!is_currently_pruned && my->prune_config) {

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -307,6 +307,15 @@ namespace eosio { namespace chain {
             my->block_file.skip(-sizeof(uint32_t));
          }
 
+         auto reconstruct_index = [&]() {
+            if (config.fix_irreversible_blocks) {
+               block_log::repair_log(block_file.get_file_path().parent_path(), UINT32_MAX);
+               block_log::construct_index(block_file.get_file_path(), index_file.get_file_path());
+            } else {
+               log_data.construct_index(index_file.get_file_path());
+            }
+         };
+
          if (index_size) {
             ilog("Index is nonempty");
             uint64_t block_pos;
@@ -324,9 +333,12 @@ namespace eosio { namespace chain {
                ilog("Index is incomplete");
                construct_index();
             }
+            else {
+               reconstruct_index();
+            } 
          } else {
-            ilog("Index is empty");
-            construct_index();
+            ilog("Index is empty. Reconstructing index...");
+            reconstruct_index();
          }
 
          if(!is_currently_pruned && my->prune_config) {

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -47,6 +47,7 @@ struct blocklog {
    bool                             as_json_array = false;
    bool                             make_index = false;
    bool                             trim_log = false;
+   bool                             fix_irreversible_blocks = false;
    bool                             smoke_test = false;
    bool                             vacuum = false;
    bool                             help = false;
@@ -194,6 +195,9 @@ void blocklog::set_program_options(options_description& cli)
           "Create blocks.index from blocks.log. Must give 'blocks-dir'. Give 'output-file' relative to current directory or absolute path (default is <blocks-dir>/blocks.index).")
          ("trim-blocklog", bpo::bool_switch(&trim_log)->default_value(false),
           "Trim blocks.log and blocks.index. Must give 'blocks-dir' and 'first and/or 'last'.")
+         ("fix-irreversible-blocks", bpo::bool_switch(&fix_irreversible_blocks)->default_value(false),
+          "When the existing block log is inconsistent with the index, allows fixing the block log and index files automatically - that is, "
+          "it will take the highest indexed block if it is valid; otherwise it will repair the block log and reconstruct the index.")
          ("smoke-test", bpo::bool_switch(&smoke_test)->default_value(false),
           "Quick test that blocks.log and blocks.index are well formed and agree with each other.")
          ("vacuum", bpo::bool_switch(&vacuum)->default_value(false),
@@ -258,6 +262,12 @@ bool trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first 
    return status;
 }
 
+void fix_irreversible_blocks(bfs::path block_dir) {
+    std::cout << "\nfix_irreversible_blocks of blocks.log and blocks.index in directory " << block_dir << '\n';
+    block_log block_logger(block_dir, fc::path(), 0, 0, true);
+    std::cout << "\nSmoke test of blocks.log and blocks.index in directory " << block_dir << '\n';
+    block_log::smoke_test(block_dir, 0);
+}
 
 void smoke_test(bfs::path block_dir) {
    using namespace std;
@@ -305,6 +315,10 @@ int main(int argc, char** argv) {
       if (blog.smoke_test) {
          smoke_test(vmap.at("blocks-dir").as<bfs::path>());
          return 0;
+      }
+      if (blog.fix_irreversible_blocks) {
+          fix_irreversible_blocks(vmap.at("blocks-dir").as<bfs::path>());
+          return 0;
       }
       if (blog.trim_log) {
          if (blog.first_block == 0 && blog.last_block == std::numeric_limits<uint32_t>::max()) {

--- a/tests/block_log_util_test.py
+++ b/tests/block_log_util_test.py
@@ -204,6 +204,25 @@ try:
     # verify it shuts down cleanly
     cluster.getNode(2).interruptAndVerifyExitStatus()
 
+    # test for blocks.log
+    blockLogFileName=os.path.join(blockLogDir, "blocks.log")
+    blockIndexFileSize = os.path.getsize(blockIndexFileName)
+    blockLogFileSize = os.path.getsize(blockLogFileName)
+
+    blockLogFile = open(blockLogFileName, 'a')
+    # truncate blocks.log by 1 byte
+    blockLogFile.truncate(blockLogFileSize - 1)
+    blockLogFile.close()
+    truncatedBlockLogFileSize = os.path.getsize(blockLogFileName)
+    assert truncatedBlockLogFileSize == blockLogFileSize - 1, "blocks.log not truncated properly\n"
+
+    # fix_irreversible_blocks
+    output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.fix_irreversible_blocks)
+
+    output=cluster.getBlockLog(0, blockLogAction=BlockLogAction.smoke_test)
+    expectedStr="no problems found"
+    assert output.find(expectedStr) != -1, "Couldn't find \"%s\" in:\n\"%s\"\n" % (expectedStr, output)
+
     testSuccessful=True
 
 finally:

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -48,6 +48,7 @@ addEnum(BlockLogAction, "make_index")
 addEnum(BlockLogAction, "trim")
 addEnum(BlockLogAction, "smoke_test")
 addEnum(BlockLogAction, "return_blocks")
+addEnum(BlockLogAction, "fix_irreversible_blocks")
 
 ###########################################################################################
 class Utils:
@@ -379,6 +380,8 @@ class Utils:
             blockLogActionStr=" --make-index "
         elif blockLogAction==BlockLogAction.trim:
             blockLogActionStr=" --trim "
+        elif blockLogAction==BlockLogAction.fix_irreversible_blocks:
+            blockLogActionStr=" --fix-irreversible-blocks "
         elif blockLogAction==BlockLogAction.smoke_test:
             blockLogActionStr=" --smoke-test "
         else:


### PR DESCRIPTION
Backports: https://github.com/EOSIO/eos/pull/9245

Provide --fix-irreversible-blocks to fix inconsistent block log and index files automatically. This addresses https://github.com/EOSIO/eos/issues/8940.

providing --fix-irreversible-blocks flag on eosio-blocklog as in nodeos

> Change Description
> eosio-blocklog has a new runtime option: --fix-irreversible-blocks : When the existing block log is inconsistent with the index,
> allows fixing the block log and index files automatically - that is, it will take the highest indexed block if it is valid; otherwise it will repair the block log and reconstruct the index.
> 
> The existing --smoke-test flag can be used to test the integrity of the blocks.log and blocks.index files.
> 
> Change Type
> Select ONE
> 
>  Documentation
>  Stability bug fix
>  Other
>  Other - special case
> Consensus Changes
>  Consensus Changes
> API Changes
>  API Changes
> Documentation Additions
> [x ] Documentation Additions
> eosio-blocklog --help will show the following new flag.
> --fix-irreversible-blocks When the existing block log is
> inconsistent with the index, allows
> fixing the block log and index files
> automatically - that is, it will take
> the highest indexed block if it is
> valid; otherwise it will repair the
> block log and reconstruct the index.

Backports: https://github.com/EOSIO/eos/pull/10086 at the same time, as it allows no index file.

> This PR allows fix_irreversible_blocks to take effect even when block index file is not available.


Resolves: https://github.com/eosnetworkfoundation/mandel/issues/407