### PR TITLE
CLEOS -- Do not throw but print non-JSON formatted error message

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -253,7 +253,14 @@ namespace eosio { namespace client { namespace http {
       throw;
    }
 
-   const auto response_result = fc::json::from_string(re);
+   fc::variant response_result;
+   try {
+      response_result = fc::json::from_string(re);
+   } catch(...) {
+      // re reported below if print_response requested
+      print_response = true;
+   }
+
    if( print_response ) {
       std::cerr << "RESPONSE:" << std::endl
                 << "---------------------" << std::endl


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/10070
Resolve https://github.com/eosnetworkfoundation/mandel/issues/413

Before the change, `cleos` would throw when an error message was not JSON formatted. After the change, `cleos` will not throw and will print out the error message.