### PR TITLE
misc pinned build script fixes - 3.1

### DIFF
--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#!/usr/bin/env bash
 
 apt-get update
 apt-get update --fix-missing

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,4 +3,4 @@
 apt-get update
 apt-get update --fix-missing
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libcurl4-openssl-dev libgmp-dev libssl-dev libusb-1.0.0-dev libzstd-dev time pkg-config zlib1g-dev libtinfo-dev bzip2 libbz2-dev
+apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libcurl4-openssl-dev libgmp-dev libssl-dev libusb-1.0.0-dev libzstd-dev time pkg-config zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3

--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -31,7 +31,6 @@ JOBS=$3
 CLANG_VER=11.0.1
 BOOST_VER=1.70.0
 LLVM_VER=7.1.0
-LIBPQXX_VER=7.2.1
 ARCH=`uname -m`
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
 START_DIR="$(pwd)"

--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -130,7 +130,7 @@ pushdir ${MANDEL_DIR}
 
 # build Mandel
 echo "Building Mandel ${SCRIPT_DIR}"
-try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin -S${SCRIPT_DIR}/..
+try cmake -DCMAKE_TOOLCHAIN_FILE=${SCRIPT_DIR}/pinned_toolchain.cmake -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${LLVM_DIR}/lib/cmake -DCMAKE_PREFIX_PATH=${BOOST_DIR}/bin ${SCRIPT_DIR}/..
 
 try make -j${JOBS}
 try cpack

--- a/scripts/pinned_build.sh
+++ b/scripts/pinned_build.sh
@@ -1,4 +1,4 @@
-#! /usr/bin/bash
+#!/usr/bin/env bash
 
 echo "Mandel Pinned Build"
 


### PR DESCRIPTION
Resolves #356 but also other issues I've encountered when using the script on all Ubuntu versions: python needs to be installed, and on Ubuntu 18 it's an old cmake so can't use `-S` argument on cmake