### PR TITLE
[3.2] Add light validation sync test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trx_finality_status_forked_test.py ${
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/plugin_http_api_test.py ${CMAKE_CURRENT_BINARY_DIR}/plugin_http_api_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/nodeos_contrl_c_test.py ${CMAKE_CURRENT_BINARY_DIR}/nodeos_contrl_c_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/resource_monitor_plugin_test.py ${CMAKE_CURRENT_BINARY_DIR}/resource_monitor_plugin_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/light_validation_sync_test.py ${CMAKE_CURRENT_BINARY_DIR}/light_validation_sync_test.py COPYONLY)
 
 #To run plugin_test with all log from blockchain displayed, put --verbose after --, i.e. plugin_test -- --verbose
 add_test(NAME plugin_test COMMAND plugin_test --report_level=detailed --color_output)
@@ -226,6 +227,8 @@ set_property(TEST resource_monitor_plugin_test PROPERTY LABELS long_running_test
 add_test(NAME nodeos_repeat_transaction_lr_test COMMAND tests/nodeos_high_transaction_test.py -v --clean-run --dump-error-detail -p 4 -n 8 --num-transactions 1000 --max-transactions-per-second 500 --send-duplicates WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST nodeos_repeat_transaction_lr_test PROPERTY LABELS long_running_tests)
 
+add_test(NAME light_validation_sync_test COMMAND tests/light_validation_sync_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST light_validation_sync_test PROPERTY LABELS long_running_tests)
 
 if(ENABLE_COVERAGE_TESTING)
 

--- a/tests/light_validation_sync_test.py
+++ b/tests/light_validation_sync_test.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+from testUtils import Account
+from testUtils import Utils
+from Cluster import Cluster
+from WalletMgr import WalletMgr
+from Node import Node
+from Node import ReturnType
+from TestHelper import TestHelper
+from TestHelper import AppArgs
+import json
+
+###############################################################
+# light_validation_sync_test
+#
+# Test message sync for light validation mode.
+# 
+# This test creates a producer node and a light validation node.
+# Pushes a transaction with context free data to the producer
+# node and check the pushed transaction can be synched to
+# the validation node.
+#
+###############################################################
+
+# Parse command line arguments
+args = TestHelper.parse_args({"-v","--clean-run","--dump-error-details","--leave-running","--keep-logs"})
+Utils.Debug = args.v
+killAll=args.clean_run
+dumpErrorDetails=args.dump_error_details
+dontKill=args.leave_running
+killEosInstances=not dontKill
+killWallet=not dontKill
+keepLogs=args.keep_logs
+
+walletMgr=WalletMgr(True)
+cluster=Cluster(walletd=True)
+cluster.setWalletMgr(walletMgr)
+
+testSuccessful = False
+try:
+    TestHelper.printSystemInfo("BEGIN")
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+
+    assert cluster.launch(
+        pnodes=1,
+        prodCount=1,
+        totalProducers=1,
+        totalNodes=2,
+        useBiosBootFile=False,
+        loadSystemContract=False,
+        specificExtraNodeosArgs={
+            1:"--validation-mode light"})
+
+    producerNode = cluster.getNode(0)
+    validationNode = cluster.getNode(1)
+
+    # Create a transaction to create an account
+    Utils.Print("create a new account payloadless from the producer node")
+    payloadlessAcc = Account("payloadless")
+    payloadlessAcc.ownerPublicKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+    payloadlessAcc.activePublicKey = "EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV"
+    producerNode.createAccount(payloadlessAcc, cluster.eosioAccount)
+
+
+    contractDir="unittests/test-contracts/payloadless"
+    wasmFile="payloadless.wasm"
+    abiFile="payloadless.abi"
+    Utils.Print("Publish payloadless contract")
+    trans = producerNode.publishContract(payloadlessAcc, contractDir, wasmFile, abiFile, waitForTransBlock=True)
+
+    trx = {
+        "actions": [{"account": "payloadless", "name": "doit", "authorization": [{
+          "actor": "payloadless", "permission": "active"}], "data": ""}],
+        "context_free_actions": [{"account": "payloadless", "name": "doit", "data": ""}],
+        "context_free_data": ["a1b2c3", "1a2b3c"],
+    } 
+
+    cmd = "push transaction '{}' -p payloadless".format(json.dumps(trx))
+    trans = producerNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans, "Failed to push transaction with context free data"
+    
+    cfTrxBlockNum = int(trans["processed"]["block_num"])
+    cfTrxId = trans["transaction_id"]
+
+    # Wait until the block where create account is executed to become irreversible 
+    def isBlockNumIrr():
+        return validationNode.getIrreversibleBlockNum() >= cfTrxBlockNum
+    Utils.waitForBool(isBlockNumIrr, timeout=30, sleepTime=0.1)
+    
+    Utils.Print("verify the account payloadless from validation node")
+    cmd = "get account -j payloadless"
+    trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans["account_name"], "Failed to get the account payloadless"
+
+    Utils.Print("verify the context free transaction from validation node")
+    cmd = "get transaction " + cfTrxId
+    trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
+    assert trans, "Failed to get the transaction with context free data from the light validation node"
+
+    testSuccessful = True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful, killEosInstances, killWallet, keepLogs, killAll, dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)

--- a/tests/light_validation_sync_test.py
+++ b/tests/light_validation_sync_test.py
@@ -41,7 +41,7 @@ try:
     TestHelper.printSystemInfo("BEGIN")
     cluster.killall(allInstances=killAll)
     cluster.cleanup()
-
+    traceNodeosArgs = " --plugin eosio::trace_api_plugin --trace-no-abis "
     assert cluster.launch(
         pnodes=1,
         prodCount=1,
@@ -49,6 +49,7 @@ try:
         totalNodes=2,
         useBiosBootFile=False,
         loadSystemContract=False,
+        extraNodeosArgs=traceNodeosArgs,
         specificExtraNodeosArgs={
             1:"--validation-mode light"})
 
@@ -94,7 +95,7 @@ try:
     assert trans["account_name"], "Failed to get the account payloadless"
 
     Utils.Print("verify the context free transaction from validation node")
-    cmd = "get transaction " + cfTrxId
+    cmd = "get transaction_trace " + cfTrxId
     trans = validationNode.processCleosCmd(cmd, cmd, silentErrors=False)
     assert trans, "Failed to get the transaction with context free data from the light validation node"
 


### PR DESCRIPTION
> backports: https://github.com/EOSIO/eos/pull/8851
> Add an integration test for messaging syncing between a production node and a light validation node.

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/558