### PR TITLE
[3.2] Update jiraIssueCreator.yml

### DIFF
--- a/.github/workflows/jiraIssueCreator.yml
+++ b/.github/workflows/jiraIssueCreator.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           JIRA_PROJECT_KEY: ${{ secrets.JIRA_PROJECT_KEY }}
           JIRA_ISSUE_SUMMARY: ${{ github.event.issue.title }}
-          JIRA_ISSUE_DESCRIPTION: "${{ github.event.issue.url }}\\n\\n${{ github.event.issue.body }}"
+          JIRA_ISSUE_DESCRIPTION: "${{ github.event.issue.url }}"
           JIRA_ISSUE_TYPE_NAME: "Story"
       - name: Check issue json
         run: |


### PR DESCRIPTION
For now, remove github issue body as it will often break json format without some additional work.  For now just include the github issue link.