### PR TITLE
[3.2] Use NET bill in transaction receipt during light validation mode

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1498,7 +1498,7 @@ struct controller_impl {
 
          try {
             if( trx->implicit ) {
-               EOS_ASSERT( !explicit_net_usage_words.valid(), transaction_exception, "NET usage cannot be explicitly set for implicit transactions" );
+               EOS_ASSERT( !explicit_net_usage_words, transaction_exception, "NET usage cannot be explicitly set for implicit transactions" );
                trx_context.init_for_implicit_trx();
                trx_context.enforce_whiteblacklist = false;
             } else {

--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -31,7 +31,9 @@ namespace eosio { namespace chain {
 
    class transaction_context {
       private:
-         void init( uint64_t initial_net_usage);
+         void init( uint64_t initial_net_usage );
+
+         void init_for_input_trx_common( uint64_t initial_net_usage, bool skip_recording );
 
       public:
 
@@ -46,7 +48,10 @@ namespace eosio { namespace chain {
 
          void init_for_input_trx( uint64_t packed_trx_unprunable_size,
                                   uint64_t packed_trx_prunable_size,
-                                  bool skip_recording);
+                                  bool skip_recording );
+
+         void init_for_input_trx_with_explicit_net( uint32_t explicit_net_usage_words,
+                                                    bool skip_recording );
 
          void init_for_deferred_trx( fc::time_point published );
 
@@ -55,7 +60,17 @@ namespace eosio { namespace chain {
          void squash();
          void undo();
 
-         inline void add_net_usage( uint64_t u ) { net_usage += u; check_net_usage(); }
+         inline void add_net_usage( uint64_t u ) { 
+            if( explicit_net_usage ) return;
+            net_usage += u;
+            check_net_usage(); 
+         }
+
+         inline void round_up_net_usage() {
+            if( explicit_net_usage ) return;
+            net_usage = ((net_usage + 7)/8)*8; // Round up to nearest multiple of word size (8 bytes)
+            check_net_usage();
+         }
 
          void check_net_usage()const;
 
@@ -158,6 +173,7 @@ namespace eosio { namespace chain {
          bool                          net_limit_due_to_greylist = false;
          uint64_t                      eager_net_limit = 0;
          uint64_t&                     net_usage; /// reference to trace->net_usage
+         bool                          explicit_net_usage = false;
 
          bool                          cpu_limit_due_to_greylist = false;
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -270,6 +270,7 @@ namespace eosio { namespace chain {
    void transaction_context::init_for_input_trx_with_explicit_net( uint32_t explicit_net_usage_words,
                                                                    bool skip_recording )
    {
+      const transaction& trx = packed_trx.get_transaction();
       if( trx.transaction_extensions.size() > 0 ) {
          disallow_transaction_extensions( "no transaction extensions supported yet for input transactions" );
       }
@@ -282,6 +283,7 @@ namespace eosio { namespace chain {
 
    void transaction_context::init_for_input_trx_common( uint64_t initial_net_usage, bool skip_recording )
    {
+      const transaction& trx = packed_trx.get_transaction();
       published = control.pending_block_time();
       is_input = true;
       if (!control.skip_trx_checks()) {

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -89,7 +89,7 @@ namespace eosio { namespace chain {
       }
    }
 
-   void transaction_context::init(uint64_t initial_net_usage)
+   void transaction_context::init( uint64_t initial_net_usage )
    {
       EOS_ASSERT( !is_initialized, transaction_exception, "cannot initialize twice" );
 
@@ -230,7 +230,7 @@ namespace eosio { namespace chain {
       }
 
       published = control.pending_block_time();
-      init( initial_net_usage);
+      init( initial_net_usage );
    }
 
    void transaction_context::init_for_input_trx( uint64_t packed_trx_unprunable_size,
@@ -264,6 +264,24 @@ namespace eosio { namespace chain {
                                + static_cast<uint64_t>(config::transaction_id_net_usage);
       }
 
+      init_for_input_trx_common( initial_net_usage, skip_recording );
+   }
+
+   void transaction_context::init_for_input_trx_with_explicit_net( uint32_t explicit_net_usage_words,
+                                                                   bool skip_recording )
+   {
+      if( trx.transaction_extensions.size() > 0 ) {
+         disallow_transaction_extensions( "no transaction extensions supported yet for input transactions" );
+      }
+
+      explicit_net_usage = true;
+      net_usage = (static_cast<uint64_t>(explicit_net_usage_words) * 8);
+
+      init_for_input_trx_common( 0, skip_recording );
+   }
+
+   void transaction_context::init_for_input_trx_common( uint64_t initial_net_usage, bool skip_recording )
+   {
       published = control.pending_block_time();
       is_input = true;
       if (!control.skip_trx_checks()) {
@@ -271,7 +289,7 @@ namespace eosio { namespace chain {
          control.validate_tapos(trx);
          validate_referenced_accounts( trx, enforce_whiteblacklist && control.is_producing_block() );
       }
-      init( initial_net_usage);
+      init( initial_net_usage );
       if (!skip_recording)
          record_transaction( packed_trx.id(), trx.expiration ); /// checks for dupes
    }
@@ -360,10 +378,10 @@ namespace eosio { namespace chain {
          billing_timer_exception_code = tx_cpu_usage_exceeded::code_value;
       }
 
-      net_usage = ((net_usage + 7)/8)*8; // Round up to nearest multiple of word size (8 bytes)
-
       eager_net_limit = net_limit;
-      check_net_usage();
+
+      round_up_net_usage(); // Round up to nearest multiple of word size (8 bytes).
+      check_net_usage();    // Check that NET usage satisfies limits (even when explicit_net_usage is true).
 
       auto now = fc::time_point::now();
       trace->elapsed = now - start;
@@ -385,21 +403,19 @@ namespace eosio { namespace chain {
    }
 
    void transaction_context::check_net_usage()const {
-      if (!control.skip_trx_checks()) {
-         if( BOOST_UNLIKELY(net_usage > eager_net_limit) ) {
-            if ( net_limit_due_to_block ) {
-               EOS_THROW( block_net_usage_exceeded,
-                          "not enough space left in block: ${net_usage} > ${net_limit}",
-                          ("net_usage", net_usage)("net_limit", eager_net_limit) );
-            }  else if (net_limit_due_to_greylist) {
-               EOS_THROW( greylist_net_usage_exceeded,
-                          "greylisted transaction net usage is too high: ${net_usage} > ${net_limit}",
-                          ("net_usage", net_usage)("net_limit", eager_net_limit) );
-            } else {
-               EOS_THROW( tx_net_usage_exceeded,
-                          "transaction net usage is too high: ${net_usage} > ${net_limit}",
-                          ("net_usage", net_usage)("net_limit", eager_net_limit) );
-            }
+      if( BOOST_UNLIKELY(net_usage > eager_net_limit) ) {
+         if ( net_limit_due_to_block ) {
+            EOS_THROW( block_net_usage_exceeded,
+                        "not enough space left in block: ${net_usage} > ${net_limit}",
+                        ("net_usage", net_usage)("net_limit", eager_net_limit) );
+         }  else if (net_limit_due_to_greylist) {
+            EOS_THROW( greylist_net_usage_exceeded,
+                        "greylisted transaction net usage is too high: ${net_usage} > ${net_limit}",
+                        ("net_usage", net_usage)("net_limit", eager_net_limit) );
+         } else {
+            EOS_THROW( tx_net_usage_exceeded,
+                        "transaction net usage is too high: ${net_usage} > ${net_limit}",
+                        ("net_usage", net_usage)("net_limit", eager_net_limit) );
          }
       }
    }

--- a/libraries/testing/include/eosio/testing/tester.hpp
+++ b/libraries/testing/include/eosio/testing/tester.hpp
@@ -652,6 +652,18 @@ namespace eosio { namespace testing {
    };
 
    /**
+    * Utility predicate to check whether an fc::exception code is equivalent to a given value
+    */
+   struct fc_exception_code_is {
+      fc_exception_code_is( int64_t code )
+            : expected( code ) {}
+
+      bool operator()( const fc::exception& ex );
+
+      int64_t expected;
+   };
+
+   /**
     * Utility predicate to check whether an fc::exception message is equivalent to a given string
     */
    struct fc_exception_message_is {

--- a/libraries/testing/tester.cpp
+++ b/libraries/testing/tester.cpp
@@ -1197,6 +1197,15 @@ namespace eosio { namespace testing {
       preactivate_protocol_features( preactivations );
    }
 
+   bool fc_exception_code_is::operator()( const fc::exception& ex ) {
+      bool match = (ex.code() == expected);
+      if( !match ) {
+         auto message = ex.get_log().at( 0 ).get_message();
+         BOOST_TEST_MESSAGE( "LOG: expected code: " << expected << ", actual code: " << ex.code() << ", message: " << message );
+      }
+      return match;
+   }
+
    bool fc_exception_message_is::operator()( const fc::exception& ex ) {
       auto message = ex.get_log().at( 0 ).get_message();
       bool match = (message == expected);


### PR DESCRIPTION
> Since the NET bill is objective, a node in full validation mode is able to calculate what the NET bill for a transaction should be. Even with this change, a node in full validation mode will always compute the NET bill rather than blindly trusting the NET bill provided by the producer in the transaction receipt and it will reject the block if there is a mismatch.
> 
> However, with the changes in this PR, a node operating in a mode where the normal transaction checks are skipped (light validation mode or applying a block by a trusted producer) will now simply use the NET bill provided by the producer in the transaction receipt rather than computing the amount itself. This sets the stage for later changes that allow a light validation node to apply a block that may have had some context-free data within the block removed, which would make it impossible to calculate the correct NET bill.
> 
> This PR also adds a new unit test, resource_limits_test/light_net_validation, to test the new behavior.

Resolves #559 