### PR TITLE
[3.1] Fix race condition on trace_api_plugin shutdown

### DIFF
--- a/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
+++ b/plugins/trace_api_plugin/include/eosio/trace_api/store_provider.hpp
@@ -251,11 +251,11 @@ namespace eosio::trace_api {
       std::optional<uint32_t> _last_compressed_slice;
       const size_t _compression_seek_point_stride;
 
-      std::atomic<uint32_t> _best_known_lib{0};
       std::mutex _maintenance_mtx;
       std::condition_variable _maintenance_condition;
       std::thread _maintenance_thread;
-      std::atomic_bool _maintenance_shutdown{false};
+      bool _maintenance_shutdown{false};
+      uint32_t _best_known_lib{0};
    };
 
    /**


### PR DESCRIPTION
Failure https://github.com/eosnetworkfoundation/mandel/runs/7143297502?check_suite_focus=true pointed to an issue in shutdown of the `trace_api_plugin`.

`slice_directory::stop_maintenance_thread()` sets atomic bool `_maintenance_shutdown = true` and calls `notify_one()` on the `_maintenance_condition` condition variable. This is a race condition because it doesn't acquire the condition variable mutex setting up the possibility that `_maintenance_shutdown ` can be set to `true` and `notify_one` called after the while check in `slice_directory::start_maintenance_thread`  but before the `wait()` causing it to wait forever. This then blocks the `slice_directory::stop_maintenance_thread()` call of `join()` on the main thread, blocking the shutdown of all other plugins.

Changed the logic to correctly use a mutex and condition variable around `_best_known_lib` & `_maintenance_shutdown`. Also made these two variables non-atomic since they are now only accessed via the mutex. Also release the mutex before running the `run_maintenance_tasks()` which appeared to be the original intention with the use of the local variables.

Accidentally targeted `main` on #591 so this is a cherry-pick back to `3.1`.
