### PR TITLE
[3.1] ensure an empty llvm-dev dep doesn't make its way to mandel-dev .deb

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -49,9 +49,9 @@ string(REGEX REPLACE "^(${CMAKE_PROJECT_NAME})" "\\1-dev" CPACK_DEBIAN_DEV_FILE_
 #deb package tooling will be unable to detect deps for the dev package. llvm is tricky since we don't know what package could have been used; try to figure it out
 set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "libboost-all-dev;libssl-dev;libgmp-dev")
 find_program(DPKG_QUERY "dpkg-query")
-if(DPKG_QUERY AND OS_RELEASE MATCHES "\n?ID=\"?ubuntu")
+if(DPKG_QUERY AND OS_RELEASE MATCHES "\n?ID=\"?ubuntu" AND LLVM_CMAKE_DIR)
    execute_process(COMMAND "${DPKG_QUERY}" -S "${LLVM_CMAKE_DIR}" COMMAND cut -d: -f1 RESULT_VARIABLE LLVM_PKG_FIND_RESULT OUTPUT_VARIABLE LLVM_PKG_FIND_OUTPUT)
-   if(LLVM_PKG_FIND_RESULT EQUAL 0)
+   if(LLVM_PKG_FIND_OUTPUT)
       string(STRIP "${LLVM_PKG_FIND_OUTPUT}" LLVM_PKG_FIND_OUTPUT)
       list(APPEND CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "${LLVM_PKG_FIND_OUTPUT}")
    endif()


### PR DESCRIPTION
When packing the experimental mandel-dev package need to more mindful when trying to discover the llvm-dev package currently in use. (we need to discover this because for some version of Ubuntu we don't know if someone used llvm-11-dev or llvm-10-dev or llvm-9-dev or ... yes all those are available in Ubuntu 20.04). If we're not mindful when doing the discovery we can accidentally stick an empty dependency in to the dependency list leading to a Bad Time.

First off, don't even perform the discovery if `LLVM_CMAKE_DIR` isn't set, which will be the case on something like aarch64 (arm8) where EOS VM OC isn't supported ergo there is no dep on llvm in the first place.

Second, ouch that `LLVM_PKG_FIND_RESULT EQUAL 0` check is no good because like a pipe on the command line it only gets you the exit status of the last command (`cut` in this case, which is happy to return 0 when `dpkg-query` returns no output on stdout when it errors out). This look up will fail when doing a pinned build because a pinned build doesn't use the system LLVM packages. Really what we should be using here is `RESULTS_VARIABLE` but sadly that's CMake 3.10+. Just change this to make sure `LLVM_PKG_FIND_OUTPUT` isn't empty which seems good enough from my testing since `dpkg-query` is silent on stdout on error.