### PR TITLE
[3.2] Added validation to FC_REFLECT

### DIFF
--- a/libraries/chain/include/eosio/chain/account_object.hpp
+++ b/libraries/chain/include/eosio/chain/account_object.hpp
@@ -104,7 +104,7 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_object, eosio::chain::account_ind
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_metadata_object, eosio::chain::account_metadata_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::account_ram_correction_object, eosio::chain::account_ram_correction_index)
 
-FC_REFLECT(eosio::chain::account_object, (name)(creation_date)(abi))
+FC_REFLECT(eosio::chain::account_object, (name)(creation_date)(abi), (id))
 FC_REFLECT(eosio::chain::account_metadata_object, (name)(recv_sequence)(auth_sequence)(code_sequence)(abi_sequence)
-                                                  (code_hash)(last_code_update)(flags)(vm_type)(vm_version))
-FC_REFLECT(eosio::chain::account_ram_correction_object, (name)(ram_correction))
+                                                  (code_hash)(last_code_update)(flags)(vm_type)(vm_version), (id))
+FC_REFLECT(eosio::chain::account_ram_correction_object, (name)(ram_correction), (id))

--- a/libraries/chain/include/eosio/chain/block_header_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_header_state.hpp
@@ -182,7 +182,8 @@ FC_REFLECT_DERIVED(  eosio::chain::block_header_state, (eosio::chain::detail::bl
                      (header)
                      (pending_schedule)
                      (activated_protocol_features)
-                     (additional_signatures)
+                     (additional_signatures),
+                     (header_exts) // ignored
 )
 
 

--- a/libraries/chain/include/eosio/chain/block_state.hpp
+++ b/libraries/chain/include/eosio/chain/block_state.hpp
@@ -69,4 +69,5 @@ namespace eosio { namespace chain {
 
 } } /// namespace eosio::chain
 
-FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(validated) )
+FC_REFLECT_DERIVED( eosio::chain::block_state, (eosio::chain::block_header_state), (block)(validated),
+                    (validated)(_pub_keys_recovered)(_cached_trxs) )

--- a/libraries/chain/include/eosio/chain/block_summary_object.hpp
+++ b/libraries/chain/include/eosio/chain/block_summary_object.hpp
@@ -34,4 +34,4 @@ namespace eosio { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::block_summary_object, eosio::chain::block_summary_multi_index)
 
-FC_REFLECT( eosio::chain::block_summary_object, (block_id) )
+FC_REFLECT( eosio::chain::block_summary_object, (block_id), (id) )

--- a/libraries/chain/include/eosio/chain/code_object.hpp
+++ b/libraries/chain/include/eosio/chain/code_object.hpp
@@ -37,4 +37,4 @@ namespace eosio { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::code_object, eosio::chain::code_index)
 
-FC_REFLECT(eosio::chain::code_object, (code_hash)(code)(code_ref_count)(first_block_used)(vm_type)(vm_version))
+FC_REFLECT(eosio::chain::code_object, (code_hash)(code)(code_ref_count)(first_block_used)(vm_type)(vm_version), (id))

--- a/libraries/chain/include/eosio/chain/contract_table_objects.hpp
+++ b/libraries/chain/include/eosio/chain/contract_table_objects.hpp
@@ -293,11 +293,11 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::index256_object, eosio::chain::index256_i
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::index_double_object, eosio::chain::index_double_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::index_long_double_object, eosio::chain::index_long_double_index)
 
-FC_REFLECT(eosio::chain::table_id_object, (code)(scope)(table)(payer)(count) )
-FC_REFLECT(eosio::chain::key_value_object, (primary_key)(payer)(value) )
+FC_REFLECT(eosio::chain::table_id_object, (code)(scope)(table)(payer)(count), (id) )
+FC_REFLECT(eosio::chain::key_value_object, (primary_key)(payer)(value), (id)(t_id) )
 
 #define REFLECT_SECONDARY(type)\
-  FC_REFLECT(type, (primary_key)(payer)(secondary_key) )
+  FC_REFLECT(type, (primary_key)(payer)(secondary_key), (id)(t_id) )
 
 REFLECT_SECONDARY(eosio::chain::index64_object)
 REFLECT_SECONDARY(eosio::chain::index128_object)

--- a/libraries/chain/include/eosio/chain/database_header_object.hpp
+++ b/libraries/chain/include/eosio/chain/database_header_object.hpp
@@ -51,4 +51,4 @@ namespace eosio { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::database_header_object, eosio::chain::database_header_multi_index)
 
-FC_REFLECT( eosio::chain::database_header_object, (version) )
+FC_REFLECT( eosio::chain::database_header_object, (version), (id) )

--- a/libraries/chain/include/eosio/chain/global_property_object.hpp
+++ b/libraries/chain/include/eosio/chain/global_property_object.hpp
@@ -171,7 +171,8 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::dynamic_global_property_object,
                          eosio::chain::dynamic_global_property_multi_index)
 
 FC_REFLECT(eosio::chain::global_property_object,
-            (proposed_schedule_block_num)(proposed_schedule)(configuration)(chain_id)(kv_configuration)(wasm_configuration)
+            (proposed_schedule_block_num)(proposed_schedule)(configuration)(chain_id)(kv_configuration)(wasm_configuration),
+            (id)
           )
 
 FC_REFLECT(eosio::chain::legacy::snapshot_global_property_object_v2,
@@ -191,5 +192,6 @@ FC_REFLECT(eosio::chain::snapshot_global_property_object,
           )
 
 FC_REFLECT(eosio::chain::dynamic_global_property_object,
-            (global_action_sequence)
+            (global_action_sequence),
+            (id)
           )

--- a/libraries/chain/include/eosio/chain/permission_link_object.hpp
+++ b/libraries/chain/include/eosio/chain/permission_link_object.hpp
@@ -75,4 +75,4 @@ namespace eosio { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::permission_link_object, eosio::chain::permission_link_index)
 
-FC_REFLECT(eosio::chain::permission_link_object, (account)(code)(message_type)(required_permission))
+FC_REFLECT(eosio::chain::permission_link_object, (account)(code)(message_type)(required_permission), (id))

--- a/libraries/chain/include/eosio/chain/permission_object.hpp
+++ b/libraries/chain/include/eosio/chain/permission_object.hpp
@@ -120,7 +120,7 @@ namespace eosio { namespace chain {
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::permission_object, eosio::chain::permission_index)
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::permission_usage_object, eosio::chain::permission_usage_index)
 
-FC_REFLECT(eosio::chain::permission_object, (usage_id)(parent)(owner)(name)(last_updated)(auth))
+FC_REFLECT(eosio::chain::permission_object, (usage_id)(parent)(owner)(name)(last_updated)(auth), (id))
 FC_REFLECT(eosio::chain::snapshot_permission_object, (parent)(owner)(name)(last_updated)(last_used)(auth))
 
-FC_REFLECT(eosio::chain::permission_usage_object, (last_used))
+FC_REFLECT(eosio::chain::permission_usage_object, (last_used), (id))

--- a/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
+++ b/libraries/chain/include/eosio/chain/protocol_feature_manager.hpp
@@ -68,6 +68,7 @@ public:
 
    protocol_feature_t get_type()const { return _type; }
 
+   friend struct fc::reflector<protocol_feature_base>;
 public:
    std::string                               protocol_feature_type;
    digest_type                               description_digest;
@@ -95,6 +96,7 @@ public:
    builtin_protocol_feature_t get_codename()const { return _codename; }
 
    friend class protocol_feature_set;
+   friend struct fc::reflector<builtin_protocol_feature>;
 
 public:
    std::string                 builtin_feature_codename;
@@ -402,7 +404,7 @@ FC_REFLECT(eosio::chain::protocol_feature_subjective_restrictions,
                (earliest_allowed_activation_time)(preactivation_required)(enabled))
 
 FC_REFLECT(eosio::chain::protocol_feature_base,
-               (protocol_feature_type)(dependencies)(description_digest)(subjective_restrictions))
+               (protocol_feature_type)(dependencies)(description_digest)(subjective_restrictions), (_type))
 
 FC_REFLECT_DERIVED(eosio::chain::builtin_protocol_feature, (eosio::chain::protocol_feature_base),
-                     (builtin_feature_codename))
+                     (builtin_feature_codename), (_codename))

--- a/libraries/chain/include/eosio/chain/protocol_state_object.hpp
+++ b/libraries/chain/include/eosio/chain/protocol_state_object.hpp
@@ -83,7 +83,8 @@ FC_REFLECT(eosio::chain::protocol_state_object::activated_protocol_feature,
           )
 
 FC_REFLECT(eosio::chain::protocol_state_object,
-            (activated_protocol_features)(preactivated_protocol_features)(whitelisted_intrinsics)(num_supported_key_types)
+            (activated_protocol_features)(preactivated_protocol_features)(whitelisted_intrinsics)(num_supported_key_types),
+            (id)
           )
 
 FC_REFLECT(eosio::chain::snapshot_protocol_state_object,

--- a/libraries/chain/include/eosio/chain/resource_limits_private.hpp
+++ b/libraries/chain/include/eosio/chain/resource_limits_private.hpp
@@ -333,8 +333,7 @@ CHAINBASE_SET_INDEX_TYPE(eosio::chain::resource_limits::resource_limits_state_ob
 
 FC_REFLECT(eosio::chain::resource_limits::usage_accumulator, (last_ordinal)(value_ex)(consumed))
 
-// @ignore pending
-FC_REFLECT(eosio::chain::resource_limits::resource_limits_object, (owner)(net_weight)(cpu_weight)(ram_bytes))
-FC_REFLECT(eosio::chain::resource_limits::resource_usage_object,  (owner)(net_usage)(cpu_usage)(ram_usage))
-FC_REFLECT(eosio::chain::resource_limits::resource_limits_config_object, (cpu_limit_parameters)(net_limit_parameters)(account_cpu_usage_average_window)(account_net_usage_average_window))
-FC_REFLECT(eosio::chain::resource_limits::resource_limits_state_object, (average_block_net_usage)(average_block_cpu_usage)(pending_net_usage)(pending_cpu_usage)(total_net_weight)(total_cpu_weight)(total_ram_bytes)(virtual_net_limit)(virtual_cpu_limit))
+FC_REFLECT(eosio::chain::resource_limits::resource_limits_object, (owner)(net_weight)(cpu_weight)(ram_bytes), (id)(pending))
+FC_REFLECT(eosio::chain::resource_limits::resource_usage_object,  (owner)(net_usage)(cpu_usage)(ram_usage), (id))
+FC_REFLECT(eosio::chain::resource_limits::resource_limits_config_object, (cpu_limit_parameters)(net_limit_parameters)(account_cpu_usage_average_window)(account_net_usage_average_window), (id))
+FC_REFLECT(eosio::chain::resource_limits::resource_limits_state_object, (average_block_net_usage)(average_block_cpu_usage)(pending_net_usage)(pending_cpu_usage)(total_net_weight)(total_cpu_weight)(total_ram_bytes)(virtual_net_limit)(virtual_cpu_limit), (id))

--- a/libraries/chain/include/eosio/chain/trace.hpp
+++ b/libraries/chain/include/eosio/chain/trace.hpp
@@ -93,4 +93,5 @@ FC_REFLECT( eosio::chain::action_trace,
 // @ignore except_ptr
 FC_REFLECT( eosio::chain::transaction_trace, (id)(block_num)(block_time)(producer_block_id)
                                              (receipt)(elapsed)(net_usage)(scheduled)
-                                             (action_traces)(account_ram_delta)(failed_dtrx_trace)(except)(error_code) )
+                                             (action_traces)(account_ram_delta)(failed_dtrx_trace)(except)(error_code),
+            (except_ptr) )

--- a/libraries/chain/include/eosio/chain/transaction.hpp
+++ b/libraries/chain/include/eosio/chain/transaction.hpp
@@ -217,5 +217,4 @@ FC_REFLECT( eosio::chain::transaction_header, (expiration)(ref_block_num)(ref_bl
 FC_REFLECT_DERIVED( eosio::chain::transaction, (eosio::chain::transaction_header), (context_free_actions)(actions)(transaction_extensions) )
 FC_REFLECT_DERIVED( eosio::chain::signed_transaction, (eosio::chain::transaction), (signatures)(context_free_data) )
 FC_REFLECT_ENUM( eosio::chain::packed_transaction::compression_type, (none)(zlib))
-// @ignore unpacked_trx
-FC_REFLECT( eosio::chain::packed_transaction, (signatures)(compression)(packed_context_free_data)(packed_trx) )
+FC_REFLECT( eosio::chain::packed_transaction, (signatures)(compression)(packed_context_free_data)(packed_trx), (unpacked_trx)(trx_id) )

--- a/libraries/chain/include/eosio/chain/transaction_object.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_object.hpp
@@ -47,4 +47,4 @@ namespace eosio { namespace chain {
 
 CHAINBASE_SET_INDEX_TYPE(eosio::chain::transaction_object, eosio::chain::transaction_multi_index)
 
-FC_REFLECT(eosio::chain::transaction_object, (expiration)(trx_id))
+FC_REFLECT(eosio::chain::transaction_object, (expiration)(trx_id), (id))

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -38,7 +38,7 @@ FC_REFLECT_ENUM( chainbase::environment::os_t,
                  (OS_LINUX)(OS_MACOS)(OS_WINDOWS)(OS_OTHER) )
 FC_REFLECT_ENUM( chainbase::environment::arch_t,
                  (ARCH_X86_64)(ARCH_ARM)(ARCH_RISCV)(ARCH_OTHER) )
-FC_REFLECT(chainbase::environment, (debug)(os)(arch)(boost_version)(compiler) )
+FC_REFLECT_PACKED(chainbase::environment, (debug)(os)(arch)(boost_version)(compiler), (reserved) )
 
 const fc::string deep_mind_logger_name("deep-mind");
 eosio::chain::deep_mind_handler _deep_mind_log;

--- a/programs/eosio-launcher/main.cpp
+++ b/programs/eosio-launcher/main.cpp
@@ -173,6 +173,7 @@ public:
 
 
 private:
+  friend struct fc::reflector<host_def>;
   uint16_t p2p_count;
   uint16_t http_count;
   string   dot_label_str;
@@ -230,6 +231,7 @@ public:
      return name.substr( name.length() - 2 );
   }
 private:
+  friend struct fc::reflector<eosd_def>;
   string dot_label_str;
 };
 
@@ -2097,9 +2099,9 @@ int main (int argc, char *argv[]) {
 
 
 //-------------------------------------------------------------
-// @ignore local_config_file
 FC_REFLECT( remote_deploy,
-            (ssh_cmd)(scp_cmd)(ssh_identity)(ssh_args) )
+            (ssh_cmd)(scp_cmd)(ssh_identity)(ssh_args),
+            (local_config_file) )
 
 FC_REFLECT( prodkey_def,
             (producer_name)(block_signing_key))
@@ -2107,21 +2109,20 @@ FC_REFLECT( prodkey_def,
 FC_REFLECT( producer_set_def,
             (schedule))
 
-// @ignore listen_addr, p2p_count, http_count, dot_label_str
 FC_REFLECT( host_def,
             (genesis)(ssh_identity)(ssh_args)(eosio_home)
             (host_name)(public_name)
             (base_p2p_port)(base_http_port)(def_file_size)
-            (instances) )
+            (instances),
+            (listen_addr)(p2p_count)(http_count)(dot_label_str) )
 
-// @ignore node, dot_label_str
 FC_REFLECT( eosd_def,
             (config_dir_name)(data_dir_name)(p2p_port)
             (http_port)(file_size)(name)(host)
-            (p2p_endpoint) )
+            (p2p_endpoint),
+            (node)(dot_label_str) )
 
-// @ignore instance, gelf_endpoint
-FC_REFLECT( tn_node_def, (name)(keys)(peers)(producers)(dont_start) )
+FC_REFLECT( tn_node_def, (name)(keys)(peers)(producers)(dont_start), (instance)(gelf_endpoint) )
 
 FC_REFLECT( testnet_def, (name)(ssh_helper)(nodes) )
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -76,9 +76,9 @@ private:
    }
 };
 
-FC_REFLECT( base_reflect, (bv) )
-FC_REFLECT_DERIVED( derived_reflect, (base_reflect), (dv) )
-FC_REFLECT_DERIVED( final_reflect, (derived_reflect), (fv) )
+FC_REFLECT( base_reflect, (bv), (base_reflect_initialized)(base_reflect_called) )
+FC_REFLECT_DERIVED( derived_reflect, (base_reflect), (dv), (derived_reflect_initialized)(derived_reflect_called) )
+FC_REFLECT_DERIVED( final_reflect, (derived_reflect), (fv), (final_reflect_initialized)(final_reflect_called) )
 
 namespace eosio
 {


### PR DESCRIPTION
Added validation to `FC_REFLECT` macro so that all members have to be listed or explicitly ignored.

Requires: https://github.com/eosnetworkfoundation/mandel-fc/pull/38
Resolves: #391 
Resolves: #515
Resolves: #516 
Resolves: #517