### PR TITLE
[3.2] CLEOS -- prints out non-JSON formatted HTTP responses

### DIFF
--- a/programs/cleos/httpc.cpp
+++ b/programs/cleos/httpc.cpp
@@ -258,6 +258,7 @@ namespace eosio { namespace client { namespace http {
       response_result = fc::json::from_string(re);
    } catch(...) {
       // re reported below if print_response requested
+      print_response = true;
    }
 
    if( print_response ) {


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/10070
Resolve https://github.com/eosnetworkfoundation/mandel/issues/413

Make `cleos` print out non-JSON formatted HTTP responses (errors).