### PR TITLE
Github workflow to create new jira issues on OCI label

### DIFF
--- a/.github/workflows/jiraIssueCreator.yml
+++ b/.github/workflows/jiraIssueCreator.yml
@@ -1,0 +1,42 @@
+name: Jira Issue Creator
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  create-jira-issue:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'OCI'
+    steps:
+      - name: Create json issue file
+        run: |
+          cat << EOF > issue.json
+          {
+              "fields": {
+                 "project":
+                 {
+                    "key": "$JIRA_PROJECT_KEY"
+                 },
+                 "summary": "$JIRA_ISSUE_SUMMARY",
+                 "description": "$JIRA_ISSUE_DESCRIPTION",
+                 "issuetype": {
+                    "name": "$JIRA_ISSUE_TYPE_NAME"
+                 }
+             }
+          }
+          EOF
+        env:
+          JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
+          JIRA_ISSUE_SUMMARY: ${{ github.event.issue.title }}
+          JIRA_ISSUE_DESCRIPTION: "${{ github.event.issue.url }}\\n\\n${{ github.event.issue.body }}"
+          JIRA_ISSUE_TYPE_NAME: "Story"
+      - name: Check issue json
+        run: |
+          cat issue.json
+      - name: Trigger jira issue creation
+        run: |
+          curl -u $JIRA_AUTH -X POST --data @issue.json -H "Content-Type: application/json" --url $JIRA_PROJECT_URL
+        env:
+          JIRA_AUTH: ${{ secrets.JIRA_USN_AND_TOKEN }}
+          JIRA_PROJECT_URL: ${{ secrets.JIRA_PROJECT_URL }}


### PR DESCRIPTION
Create github workflow to create new jira issues when github issues are labeled OCI.