### PR TITLE
[3.1] Fix log trimming of hex_data JSON output.

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -475,7 +475,7 @@ namespace impl {
                      binary_to_variant_context _ctx(*abi, ctx, type);
                      _ctx.short_path = true; // Just to be safe while avoiding the complexity of threading an override boolean all over the place
                      mvo( "data", abi->_binary_to_variant( type, act.data, _ctx ));
-                     mvo("hex_data", act.data);
+                     set_hex_data(mvo, "hex_data", act.data);
                   } catch(...) {
                      // any failure to serialize data, then leave as not serailzed
                      set_hex_data(mvo, "data", act.data);

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -1196,6 +1196,18 @@ launcher_def::write_logging_config_file(tn_node_def &node) {
   if( gelf_enabled ) tft.appenders.push_back( "net" );
   log_config.loggers.emplace_back( tft );
 
+  fc::logger_config tts( "transaction_trace_success" );
+  tts.level = fc::log_level::debug;
+  tts.appenders.push_back( "stderr" );
+  if( gelf_enabled ) tts.appenders.push_back( "net" );
+  log_config.loggers.emplace_back( tts );
+
+   fc::logger_config ttf( "transaction_trace_failure" );
+   ttf.level = fc::log_level::debug;
+   ttf.appenders.push_back( "stderr" );
+   if( gelf_enabled ) ttf.appenders.push_back( "net" );
+   log_config.loggers.emplace_back( ttf );
+
   fc::logger_config ta( "trace_api" );
   ta.level = fc::log_level::debug;
   ta.appenders.push_back( "stderr" );


### PR DESCRIPTION
Merge issue of https://github.com/eosnetworkfoundation/mandel/pull/190 missed trimming the "hex_data" attribute in logged transaction trace data.

Added `transaction_trace_success` and `transaction_trace_failure` trace loggers to `eosio-launcher` to provide additional logging during tests.

Example:

`debug 2022-06-25T18:48:07.183 nodeos    producer_plugin.cpp:642       operator()           ] [TRX_TRACE] Speculative execution is ACCEPTING tx: {"id":"17ad680cbb16e142f0fc4e0b50a0a5be59362098056c969bb5a7ee00e9beee1c","block_num":18,"block_time":"2022-06-25T18:48:07.500","producer_block_id":null,"receipt":{"status":"executed","cpu_usage_us":2721,"net_usage_words":878},"elapsed":5525,"net_usage":7024,"scheduled":false,"action_traces":[{"action_ordinal":1,"creator_action_ordinal":0,"closest_unnotified_ancestor_action_ordinal":0,"receipt":{"receiver":"eosio","act_digest":"9a90c525172f87bbac0a6378610727f0fe1d7ebe908df973923d29a1606f9a57","global_sequence":18,"recv_sequence":18,"auth_sequence":[["eosio",18]],"code_sequence":1,"abi_sequence":0},"receiver":"eosio","act":{"account":"eosio","name":"setcode","authorization":[{"actor":"eosio","permission":"active"}],"code_hash":"1f5c063768890aad54a6b7079606e4b683e37d8fcf270dfacd9df05f5569348c","data":{"account":"eosio","vmtype":0,"vmversion":0,"code":{"size":17777,"trimmed_hex":"0061736d01000000019d011a60000060037f7e7f0060027f7e0060027f7f0060057f7e7e7e7e0060047f7e7e7e0060017f017f60017f0060037f7f7f017f6000"}},"hex_data":{"size":17790,"trimmed_hex":"0000000000ea30550000f18a010061736d01000000019d011a60000060037f7e7f0060027f7e0060027f7f0060057f7e7e7e7e0060047f7e7e7e0060017f017f"}},"context_free":false,"elapsed":2331,"console":"","trx_id":"17ad680cbb16e142f0fc4e0b50a0a5be59362098056c969bb5a7ee00e9beee1c","block_num":18,"block_time":"2022-06-25T18:48:07.500","producer_block_id":null,"account_ram_deltas":[{"account":"eosio","delta":177770}],"except":null,"error_code":null,"return_value_hex_data":""},{"action_ordinal":2,"creator_action_ordinal":0,"closest_unnotified_ancestor_action_ordinal":0,"receipt":{"receiver":"eosio","act_digest":"e7de58a9939c6e694d3235202685f51b7fab8e82b1f9f96a637dafd9be0998a2","global_sequence":19,"recv_sequence":19,"auth_sequence":[["eosio",19]],"code_sequence":1,"abi_sequence":1},"receiver":"eosio","act":{"account":"eosio","name":"setabi","authorization":[{"actor":"eosio","permission":"active"}],"data":{"account":"eosio","abi":{"size":2176,"trimmed_hex":"0e656f73696f3a3a6162692f312e310019086162695f686173680002056f776e6572046e616d6504686173680b636865636b73756d3235360861637469766174"}},"hex_data":{"size":2186,"trimmed_hex":"0000000000ea305580110e656f73696f3a3a6162692f312e310019086162695f686173680002056f776e6572046e616d6504686173680b636865636b73756d32"}},"context_free":false,"elapsed":2951,"console":"","trx_id":"17ad680cbb16e142f0fc4e0b50a0a5be59362098056c969bb5a7ee00e9beee1c","block_num":18,"block_time":"2022-06-25T18:48:07.500","producer_block_id":null,"account_ram_deltas":[{"account":"eosio","delta":308}],"except":null,"error_code":null,"return_value_hex_data":""}],"account_ram_delta":null,"except":null,"error_code":null}`

Resolves #538 