### PR TITLE
[3.2] skip context free actions during light validation

### DIFF
--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -72,51 +72,53 @@ void apply_context::exec_one()
       try {
          action_return_value.clear();
          receiver_account = &db.get<account_metadata_object,by_name>( receiver );
-         privileged = receiver_account->is_privileged();
-         auto native = control.find_apply_handler( receiver, act->account, act->name );
-         if( native ) {
-            if( trx_context.enforce_whiteblacklist && control.is_producing_block() ) {
-               control.check_contract_list( receiver );
-               control.check_action_list( act->account, act->name );
-            }
-            (*native)( *this );
-         }
-
-         if( ( receiver_account->code_hash != digest_type() ) &&
-               (  !( act->account == config::system_account_name
-                     && act->name == "setcode"_n
-                     && receiver == config::system_account_name )
-                  || control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
-               )
-         ) {
-            if( trx_context.enforce_whiteblacklist && control.is_producing_block() ) {
-               control.check_contract_list( receiver );
-               control.check_action_list( act->account, act->name );
-            }
-            try {
-               control.get_wasm_interface().apply( receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, *this );
-            } catch( const wasm_exit& ) {}
-         }
-
-         if( !privileged && control.is_builtin_activated( builtin_protocol_feature_t::ram_restrictions ) ) {
-            const size_t checktime_interval = 10;
-            size_t counter = 0;
-            bool   not_in_notify_context = (receiver == act->account);
-            const auto end = _account_ram_deltas.end();
-            for( auto itr = _account_ram_deltas.begin(); itr != end; ++itr, ++counter ) {
-               if( counter == checktime_interval ) {
-                  trx_context.checktime();
-                  counter = 0;
+         if( !context_free || (context_free && !control.skip_auth_check() ) ) {
+            privileged = receiver_account->is_privileged();
+            auto native = control.find_apply_handler( receiver, act->account, act->name );
+            if( native ) {
+               if( trx_context.enforce_whiteblacklist && control.is_producing_block() ) {
+                  control.check_contract_list( receiver );
+                  control.check_action_list( act->account, act->name );
                }
-               if( itr->delta > 0 && itr->account != receiver ) {
-                  EOS_ASSERT( not_in_notify_context, unauthorized_ram_usage_increase,
-                              "unprivileged contract cannot increase RAM usage of another account within a notify context: ${account}",
-                              ("account", itr->account)
-                  );
-                  EOS_ASSERT( has_authorization( itr->account ), unauthorized_ram_usage_increase,
-                              "unprivileged contract cannot increase RAM usage of another account that has not authorized the action: ${account}",
-                              ("account", itr->account)
-                  );
+               (*native)( *this );
+            }
+
+            if( ( receiver_account->code_hash != digest_type() ) &&
+                (  !( act->account == config::system_account_name
+                      && act->name == N( setcode )
+                      && receiver == config::system_account_name )
+                  || control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
+                )
+                  ) {
+               if( trx_context.enforce_whiteblacklist && control.is_producing_block() ) {
+                  control.check_contract_list( receiver );
+                  control.check_action_list( act->account, act->name );
+               }
+               try {
+                  control.get_wasm_interface().apply( receiver_account->code_hash, receiver_account->vm_type, receiver_account->vm_version, *this );
+               } catch( const wasm_exit& ) {}
+            }
+
+            if( !privileged && control.is_builtin_activated( builtin_protocol_feature_t::ram_restrictions ) ) {
+               const size_t checktime_interval = 10;
+               size_t counter = 0;
+               bool not_in_notify_context = (receiver == act->account);
+               const auto end = _account_ram_deltas.end();
+               for( auto itr = _account_ram_deltas.begin(); itr != end; ++itr, ++counter ) {
+                  if( counter == checktime_interval ) {
+                     trx_context.checktime();
+                     counter = 0;
+                  }
+                  if( itr->delta > 0 && itr->account != receiver ) {
+                     EOS_ASSERT( not_in_notify_context, unauthorized_ram_usage_increase,
+                                 "unprivileged contract cannot increase RAM usage of another account within a notify context: ${account}",
+                                 ("account", itr->account)
+                     );
+                     EOS_ASSERT( has_authorization( itr->account ), unauthorized_ram_usage_increase,
+                                 "unprivileged contract cannot increase RAM usage of another account that has not authorized the action: ${account}",
+                                 ("account", itr->account)
+                     );
+                  }
                }
             }
          }

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -72,7 +72,7 @@ void apply_context::exec_one()
       try {
          action_return_value.clear();
          receiver_account = &db.get<account_metadata_object,by_name>( receiver );
-         if( !context_free || (context_free && !control.skip_auth_check() ) ) {
+         if( !context_free || (context_free && !control.skip_trx_checks() ) ) {
             privileged = receiver_account->is_privileged();
             auto native = control.find_apply_handler( receiver, act->account, act->name );
             if( native ) {

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -84,12 +84,12 @@ void apply_context::exec_one()
             }
 
             if( ( receiver_account->code_hash != digest_type() ) &&
-                (  !( act->account == config::system_account_name
-                      && act->name == N( setcode )
-                      && receiver == config::system_account_name )
-                  || control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
-                )
-                  ) {
+                  (  !( act->account == config::system_account_name
+                        && act->name == N( setcode )
+                        && receiver == config::system_account_name )
+                     || control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
+                  )
+            ) {
                if( trx_context.enforce_whiteblacklist && control.is_producing_block() ) {
                   control.check_contract_list( receiver );
                   control.check_action_list( act->account, act->name );

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -85,7 +85,7 @@ void apply_context::exec_one()
 
             if( ( receiver_account->code_hash != digest_type() ) &&
                   (  !( act->account == config::system_account_name
-                        && act->name == N( setcode )
+                        && act->name == "setcode"_n
                         && receiver == config::system_account_name )
                      || control.is_builtin_activated( builtin_protocol_feature_t::forward_setcode )
                   )

--- a/libraries/chain/apply_context.cpp
+++ b/libraries/chain/apply_context.cpp
@@ -72,7 +72,7 @@ void apply_context::exec_one()
       try {
          action_return_value.clear();
          receiver_account = &db.get<account_metadata_object,by_name>( receiver );
-         if( !context_free || (context_free && !control.skip_trx_checks() ) ) {
+         if( !(context_free && control.skip_trx_checks()) ) {
             privileged = receiver_account->is_privileged();
             auto native = control.find_apply_handler( receiver, act->account, act->name );
             if( native ) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -723,7 +723,7 @@ namespace eosio { namespace chain {
       const auto& db = control.db();
       const auto& auth_manager = control.get_authorization_manager();
 
-      if( trx.context_free_actions.size() > 0 && !control.skip_auth_check() ) {
+      if( !trx.context_free_actions.empty() && !control.skip_trx_checks() ) {
          for( const auto& a : trx.context_free_actions ) {
             auto* code = db.find<account_object, by_name>( a.account );
             EOS_ASSERT( code != nullptr, transaction_exception,

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -723,12 +723,14 @@ namespace eosio { namespace chain {
       const auto& db = control.db();
       const auto& auth_manager = control.get_authorization_manager();
 
-      for( const auto& a : trx.context_free_actions ) {
-         auto* code = db.find<account_object, by_name>(a.account);
-         EOS_ASSERT( code != nullptr, transaction_exception,
-                     "action's code account '${account}' does not exist", ("account", a.account) );
-         EOS_ASSERT( a.authorization.size() == 0, transaction_exception,
-                     "context-free actions cannot have authorizations" );
+      if( trx.context_free_actions.size() > 0 && !control.skip_auth_check() ) {
+         for( const auto& a : trx.context_free_actions ) {
+            auto* code = db.find<account_object, by_name>( a.account );
+            EOS_ASSERT( code != nullptr, transaction_exception,
+                        "action's code account '${account}' does not exist", ("account", a.account) );
+            EOS_ASSERT( a.authorization.size() == 0, transaction_exception,
+                        "context-free actions cannot have authorizations" );
+         }
       }
 
       flat_set<account_name> actors;

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -881,7 +881,11 @@ BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
    BOOST_REQUIRE(trace->receipt);
    BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::executed);
    BOOST_CHECK_EQUAL(2, trace->action_traces.size());
+
+   BOOST_CHECK(trace->action_traces.at(0).context_free); // cfa
    BOOST_CHECK_EQUAL("test\n", trace->action_traces.at(0).console); // cfa executed
+
+   BOOST_CHECK(!trace->action_traces.at(1).context_free); // non-cfa
    BOOST_CHECK_EQUAL("", trace->action_traces.at(1).console);
 
 
@@ -911,9 +915,19 @@ BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
    BOOST_REQUIRE(other_trace);
    BOOST_REQUIRE(other_trace->receipt);
    BOOST_CHECK_EQUAL(other_trace->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK(*trace->receipt == *other_trace->receipt);
    BOOST_CHECK_EQUAL(2, other_trace->action_traces.size());
+
+   BOOST_CHECK(other_trace->action_traces.at(0).context_free); // cfa
    BOOST_CHECK_EQUAL("", other_trace->action_traces.at(0).console); // cfa not executed for light validation (trusted producer)
+   BOOST_CHECK_EQUAL(trace->action_traces.at(0).receipt->global_sequence, other_trace->action_traces.at(0).receipt->global_sequence);
+   BOOST_CHECK_EQUAL(trace->action_traces.at(0).receipt->digest(), other_trace->action_traces.at(0).receipt->digest());
+
+   BOOST_CHECK(!other_trace->action_traces.at(1).context_free); // non-cfa
    BOOST_CHECK_EQUAL("", other_trace->action_traces.at(1).console);
+   BOOST_CHECK_EQUAL(trace->action_traces.at(1).receipt->global_sequence, other_trace->action_traces.at(1).receipt->global_sequence);
+   BOOST_CHECK_EQUAL(trace->action_traces.at(1).receipt->digest(), other_trace->action_traces.at(1).receipt->digest());
+
 
    other.close();
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -851,7 +851,7 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
 } FC_LOG_AND_RETHROW()
 
 BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
-   tester chain;
+   tester chain(setup_policy::full);
 
    std::vector<signed_block_ptr> blocks;
    blocks.push_back(chain.produce_block());
@@ -881,10 +881,19 @@ BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
    BOOST_REQUIRE(trace->receipt);
    BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::executed);
    BOOST_CHECK_EQUAL(2, trace->action_traces.size());
+   BOOST_CHECK_EQUAL("test\n", trace->action_traces.at(0).console); // cfa executed
+   BOOST_CHECK_EQUAL("", trace->action_traces.at(1).console);
 
-   flat_set<account_name> trusted_producers = { N(eosio) };
-   validating_tester other(trusted_producers);
-   other.skip_validate = true;
+
+   fc::temp_directory tempdir;
+   auto conf_genesis = tester::default_config( tempdir );
+
+   auto& cfg = conf_genesis.first;
+   cfg.trusted_producers = { N(eosio) }; // light validation
+
+   tester other( conf_genesis.first, conf_genesis.second );
+   other.execute_setup_policy( setup_policy::full );
+
 
    transaction_trace_ptr other_trace;
    auto cc = other.control->applied_transaction.connect( [&](std::tuple<const transaction_trace_ptr&, const signed_transaction&> x) {
@@ -895,14 +904,16 @@ BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
    } );
 
    for (auto& new_block : blocks) {
-      other.validate_push_block(new_block);
+      other.push_block(new_block);
    }
    blocks.clear();
 
    BOOST_REQUIRE(other_trace);
    BOOST_REQUIRE(other_trace->receipt);
    BOOST_CHECK_EQUAL(other_trace->receipt->status, transaction_receipt::executed);
-   BOOST_CHECK_EQUAL(1, other_trace->action_traces.size()); // no cfa
+   BOOST_CHECK_EQUAL(2, other_trace->action_traces.size());
+   BOOST_CHECK_EQUAL("", other_trace->action_traces.at(0).console); // cfa not executed for light validation (trusted producer)
+   BOOST_CHECK_EQUAL("", other_trace->action_traces.at(1).console);
 
    other.close();
 

--- a/unittests/api_tests.cpp
+++ b/unittests/api_tests.cpp
@@ -850,6 +850,64 @@ BOOST_FIXTURE_TEST_CASE(deferred_cfa_success, TESTER)  try {
    BOOST_REQUIRE_EQUAL( validate(), true );
 } FC_LOG_AND_RETHROW()
 
+BOOST_AUTO_TEST_CASE(light_validation_skip_cfa) try {
+   tester chain;
+
+   std::vector<signed_block_ptr> blocks;
+   blocks.push_back(chain.produce_block());
+
+   chain.create_account( N(testapi) );
+   chain.create_account( N(dummy) );
+   blocks.push_back(chain.produce_block());
+   chain.set_code( N(testapi), contracts::test_api_wasm() );
+   blocks.push_back(chain.produce_block());
+
+   cf_action cfa;
+   signed_transaction trx;
+   action act({}, cfa);
+   trx.context_free_actions.push_back(act);
+   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(100)); // verify payload matches context free data
+   trx.context_free_data.emplace_back(fc::raw::pack<uint32_t>(200));
+   // add a normal action along with cfa
+   dummy_action da = { DUMMY_ACTION_DEFAULT_A, DUMMY_ACTION_DEFAULT_B, DUMMY_ACTION_DEFAULT_C };
+   action act1(vector<permission_level>{{N(testapi), config::active_name}}, da);
+   trx.actions.push_back(act1);
+   chain.set_transaction_headers(trx);
+   // run normal passing case
+   auto sigs = trx.sign(chain.get_private_key(N(testapi), "active"), chain.control->get_chain_id());
+   auto trace = chain.push_transaction(trx);
+   blocks.push_back(chain.produce_block());
+
+   BOOST_REQUIRE(trace->receipt);
+   BOOST_CHECK_EQUAL(trace->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK_EQUAL(2, trace->action_traces.size());
+
+   flat_set<account_name> trusted_producers = { N(eosio) };
+   validating_tester other(trusted_producers);
+   other.skip_validate = true;
+
+   transaction_trace_ptr other_trace;
+   auto cc = other.control->applied_transaction.connect( [&](std::tuple<const transaction_trace_ptr&, const signed_transaction&> x) {
+      auto& t = std::get<0>(x);
+      if( t && t->id == trace->id ) {
+         other_trace = t;
+      }
+   } );
+
+   for (auto& new_block : blocks) {
+      other.validate_push_block(new_block);
+   }
+   blocks.clear();
+
+   BOOST_REQUIRE(other_trace);
+   BOOST_REQUIRE(other_trace->receipt);
+   BOOST_CHECK_EQUAL(other_trace->receipt->status, transaction_receipt::executed);
+   BOOST_CHECK_EQUAL(1, other_trace->action_traces.size()); // no cfa
+
+   other.close();
+
+} FC_LOG_AND_RETHROW()
+
 /*************************************************************************************
  * checktime_tests test case
  *************************************************************************************/


### PR DESCRIPTION
> Skip context_free_action execution during light validation.
> Since context free actions are designed not have any side-effects (except for possible console output) and to only influence execution via asserting, the fact that they exist in a signed block is indication that the producer executed them and they didn't assert. Therefore, they can be skipped during light validation where producers are implicitly trusted.
> Any node that wishes to include all context free action console output in action traces needs to run with --force-all-checks for replay, run with no trusted producers, and run in full validation mode. [NOTE: this is currently not completely accurate as it depends on PR Skip checks [ #8848]](https://github.com/EOSIO/eos/pull/8848)

Part of https://github.com/eosnetworkfoundation/mandel/issues/188

Backports https://github.com/EOSIO/eos/pull/8846
Resolves: https://github.com/eosnetworkfoundation/mandel/issues/556