### PR TITLE
[3.2] Backport: Fix build when build path has spaces for mandel and appbase

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories( unit_test PUBLIC
 add_test(NAME protocol_feature_digest_unit_test COMMAND unit_test --run_test=protocol_feature_digest_tests --report_level=detailed --color_output --catch_system_errors=no)
 set(ctest_tests "protocol_feature_digest_tests")
 foreach(TEST_SUITE ${UNIT_TESTS}) # create an independent target for each test suite
-  execute_process(COMMAND sh -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' ${TEST_SUITE} | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
+  execute_process(COMMAND sh -c "grep -E 'BOOST_AUTO_TEST_SUITE\\s*[(]' '${TEST_SUITE}' | grep -vE '//.*BOOST_AUTO_TEST_SUITE\\s*[(]' | cut -d ')' -f 1 | cut -d '(' -f 2" OUTPUT_VARIABLE SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # get the test suite name from the *.cpp file
   if (NOT "" STREQUAL "${SUITE_NAME}") # ignore empty lines
     execute_process(COMMAND sh -c "echo ${SUITE_NAME} | sed -e 's/s$//' | sed -e 's/_test$//'" OUTPUT_VARIABLE TRIMMED_SUITE_NAME OUTPUT_STRIP_TRAILING_WHITESPACE) # trim "_test" or "_tests" from the end of ${SUITE_NAME}
     # to run unit_test with all log from blockchain displayed, put "--verbose" after "--", i.e. "unit_test -- --verbose"


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/9160. Resolve https://github.com/eosnetworkfoundation/mandel/issues/424.

https://github.com/EOSIO/eos/pull/9160 contained fixes for `EOSIO`, `appbase`, and `eosio-wasm-spec-tests`. The fix for `eosio-wasm-spec-tests` was already in `historical-v2.1.x` and `main`; no further work is required for that. This PR only pulls in changes from `EOSIO` and `appbase`.