### PR TITLE
[3.2] Backport unpack transaction data

### DIFF
--- a/tests/Node.py
+++ b/tests/Node.py
@@ -869,7 +869,7 @@ class Node(object):
             return (False, msg)
 
     # returns tuple with transaction execution status and transaction
-    def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None):
+    def pushMessage(self, account, action, data, opts, silentErrors=False, signatures=None, expectTrxTrace=True):
         cmd="%s %s push action -j %s %s" % (Utils.EosClientPath, self.eosClientArgs(), account, action)
         cmdArr=cmd.split()
         # not using __sign_str, since cmdArr messes up the string
@@ -888,7 +888,7 @@ class Node(object):
             if Utils.Debug:
                 end=time.perf_counter()
                 Utils.Print("cmd Duration: %.3f sec" % (end-start))
-            return (Node.getTransStatus(trans) == 'executed', trans)
+            return (Node.getTransStatus(trans) == 'executed' if expectTrxTrace else True, trans)
         except subprocess.CalledProcessError as ex:
             msg=ex.output.decode("utf-8")
             if not silentErrors:

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -582,7 +582,7 @@ try:
     data="{\"from\":\"currency1111\",\"to\":\"defproducera\",\"quantity\":"
     data +="\"00.0001 CUR\",\"memo\":\"test\"}"
     opts="-s -d --permission currency1111@active"
-    trans=node.pushMessage(contract, action, data, opts)
+    trans=node.pushMessage(contract, action, data, opts, expectTrxTrace=False)
 
     try:
         assert(not trans[1]["signatures"])

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -578,6 +578,36 @@ try:
     if actual != expected:
         errorExit("FAILURE - Wrong currency1111 balance (expected=%s, actual=%s)" % (str(expected), str(actual)), raw=True)
 
+    Print("push transfer action to currency1111 contract with sign skipping option enabled")
+    data="{\"from\":\"currency1111\",\"to\":\"defproducera\",\"quantity\":"
+    data +="\"00.0001 CUR\",\"memo\":\"test\"}"
+    opts="-s -d --permission currency1111@active"
+    trans=node.pushMessage(contract, action, data, opts)
+
+    try:
+        assert(not trans[1]["signatures"])
+    except (AssertionError, KeyError) as _:
+        Print("ERROR: Expected signatures array to be empty due to skipping option enabled.")
+        raise
+
+    try:
+        assert(trans[1]["actions"][0]["data"]["from"] == "currency1111")
+        assert(trans[1]["actions"][0]["data"]["to"] == "defproducera")
+        assert(trans[1]["actions"][0]["data"]["quantity"] == "0.0001 CUR")
+        assert(trans[1]["actions"][0]["data"]["memo"] == "test")
+    except (AssertionError, KeyError) as _:
+        Print("ERROR: Expecting unpacked data fields on push transfer action json result.")
+        raise
+
+    result=node.pushTransaction(trans[1], None)
+
+    amountStr=node.getTableAccountBalance("currency1111", currencyAccount.name)
+
+    expected="99999.9999 CUR"
+    actual=amountStr
+    if actual != expected:
+        errorExit("FAILURE - Wrong currency1111 balance (expectedgma=%s, actual=%s)" % (str(expected), str(actual)), raw=True)
+
     Print("Locking wallet \"%s\"." % (defproduceraWallet.name))
     if not walletMgr.lockWallet(defproduceraWallet):
         cmdError("%s wallet lock" % (ClientName))


### PR DESCRIPTION
unpack data when forming transaction, useful for example when signing the transaction with trezor wallets

Change Description
In cleos unpack data when forming transaction, useful for example when signing the transaction with trezor wallets

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/579

Related to: https://github.com/eosnetworkfoundation/mandel/issues/427