### PR TITLE
[3.2] cleos Http 1.1 support and improves response handling

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -195,7 +195,7 @@ namespace eosio { namespace client { namespace http {
    boost::asio::streambuf request;
    std::ostream request_stream(&request);
    auto host_header_value = format_host_header(url);
-   request_stream << "POST " << url.path << " HTTP/1.0\r\n";
+   request_stream << "POST " << url.path << " HTTP/1.1\r\n";
    request_stream << "Host: " << host_header_value << "\r\n";
    request_stream << "content-length: " << postjson.size() << "\r\n";
    request_stream << "Accept: */*\r\n";
@@ -253,14 +253,15 @@ namespace eosio { namespace client { namespace http {
       throw;
    }
 
-   const auto response_result = fc::json::from_string(re);
    if( print_response ) {
       std::cerr << "RESPONSE:" << std::endl
                 << "---------------------" << std::endl
-                << fc::json::to_pretty_string( response_result ) << std::endl
+                << re << std::endl
                 << "---------------------" << std::endl;
    }
+
    if( status_code == 200 || status_code == 201 || status_code == 202 ) {
+      auto response_result = fc::json::from_string(re);
       return response_result;
    } else if( status_code == 404 ) {
       // Unknown endpoint
@@ -278,6 +279,7 @@ namespace eosio { namespace client { namespace http {
          }
       }
    } else {
+      auto response_result = fc::json::from_string(re);
       auto &&error_info = response_result.as<eosio::error_results>().error;
       // Construct fc exception from error
       const auto &error_details = error_info.details;
@@ -292,6 +294,6 @@ namespace eosio { namespace client { namespace http {
    }
 
    EOS_ASSERT( status_code == 200, http_request_fail, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re) );
-   return response_result;
+   return variant();
    }
 }}}

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -253,15 +253,21 @@ namespace eosio { namespace client { namespace http {
       throw;
    }
 
+   fc::variant response_result;
+   try {
+      response_result = fc::json::from_string(re);
+   } catch(...) {
+      // re reported below if print_response requested
+   }
+
    if( print_response ) {
       std::cerr << "RESPONSE:" << std::endl
                 << "---------------------" << std::endl
-                << re << std::endl
+                << ( response_result.is_null() ? re : fc::json::to_pretty_string( response_result ) ) << std::endl
                 << "---------------------" << std::endl;
    }
 
    if( status_code == 200 || status_code == 201 || status_code == 202 ) {
-      auto response_result = fc::json::from_string(re);
       return response_result;
    } else if( status_code == 404 ) {
       // Unknown endpoint
@@ -279,7 +285,6 @@ namespace eosio { namespace client { namespace http {
          }
       }
    } else {
-      auto response_result = fc::json::from_string(re);
       auto &&error_info = response_result.as<eosio::error_results>().error;
       // Construct fc exception from error
       const auto &error_details = error_info.details;
@@ -294,6 +299,6 @@ namespace eosio { namespace client { namespace http {
    }
 
    EOS_ASSERT( status_code == 200, http_request_fail, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re) );
-   return variant();
+   return response_result;
    }
 }}}

--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -267,38 +267,37 @@ namespace eosio { namespace client { namespace http {
                 << "---------------------" << std::endl;
    }
 
-   if( status_code == 200 || status_code == 201 || status_code == 202 ) {
-      return response_result;
-   } else if( status_code == 404 ) {
-      // Unknown endpoint
-      if (url.path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
-         throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled"));
-      } else if (url.path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
-         throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available"));
-      } else if (url.path.compare(0, history_func_base.size(), history_func_base) == 0) {
-         throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API plugin is not enabled"));
-      } else if (url.path.compare(0, net_func_base.size(), net_func_base) == 0) {
-         throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled"));
-      } else if (url.path.compare(0, trace_api_func_base.size(), trace_api_func_base) == 0) {
-         if ( re.find("Trace API:") == string::npos ) {
-            throw chain::missing_trace_api_plugin_exception(FC_LOG_MESSAGE(error, "Trace API plugin is not enabled"));
+   if( !response_result.is_null() ) {
+      if( status_code == 200 || status_code == 201 || status_code == 202 ) {
+         return response_result;
+      } else if( status_code == 404 ) {
+         // Unknown endpoint
+         if (url.path.compare(0, chain_func_base.size(), chain_func_base) == 0) {
+            throw chain::missing_chain_api_plugin_exception(FC_LOG_MESSAGE(error, "Chain API plugin is not enabled"));
+         } else if (url.path.compare(0, wallet_func_base.size(), wallet_func_base) == 0) {
+            throw chain::missing_wallet_api_plugin_exception(FC_LOG_MESSAGE(error, "Wallet is not available"));
+         } else if (url.path.compare(0, history_func_base.size(), history_func_base) == 0) {
+            throw chain::missing_history_api_plugin_exception(FC_LOG_MESSAGE(error, "History API plugin is not enabled"));
+         } else if (url.path.compare(0, net_func_base.size(), net_func_base) == 0) {
+            throw chain::missing_net_api_plugin_exception(FC_LOG_MESSAGE(error, "Net API plugin is not enabled"));
          }
-      }
-   } else {
-      auto &&error_info = response_result.as<eosio::error_results>().error;
-      // Construct fc exception from error
-      const auto &error_details = error_info.details;
+      } else {
+         auto &&error_info = response_result.as<eosio::error_results>().error;
+         // Construct fc exception from error
+         const auto &error_details = error_info.details;
 
-      fc::log_messages logs;
-      for (auto itr = error_details.begin(); itr != error_details.end(); itr++) {
-         const auto& context = fc::log_context(fc::log_level::error, itr->file.data(), itr->line_number, itr->method.data());
-         logs.emplace_back(fc::log_message(context, itr->message));
-      }
+         fc::log_messages logs;
+         for (auto itr = error_details.begin(); itr != error_details.end(); itr++) {
+            const auto& context = fc::log_context(fc::log_level::error, itr->file.data(), itr->line_number, itr->method.data());
+            logs.emplace_back(fc::log_message(context, itr->message));
+         }
 
-      throw fc::exception(logs, error_info.code, error_info.name, error_info.what);
+         throw fc::exception(logs, error_info.code, error_info.name, error_info.what);
+      }
    }
 
-   EOS_ASSERT( status_code == 200, http_request_fail, "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re) );
+   EOS_ASSERT( status_code == 200 && !response_result.is_null(), http_request_fail,
+               "Error code ${c}\n: ${msg}\n", ("c", status_code)("msg", re) );
    return response_result;
    }
 }}}


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/9349
Resolve https://github.com/eosnetworkfoundation/mandel/issues/430

From the original PR:

- Upgrades cleos http 1.0 to 1.1: in more advanced cloud stacks cleos is being rejected by gateways or proxies with HTTP status 426:
The HTTP 426 Upgrade Required client error response code indicates that the server refuses to perform the request using the current protocol but might be willing to do so after the client upgrades to a different protocol. The server sends an Upgrade header with this response to indicate the required protocol(s).

- Removes unnecessary json parsing if it's an error code
- Straight dump responses for --print-response if unable to convert to variant
