### PR TITLE
[3.2] Fix compile warnings in eos-vm-oc's memory.hpp, executor.cpp, and memory.cpp

### DIFF
--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp
@@ -52,7 +52,7 @@ class memory {
 
       // Changed from -cb_offset == EOS_VM_OC_CONTROL_BLOCK_OFFSET to get around
       // of compile warning about comparing integers of different signedness
-      static_assert(EOS_VM_OC_CONTROL_BLOCK_OFFSET + cb_offset == 0, "EEOS VM OC control block offset has slid out of place somehow");
+      static_assert(EOS_VM_OC_CONTROL_BLOCK_OFFSET + cb_offset == 0, "EOS VM OC control block offset has slid out of place somehow");
       static_assert(stride == EOS_VM_OC_MEMORY_STRIDE, "EOS VM OC memory stride has slid out of place somehow");
 
    private:

--- a/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp
+++ b/libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp
@@ -50,7 +50,9 @@ class memory {
       // The maximum amount of data that PIC code can include in the prologue
       static constexpr uintptr_t max_prologue_size = mutable_global_size + table_size;
 
-      static_assert(-cb_offset == EOS_VM_OC_CONTROL_BLOCK_OFFSET, "EOS VM OC control block offset has slid out of place somehow");
+      // Changed from -cb_offset == EOS_VM_OC_CONTROL_BLOCK_OFFSET to get around
+      // of compile warning about comparing integers of different signedness
+      static_assert(EOS_VM_OC_CONTROL_BLOCK_OFFSET + cb_offset == 0, "EEOS VM OC control block offset has slid out of place somehow");
       static_assert(stride == EOS_VM_OC_MEMORY_STRIDE, "EOS VM OC memory stride has slid out of place somehow");
 
    private:

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp
@@ -223,7 +223,7 @@ void executor::execute(const code_descriptor& code, memory& mem, apply_context& 
       cb->bounce_buffers->clear();
       tt.set_expiration_callback(nullptr, nullptr);
 
-      uint64_t base_pages = mem.size_of_memory_slice_mapping()/memory::stride - 1;
+      int64_t base_pages = mem.size_of_memory_slice_mapping()/memory::stride - 1;
       if(cb->current_linear_memory_pages > base_pages) {
          mprotect(mem.full_page_memory_base() + base_pages * eosio::chain::wasm_constraints::wasm_page_size,
                   (cb->current_linear_memory_pages - base_pages) * eosio::chain::wasm_constraints::wasm_page_size, PROT_NONE);

--- a/libraries/chain/webassembly/runtimes/eos-vm-oc/memory.cpp
+++ b/libraries/chain/webassembly/runtimes/eos-vm-oc/memory.cpp
@@ -25,7 +25,7 @@ memory::memory(uint64_t max_pages) {
    FC_ASSERT(mapbase != MAP_FAILED, "Failed to mmap memory");
 
    uint8_t* next_slice = mapbase;
-   uint8_t* last;
+   uint8_t* last = nullptr;
 
    for(unsigned int p = 0; p < number_slices; ++p) {
       last = (uint8_t*)mmap(next_slice, memory_prologue_size+64u*1024u*p, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, fd, 0);
@@ -33,6 +33,7 @@ memory::memory(uint64_t max_pages) {
       next_slice += total_memory_per_slice;
    }
 
+   FC_ASSERT(last != nullptr, "expected last not nullptr");
    zeropage_base = mapbase + memory_prologue_size;
    fullpage_base = last + memory_prologue_size;
 


### PR DESCRIPTION
Resolve https://github.com/eosnetworkfoundation/mandel/issues/612

Fix the following warnings. Please double check if my fixes for `memory.cpp` and `executor.cpp` do not break anything. Thanks.

```
.../libraries/chain/include/eosio/chain/webassembly/eos-vm-oc/memory.hpp:53:32: warning: comparison of integer expressions of different signedness: ‘long unsigned int’ and ‘int’ [-Wsign-compare]
   53 |       static_assert(-cb_offset == EOS_VM_OC_CONTROL_BLOCK_OFFSET, "EOS VM OC control block offset has slid out of place somehow");

.../libraries/chain/webassembly/runtimes/eos-vm-oc/memory.cpp: In constructor ‘eosio::chain::eosvmoc::memory::memory(uint64_t)’:
.../libraries/chain/webassembly/runtimes/eos-vm-oc/memory.cpp:37:25: warning: ‘last’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   37 |    fullpage_base = last + memory_prologue_size;
      |                    ~~~~~^~~~~~~~~~~~~~~~~~~~~~

.../libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp: In lambda function:
.../libraries/chain/webassembly/runtimes/eos-vm-oc/executor.cpp:227:42: warning: comparison of integer expressions of different signedness: ‘int64_t’ {aka ‘long  int’} and ‘uint64_t’ {aka ‘long unsigned int’} [-Wsign-compare]
  227 |       if(cb->current_linear_memory_pages > base_pages) {
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
```