### PR TITLE
[3.2] Backport: Fix unpack data for signing transaction

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3618,7 +3618,7 @@ int main( int argc, char** argv ) {
 
       signed_transaction trx;
       try {
-        trx = trx_var.as<signed_transaction>();
+        abi_serializer::from_variant( trx_var, trx, abi_serializer_resolver_empty, abi_serializer::create_yield_function( abi_serializer_max_time ) );
       } EOS_RETHROW_EXCEPTIONS(transaction_type_exception, "Invalid transaction format: '${data}'",
                                ("data", fc::json::to_string(trx_var, fc::time_point::maximum())))
 

--- a/tests/Node.py
+++ b/tests/Node.py
@@ -526,7 +526,7 @@ class Node(object):
     def waitForIrreversibleBlock(self, blockNum, timeout=None, reportInterval=None):
         return self.waitForBlock(blockNum, timeout=timeout, blockType=BlockType.lib, reportInterval=reportInterval)
 
-    def __transferFundsCmdArr(self, source, destination, amountStr, memo, force, retry, sign, dontSend, expiration):
+    def __transferFundsCmdArr(self, source, destination, amountStr, memo, force, retry, sign, dontSend, expiration, skipSign):
         assert isinstance(amountStr, str)
         assert(source)
         assert(isinstance(source, Account))
@@ -553,6 +553,9 @@ class Node(object):
             cmdArr.append("--sign-with")
             cmdArr.append("[ \"%s\" ]" % (source.activePublicKey))
 
+        if skipSign:
+            cmdArr.append("--skip-sign")
+
         cmdArr.append(source.name)
         cmdArr.append(destination.name)
         cmdArr.append(amountStr)
@@ -564,8 +567,8 @@ class Node(object):
         return cmdArr
 
     # Trasfer funds. Returns "transfer" json return object
-    def transferFunds(self, source, destination, amountStr, memo="memo", force=False, waitForTransBlock=False, exitOnError=True, reportStatus=True, retry=None, sign=False, dontSend=False, expiration=90):
-        cmdArr = self.__transferFundsCmdArr(source, destination, amountStr, memo, force, retry, sign, dontSend, expiration)
+    def transferFunds(self, source, destination, amountStr, memo="memo", force=False, waitForTransBlock=False, exitOnError=True, reportStatus=True, retry=None, sign=False, dontSend=False, expiration=90, skipSign=False):
+        cmdArr = self.__transferFundsCmdArr(source, destination, amountStr, memo, force, retry, sign, dontSend, expiration, skipSign)
         trans=None
         start=time.perf_counter()
         try:
@@ -591,8 +594,8 @@ class Node(object):
         return self.waitForTransBlockIfNeeded(trans, waitForTransBlock, exitOnError=exitOnError)
 
     # Trasfer funds. Returns (popen, cmdArr) for checkDelayedOutput
-    def transferFundsAsync(self, source, destination, amountStr, memo="memo", force=False, exitOnError=True, retry=None, sign=False, dontSend=False, expiration=90):
-        cmdArr = self.__transferFundsCmdArr(source, destination, amountStr, memo, force, retry, sign, dontSend, expiration)
+    def transferFundsAsync(self, source, destination, amountStr, memo="memo", force=False, exitOnError=True, retry=None, sign=False, dontSend=False, expiration=90, skipSign=False):
+        cmdArr = self.__transferFundsCmdArr(source, destination, amountStr, memo, force, retry, sign, dontSend, expiration, skipSign)
         start=time.perf_counter()
         try:
             popen=Utils.delayedCheckOutput(cmdArr)

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -608,6 +608,37 @@ try:
     if actual != expected:
         errorExit("FAILURE - Wrong currency1111 balance (expectedgma=%s, actual=%s)" % (str(expected), str(actual)), raw=True)
 
+    Print("---- Test for signing transaction ----")
+    testeraAccountAmountBeforeTrx=node.getAccountEosBalanceStr(testeraAccount.name)
+    currencyAccountAmountBeforeTrx=node.getAccountEosBalanceStr(currencyAccount.name)
+
+    xferAmount="1.2345 {0}".format(CORE_SYMBOL)
+    unsignedTrxRet = node.transferFunds(currencyAccount, testeraAccount, xferAmount, "unsigned trx", False, False, True, False, False, True, None, True)
+    unsignedTrxJsonFile = "unsigned_trx_file"
+    with open(unsignedTrxJsonFile, 'w') as outfile:
+        json.dump(unsignedTrxRet, outfile)
+    testeraAccountAmountAftrTrx=node.getAccountEosBalanceStr(testeraAccount.name)
+    currencyAccountAmountAftrTrx=node.getAccountEosBalanceStr(currencyAccount.name)
+    try:
+        assert(testeraAccountAmountBeforeTrx == testeraAccountAmountAftrTrx)
+        assert(currencyAccountAmountBeforeTrx == currencyAccountAmountAftrTrx)
+    except (AssertionError) as _:
+        Print("ERROR: Expecting transfer is not executed.")
+        raise
+
+    signCmd = "sign --public-key {0} {1} -p".format(currencyAccount.activePublicKey, unsignedTrxJsonFile)
+    node.processCleosCmd(signCmd, "Sign and push a transaction", False, True)
+    os.remove(unsignedTrxJsonFile)
+
+    testeraAccountAmountAfterSign=node.getAccountEosBalanceStr(testeraAccount.name)
+    currencyAccountAmountAfterSign=node.getAccountEosBalanceStr(currencyAccount.name)
+    try:
+        assert(Utils.addAmount(testeraAccountAmountAftrTrx, xferAmount) == testeraAccountAmountAfterSign)
+        assert(Utils.deduceAmount(currencyAccountAmountAftrTrx, xferAmount) == currencyAccountAmountAfterSign)
+    except (AssertionError) as _:
+        Print("ERROR: Expecting transfer has been executed with exact amount.")
+        raise
+
     Print("Locking wallet \"%s\"." % (defproduceraWallet.name))
     if not walletMgr.lockWallet(defproduceraWallet):
         cmdError("%s wallet lock" % (ClientName))

--- a/tests/nodeos_run_test.py
+++ b/tests/nodeos_run_test.py
@@ -613,7 +613,7 @@ try:
     currencyAccountAmountBeforeTrx=node.getAccountEosBalanceStr(currencyAccount.name)
 
     xferAmount="1.2345 {0}".format(CORE_SYMBOL)
-    unsignedTrxRet = node.transferFunds(currencyAccount, testeraAccount, xferAmount, "unsigned trx", False, False, True, False, False, True, None, True)
+    unsignedTrxRet = node.transferFunds(currencyAccount, testeraAccount, xferAmount, "unsigned trx", force=False, waitForTransBlock=False, exitOnError=True, reportStatus=False, sign=False, dontSend=True, expiration=None, skipSign=True)
     unsignedTrxJsonFile = "unsigned_trx_file"
     with open(unsignedTrxJsonFile, 'w') as outfile:
         json.dump(unsignedTrxRet, outfile)

--- a/tests/testUtils.py
+++ b/tests/testUtils.py
@@ -473,6 +473,29 @@ class Utils:
 
         return "comparison of %s type is not supported, context=%s" % (typeName,context)
 
+    @staticmethod
+    def addAmount(assetStr: str, deltaStr: str) -> str:
+        asset = assetStr.split()
+        if len(asset) != 2:
+            return None
+        delta = deltaStr.split()
+        if len(delta) != 2:
+            return None
+        if asset[1] != delta[1]:
+            return None
+        return "{0} {1}".format(round(float(asset[0]) + float(delta[0]), 4), asset[1])
+
+    @staticmethod
+    def deduceAmount(assetStr: str, deltaStr: str) -> str:
+        asset = assetStr.split()
+        if len(asset) != 2:
+            return None
+        delta = deltaStr.split()
+        if len(delta) != 2:
+            return None
+        if asset[1] != delta[1]:
+            return None
+        return "{0} {1}".format(round(float(asset[0]) - float(delta[0]), 4), asset[1])
 ###########################################################################################
 class Account(object):
     # pylint: disable=too-few-public-methods


### PR DESCRIPTION
Use an abi_serializer to unpack transaction data for signing, also add a test case for signing transaction.

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/399

Relates to: https://github.com/eosnetworkfoundation/mandel/issues/427