### PR TITLE
Add extract-blocks option to eosio-blocklog

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -1185,31 +1185,29 @@ namespace eosio { namespace chain {
       }
    }
 
-   bool block_log::trim_blocklog_front(const fc::path& block_dir, const fc::path& temp_dir, uint32_t truncate_at_block) {
-      using namespace std;
-      EOS_ASSERT( block_dir != temp_dir, block_log_exception, "block_dir and temp_dir need to be different directories" );
-      ilog("In directory ${dir} will trim all blocks before block ${n} from blocks.log and blocks.index.",
-           ("dir", block_dir.generic_string())("n", truncate_at_block));
+   bool block_log::extract_block_range(const fc::path& block_dir, const fc::path&output_dir, block_num_type& start, block_num_type& end, bool rename_input, progress_function&& progress) {
+      EOS_ASSERT( block_dir != output_dir, block_log_exception, "block_dir and output_dir need to be different directories" );
       trim_data original_block_log(block_dir);
-      if (truncate_at_block <= original_block_log.first_block) {
-         ilog("There are no blocks before block ${n} so do nothing.", ("n", truncate_at_block));
-         return false;
+      if(start < original_block_log.first_block) {
+         dlog("Requested start block of ${start} is less than the first available block ${n}; adjusting to ${n}", ("start", start)("n", original_block_log.first_block));
+         start = original_block_log.first_block;
       }
-      if (truncate_at_block > original_block_log.last_block) {
-         ilog("All blocks are before block ${n} so do nothing (trim front would delete entire blocks.log).", ("n", truncate_at_block));
-         return false;
+      if(end > original_block_log.last_block) {
+         dlog("Requested end block of ${end} is greater than the last available block ${n}; adjusting to ${n}", ("end", end)("n", original_block_log.last_block));
+         end = original_block_log.last_block;
       }
-
+      ilog("In directory ${ouput} will create new block log with range ${start}-${end}",
+           ("output", output_dir.generic_string())("start", start)("end", end));
       // ****** create the new block log file and write out the header for the file
-      fc::create_directories(temp_dir);
-      fc::path new_block_filename = temp_dir / "blocks.log";
+      fc::create_directories(output_dir);
+      fc::path new_block_filename = output_dir / "blocks.log";
       if (fc::remove(new_block_filename)) {
-         ilog("Removing old blocks.out file");
+         ilog("Removing existing blocks.log file");
       }
       fc::cfile new_block_file;
       new_block_file.set_file_path(new_block_filename);
-      // need to open as append since the file doesn't already exist, then reopen without append to allow writing the
-      // file in any order
+      // need to open as write since the file doesn't already exist, then reopen
+      // with read/write to allow writing the file in any order
       new_block_file.open( LOG_WRITE_C );
       new_block_file.close();
       new_block_file.open( LOG_RW_C );
@@ -1219,37 +1217,49 @@ namespace eosio { namespace chain {
       uint32_t version = block_log::max_supported_version;
       new_block_file.seek(0);
       new_block_file.write((char*)&version, sizeof(version));
-      new_block_file.write((char*)&truncate_at_block, sizeof(truncate_at_block));
+      new_block_file.write((char*)&start, sizeof(start));
 
-      new_block_file << original_block_log.chain_id;
+      if (start > 1) {
+         new_block_file << original_block_log.chain_id;
+      } else {
+         fc::raw::pack(new_block_file, original_block_log.gs);
+      }
 
       // append a totem to indicate the division between blocks and header
       auto totem = block_log::npos;
       new_block_file.write((char*)&totem, sizeof(totem));
-
-      const auto new_block_file_first_block_pos = new_block_file.tellp();
       // ****** end of new block log header
 
+      const auto new_block_file_first_block_pos = new_block_file.tellp();
+
       // copy over remainder of block log to new block log
-      auto buffer =  make_unique<char[]>(detail::reverse_iterator::_buf_len);
+      auto buffer =  std::make_unique<char[]>(detail::reverse_iterator::_buf_len);
       char* buf =  buffer.get();
 
       // offset bytes to shift from old blocklog position to new blocklog position
-      const uint64_t original_file_block_pos = original_block_log.block_pos(truncate_at_block);
-      const uint64_t pos_delta = original_file_block_pos - new_block_file_first_block_pos;
-      auto status = fseek(original_block_log.blk_in, 0, SEEK_END);
-      EOS_ASSERT( status == 0, block_log_exception, "blocks.log seek failed" );
+      uint64_t original_file_start_block_pos = original_block_log.block_pos(start);
+      const uint64_t pos_delta = original_file_start_block_pos - new_block_file_first_block_pos;
+      uint64_t original_file_end_block_pos;
+      if (end == original_block_log.last_block) {
+         auto status = fseek(original_block_log.blk_in, 0, SEEK_END);
+         EOS_ASSERT( status == 0, block_log_exception, "blocks.log seek failed" );
+         original_file_end_block_pos = ftell(original_block_log.blk_in);
+      } else {
+         original_file_end_block_pos = original_block_log.block_pos(end+1);
+         auto status = fseek(original_block_log.blk_in, original_file_end_block_pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "blocks.log seek failed" );
+      }
 
-      // all blocks to copy to the new blocklog
-      const uint64_t to_write = ftell(original_block_log.blk_in) - original_file_block_pos;
-      const auto pos_size = sizeof(uint64_t);
+      // all bytes to copy to the new blocklog
+      const uint64_t to_write = original_file_end_block_pos - original_file_start_block_pos;
 
       // start with the last block's position stored at the end of the block
-      uint64_t original_pos = ftell(original_block_log.blk_in) - pos_size;
+      const auto pos_size = sizeof(uint64_t);
+      uint64_t original_pos = original_file_end_block_pos - pos_size;
 
-      const auto num_blocks = original_block_log.last_block - truncate_at_block + 1;
+      const auto num_blocks = end - start + 1;
 
-      fc::path new_index_filename = temp_dir / "blocks.index";
+      fc::path new_index_filename = output_dir / "blocks.index";
       detail::index_writer index(new_index_filename, num_blocks);
 
       uint64_t read_size = 0;
@@ -1261,10 +1271,11 @@ namespace eosio { namespace chain {
          }
 
          // read in the previous contiguous memory into the read buffer
-         const auto start_of_blk_buffer_pos = original_file_block_pos + to_write_remaining - read_size;
-         status = fseek(original_block_log.blk_in, start_of_blk_buffer_pos, SEEK_SET);
+         const auto start_of_blk_buffer_pos = original_file_start_block_pos + to_write_remaining - read_size;
+         auto status = fseek(original_block_log.blk_in, start_of_blk_buffer_pos, SEEK_SET);
+         EOS_ASSERT( status == 0, block_log_exception, "original blocks.log seek failed" );
          const auto num_read = fread(buf, read_size, 1, original_block_log.blk_in);
-         EOS_ASSERT( num_read == 1, block_log_exception, "blocks.log read failed" );
+         EOS_ASSERT( num_read == 1, block_log_exception, "original blocks.log read failed" );
 
          // walk this memory section to adjust block position to match the adjusted location
          // of the block start and store in the new index file
@@ -1286,6 +1297,7 @@ namespace eosio { namespace chain {
          new_block_file.seek(new_block_file_first_block_pos + to_write_remaining - write_size);
          uint64_t offset = read_size - write_size;
          new_block_file.write(buf+offset, write_size);
+         progress(static_cast<double>(to_write - to_write_remaining)/to_write);
       }
 
       fclose(original_block_log.blk_in);
@@ -1293,12 +1305,14 @@ namespace eosio { namespace chain {
       new_block_file.flush();
       new_block_file.close();
 
-      fc::path old_log = temp_dir / "old.log";
-      rename(original_block_log.block_file_name, old_log);
-      rename(new_block_filename, original_block_log.block_file_name);
-      fc::path old_ind = temp_dir / "old.index";
-      rename(original_block_log.index_file_name, old_ind);
-      rename(new_index_filename, original_block_log.index_file_name);
+      if (rename_input) {
+         fc::path old_log = output_dir / "old.log";
+         rename(original_block_log.block_file_name, old_log);
+         rename(new_block_filename, original_block_log.block_file_name);
+         fc::path old_ind = output_dir / "old.index";
+         rename(original_block_log.index_file_name, old_ind);
+         rename(new_index_filename, original_block_log.index_file_name);
+      }
 
       return true;
    }
@@ -1333,7 +1347,6 @@ namespace eosio { namespace chain {
          EOS_ASSERT(size == 1, block_log_exception, "invalid format for file ${file}",
                     ("file", block_file_name.string()));
          if (block_log::contains_genesis_state(version, first_block)) {
-            genesis_state gs;
             fc::raw::unpack(ds, gs);
             chain_id = gs.compute_chain_id();
          }

--- a/libraries/chain/include/eosio/chain/block_log.hpp
+++ b/libraries/chain/include/eosio/chain/block_log.hpp
@@ -7,6 +7,8 @@ namespace eosio { namespace chain {
 
    namespace detail { class block_log_impl; }
 
+   using progress_function = std::function<void(const double)>;
+
    /* The block log is an external append only log of the blocks with a header. Blocks should only
     * be written to the log after they irreverisble as the log is append only. The log is a doubly
     * linked list of blocks. There is a secondary index file of only block positions that enables
@@ -91,7 +93,7 @@ namespace eosio { namespace chain {
 
          static bool is_pruned_log(const fc::path& data_dir);
 
-         static bool trim_blocklog_front(const fc::path& block_dir, const fc::path& temp_dir, uint32_t truncate_at_block);
+         static bool extract_block_range(const fc::path& block_dir, const fc::path&output_dir, block_num_type& start, block_num_type& end, bool rename_input=false, progress_function&& progress=[](const double){});
 
    private:
          void open(const fc::path& data_dir);
@@ -119,6 +121,7 @@ namespace eosio { namespace chain {
       FILE* ind_in = nullptr;                            //C style files for reading blocks.log and blocks.index
       //we use low level file IO because it is distinctly faster than C++ filebuf or iostream
       uint64_t first_block_pos = 0;                      //file position in blocks.log for the first block in the log
+      genesis_state gs;
       chain_id_type chain_id;
 
       static constexpr int blknum_offset{14};            //offset from start of block to 4 byte block number, valid for the only allowed versions

--- a/programs/eosio-blocklog/CMakeLists.txt
+++ b/programs/eosio-blocklog/CMakeLists.txt
@@ -1,14 +1,22 @@
 add_executable( eosio-blocklog main.cpp )
 
+find_package(progressbar 2.0 QUIET)
+
+if(progressbar_FOUND)
+  message(STATUS "Enabling progressbar in eosio-blocklog")
+endif()
+
 if( UNIX AND NOT APPLE )
   set(rt_library rt )
 endif()
 
-target_include_directories(eosio-blocklog PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
+configure_file(config.hpp.in config.hpp ESCAPE_QUOTES)
+
+target_include_directories(eosio-blocklog PUBLIC ${LIBPROGRESSBAR_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
 
 target_link_libraries( eosio-blocklog
         PRIVATE appbase
-        PRIVATE eosio_chain fc ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
+        PRIVATE eosio_chain fc ${LIBPROGRESSBAR_LIBRARIES} ${CMAKE_DL_LIBS} ${PLATFORM_SPECIFIC_LIBS} )
 
 copy_bin( eosio-blocklog )
 install( TARGETS

--- a/programs/eosio-blocklog/config.hpp.in
+++ b/programs/eosio-blocklog/config.hpp.in
@@ -1,0 +1,11 @@
+/**
+ * \warning This file is machine generated. DO NOT EDIT.  See config.hpp.in for changes.
+ */
+#pragma once
+
+#ifndef CONFIG_HPP_IN
+#define CONFIG_HPP_IN
+
+#define ENABLE_PROGRESSBAR ${progressbar_FOUND}
+
+#endif // CONFIG_HPP_

--- a/programs/eosio-blocklog/main.cpp
+++ b/programs/eosio-blocklog/main.cpp
@@ -16,6 +16,12 @@
 
 #include <chrono>
 
+#include "config.hpp"
+
+#if ENABLE_PROGRESSBAR
+  #include <progressbar/progressbar.h>
+#endif
+
 #ifndef _WIN32
 #define FOPEN(p, m) fopen(p, m)
 #else
@@ -47,6 +53,7 @@ struct blocklog {
    bool                             as_json_array = false;
    bool                             make_index = false;
    bool                             trim_log = false;
+   bool                             extract_blocks = false;
    bool                             smoke_test = false;
    bool                             vacuum = false;
    bool                             help = false;
@@ -193,7 +200,11 @@ void blocklog::set_program_options(options_description& cli)
          ("make-index", bpo::bool_switch(&make_index)->default_value(false),
           "Create blocks.index from blocks.log. Must give 'blocks-dir'. Give 'output-file' relative to current directory or absolute path (default is <blocks-dir>/blocks.index).")
          ("trim-blocklog", bpo::bool_switch(&trim_log)->default_value(false),
-          "Trim blocks.log and blocks.index. Must give 'blocks-dir' and 'first and/or 'last'.")
+          "Trim blocks.log and blocks.index. Must give 'blocks-dir' and 'first' and/or 'last'.")
+         ("extract-blocks", bpo::bool_switch(&extract_blocks)->default_value(false),
+          "Extract range of blocks from blocks.log and write to output-dir.  Must give 'first' and/or 'last'.")
+         ("output-dir", bpo::value<bfs::path>(),
+          "the output directory for the block log extracted from blocks-dir")
          ("smoke-test", bpo::bool_switch(&smoke_test)->default_value(false),
           "Quick test that blocks.log and blocks.index are well formed and agree with each other.")
          ("vacuum", bpo::bool_switch(&vacuum)->default_value(false),
@@ -253,7 +264,25 @@ int trim_blocklog_end(bfs::path block_dir, uint32_t n) {       //n is last block
 
 bool trim_blocklog_front(bfs::path block_dir, uint32_t n) {        //n is first block to keep (remove prior blocks)
    report_time rt("trimming blocklog start");
-   const bool status = block_log::trim_blocklog_front(block_dir, block_dir / "old", n);
+   block_num_type end = std::numeric_limits<block_num_type>::max();
+   const bool status = block_log::extract_block_range(block_dir, block_dir / "old", n, end, true);
+   rt.report();
+   return status;
+}
+
+bool extract_block_range(bfs::path block_dir, bfs::path output_dir, uint32_t start, uint32_t end) {
+   report_time rt("extracting block range");
+   EOS_ASSERT( end > start, block_log_exception, "extract range end must be greater than start");
+#if ENABLE_PROGRESSBAR
+   progressbar *bar = progressbar_new_percent_with_format_and_tumbler("Extracting:", "[= ]", "/-\\|");
+   auto progress_increment = [bar](const double percent){progressbar_update_percent(bar, percent);};
+#else
+   auto progress_increment = [](){};
+#endif
+   const bool status = block_log::extract_block_range(block_dir, output_dir, start, end, false, std::move(progress_increment));
+#if ENABLE_PROGRESSBAR
+   progressbar_finish(bar);
+#endif
    rt.report();
    return status;
 }
@@ -308,7 +337,7 @@ int main(int argc, char** argv) {
       }
       if (blog.trim_log) {
          if (blog.first_block == 0 && blog.last_block == std::numeric_limits<uint32_t>::max()) {
-            std::cerr << "trim-blocklog does nothing unless specify first and/or last block.";
+            std::cerr << "trim-blocklog does nothing unless first and/or last block are specified.";
             return -1;
          }
          if (blog.last_block != std::numeric_limits<uint32_t>::max()) {
@@ -319,6 +348,15 @@ int main(int argc, char** argv) {
             if (!trim_blocklog_front(vmap.at("blocks-dir").as<bfs::path>(), blog.first_block))
                return -1;
          }
+         return 0;
+      }
+      if (blog.extract_blocks) {
+         if (blog.first_block == 0 && blog.last_block == std::numeric_limits<uint32_t>::max()) {
+            std::cerr << "extract-blocklog does nothing unless first and/or last block are specified.";
+            return -1;
+         }
+         if (!extract_block_range(vmap.at("blocks-dir").as<bfs::path>(), vmap.at("output-dir").as<bfs::path>(), blog.first_block, blog.last_block))
+            return -1;
          return 0;
       }
       if (blog.vacuum) {

--- a/unittests/block_log_extract.cpp
+++ b/unittests/block_log_extract.cpp
@@ -1,0 +1,100 @@
+#include <boost/test/unit_test.hpp>
+
+#include <fc/bitutil.hpp>
+
+#include <eosio/chain/block_log.hpp>
+#include <eosio/chain/block.hpp>
+
+using namespace eosio::chain;
+
+struct block_log_extract_fixture {
+   block_log_extract_fixture() {
+      log.emplace(dir.path(), std::optional<block_log_prune_config>());
+      log->reset(genesis_state(), std::make_shared<signed_block>());
+      BOOST_REQUIRE_EQUAL(log->first_block_num(), 1);
+      BOOST_REQUIRE_EQUAL(log->head()->block_num(), 1);
+      for(uint32_t i = 2; i < 13; ++i) {
+         add(i);
+      }
+      BOOST_REQUIRE_EQUAL(log->head()->block_num(), 12);
+   };
+
+   void add(uint32_t index) {
+      signed_block_ptr p = std::make_shared<signed_block>();
+      p->previous._hash[0] = fc::endian_reverse_u32(index-1);
+      log->append(p);
+   }
+
+   genesis_state gs;
+   fc::temp_directory dir;
+   std::optional<block_log> log;
+};
+
+BOOST_AUTO_TEST_SUITE(block_log_extraction_tests)
+
+BOOST_FIXTURE_TEST_CASE(extract_from_middle, block_log_extract_fixture) try {
+
+   fc::temp_directory output_dir;
+   block_num_type start=3, end=7;
+   block_log::extract_block_range(dir.path(), output_dir.path(), start, end);
+
+   block_log new_log(output_dir.path(), std::optional<block_log_prune_config>());
+
+   auto id = gs.compute_chain_id();
+   BOOST_REQUIRE_EQUAL(new_log.extract_chain_id(output_dir.path()), id);
+   BOOST_REQUIRE_EQUAL(new_log.first_block_num(), 3);
+   BOOST_REQUIRE_EQUAL(new_log.head()->block_num(), 7);
+
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(extract_from_start, block_log_extract_fixture) try {
+
+   fc::temp_directory output_dir;
+   block_num_type start=0, end=7;
+   block_log::extract_block_range(dir.path(), output_dir.path(), start, end);
+
+   block_log new_log(output_dir.path(), std::optional<block_log_prune_config>());
+
+   auto id = gs.compute_chain_id();
+   BOOST_REQUIRE_EQUAL(new_log.extract_chain_id(output_dir.path()), id);
+   BOOST_REQUIRE_EQUAL(new_log.first_block_num(), 1);
+   BOOST_REQUIRE_EQUAL(new_log.head()->block_num(), 7);
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(reextract_from_start, block_log_extract_fixture) try {
+
+   fc::temp_directory output_dir;
+   block_num_type start=0, end=9;
+   block_log::extract_block_range(dir.path(), output_dir.path(), start, end);
+
+   fc::temp_directory output_dir2;
+   end=6;
+   block_log::extract_block_range(output_dir.path(), output_dir2.path(), start, end);
+
+   block_log new_log(output_dir2.path(), std::optional<block_log_prune_config>());
+
+   auto id = gs.compute_chain_id();
+   BOOST_REQUIRE_EQUAL(new_log.extract_chain_id(output_dir2.path()), id);
+   BOOST_REQUIRE_EQUAL(new_log.first_block_num(), 1);
+   BOOST_REQUIRE_EQUAL(new_log.head()->block_num(), 6);
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(extract_to_end, block_log_extract_fixture) try {
+
+   fc::temp_directory output_dir;
+   block_num_type start=5, end=std::numeric_limits<block_num_type>::max();
+   block_log::extract_block_range(dir.path(), output_dir.path(), start, end);
+
+   block_log new_log(output_dir.path(), std::optional<block_log_prune_config>());
+
+   auto id = gs.compute_chain_id();
+   BOOST_REQUIRE_EQUAL(new_log.extract_chain_id(output_dir.path()), id);
+   BOOST_REQUIRE_EQUAL(new_log.first_block_num(), 5);
+   BOOST_REQUIRE_EQUAL(new_log.head()->block_num(), 12);
+
+} FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittests/restart_chain_tests.cpp
+++ b/unittests/restart_chain_tests.cpp
@@ -130,7 +130,8 @@ void trim_blocklog_front(uint32_t truncate_at_block, buf_len_type len_type) {
          return;
    }
 
-   BOOST_CHECK( block_log::trim_blocklog_front(temp1.path, temp2.path, truncate_at_block) == true);
+   block_num_type end = std::numeric_limits<block_num_type>::max();
+   BOOST_CHECK( block_log::extract_block_range(temp1.path, temp2.path, truncate_at_block, end) == true);
    trim_data new_log(temp1.path);
    BOOST_CHECK(new_log.first_block == truncate_at_block);
    BOOST_CHECK(new_log.last_block == old_log.last_block);


### PR DESCRIPTION
Adds `--extract-blocks` option to the `eosio-blocklog` tool, along with an accompanying `--output-dir` option.  This option extracts the range of blocks specified by the `-f` or `--first` block option and the `-l` or `--last` block option and writes a new block log with accompanying index file to the directory specified by the `--output-dir` option.  At least one of `--first` or `--last` must be specified.