### PR TITLE
[3.1 -> main] ensure an empty llvm-dev dep doesn't make its way to mandel-dev .deb

### DIFF
--- a/package.cmake
+++ b/package.cmake
@@ -49,9 +49,9 @@ string(REGEX REPLACE "^(${CMAKE_PROJECT_NAME})" "\\1-dev" CPACK_DEBIAN_DEV_FILE_
 #deb package tooling will be unable to detect deps for the dev package. llvm is tricky since we don't know what package could have been used; try to figure it out
 set(CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "libboost-all-dev;libssl-dev;libgmp-dev")
 find_program(DPKG_QUERY "dpkg-query")
-if(DPKG_QUERY AND OS_RELEASE MATCHES "\n?ID=\"?ubuntu")
+if(DPKG_QUERY AND OS_RELEASE MATCHES "\n?ID=\"?ubuntu" AND LLVM_CMAKE_DIR)
    execute_process(COMMAND "${DPKG_QUERY}" -S "${LLVM_CMAKE_DIR}" COMMAND cut -d: -f1 RESULT_VARIABLE LLVM_PKG_FIND_RESULT OUTPUT_VARIABLE LLVM_PKG_FIND_OUTPUT)
-   if(LLVM_PKG_FIND_RESULT EQUAL 0)
+   if(LLVM_PKG_FIND_OUTPUT)
       string(STRIP "${LLVM_PKG_FIND_OUTPUT}" LLVM_PKG_FIND_OUTPUT)
       list(APPEND CPACK_DEBIAN_DEV_PACKAGE_DEPENDS "${LLVM_PKG_FIND_OUTPUT}")
    endif()


### PR DESCRIPTION
main port of #618 for ensuring dependency list in the experimental -dev package doesn't end up with an empty package when failing to discover llvm package