### PR TITLE
[3.2] remove old outdated MSVC paths in cmake files

### DIFF
--- a/libraries/chain/CMakeLists.txt
+++ b/libraries/chain/CMakeLists.txt
@@ -162,6 +162,3 @@ install( DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/eosio/chain/
       FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h" EXCLUDE
 )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/eosio/chain/core_symbol.hpp DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/eosio/chain COMPONENT dev EXCLUDE_FROM_ALL)
-#if(MSVC)
-#  set_source_files_properties( db_init.cpp db_block.cpp database.cpp block_log.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
-#endif(MSVC)

--- a/libraries/testing/CMakeLists.txt
+++ b/libraries/testing/CMakeLists.txt
@@ -18,10 +18,6 @@ target_include_directories( eosio_testing
                                    "${CMAKE_BINARY_DIR}/unittests/include"
                             )
 
-if(MSVC)
-  set_source_files_properties( db_init.cpp db_block.cpp database.cpp block_log.cpp PROPERTIES COMPILE_FLAGS "/bigobj" )
-endif(MSVC)
-
 set_target_properties( eosio_testing PROPERTIES PUBLIC_HEADER "${HEADERS}" )
 install( TARGETS eosio_testing
    RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR} COMPONENT dev EXCLUDE_FROM_ALL


### PR DESCRIPTION
Backport https://github.com/EOSIO/eos/pull/10310. Resolve https://github.com/eosnetworkfoundation/mandel/issues/463.

Original change description:
AFAIK no one has attempted a MSVC build in years. These aren't even right anyways. Remove this old cruft.