### PR TITLE
Backport: fix bug in trace_api_plugin no params returned #467

### DIFF
--- a/plugins/trace_api_plugin/abi_data_handler.cpp
+++ b/plugins/trace_api_plugin/abi_data_handler.cpp
@@ -31,7 +31,11 @@ namespace eosio::trace_api {
                   auto params = serializer_p->binary_to_variant(type_name, action.data, abi_yield);
                   if constexpr (std::is_same_v<T, action_trace_v1>) {
                      if(action.return_value.size() > 0) {
-                        ret_data = serializer_p->binary_to_variant(type_name, action.return_value, abi_yield);
+                        // catch exception in place if any (aside from empty return value handled line above)
+                        try {
+                           ret_data = serializer_p->binary_to_variant(type_name, action.return_value, abi_yield);
+                        }
+                        catch(...) {  }
                      }
                   }
                   return {params, ret_data};

--- a/tests/trace_plugin_test.py
+++ b/tests/trace_plugin_test.py
@@ -32,7 +32,7 @@ class TraceApiPluginTest(unittest.TestCase):
     def startEnv(self) :
         account_names = ["alice", "bob", "charlie"]
         abs_path = os.path.abspath(os.getcwd() + '/unittests/contracts/eosio.token/eosio.token.abi')
-        traceNodeosArgs = " --plugin eosio::trace_api_plugin --trace-rpc-abi eosio.token=" + abs_path
+        traceNodeosArgs = " --plugin eosio::trace_api_plugin --trace-rpc-abi eosio.token=" + abs_path + " --trace-dir=."
         self.cluster.launch(totalNodes=1, extraNodeosArgs=traceNodeosArgs)
         self.walletMgr.launch()
         testWalletName="testwallet"


### PR DESCRIPTION
This is may not be needed, it wrapping of serializer's binary_to_variant call in try/catch as what backport suggests. Current implementation already checks for empty return_value. But can serializer throw for another reason then empty string?