### PR TITLE
[3.2] fixing compile warnings in cleos main.cpp

### DIFF
--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -3176,6 +3176,7 @@ int main( int argc, char** argv ) {
       }
    });
 
+   get_schedule_subcommand{get};
    auto getTransactionId = get_transaction_id_subcommand{get};
 
    // set subcommand

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -212,6 +212,7 @@ packed_transaction::compression_type to_compression_type( tx_compression_type t 
       case tx_compression_type::none: return packed_transaction::compression_type::none;
       case tx_compression_type::zlib: return packed_transaction::compression_type::zlib;
       case tx_compression_type::default_compression: return packed_transaction::compression_type::none;
+      default: EOS_ASSERT(false, unknown_transaction_compression, "unknown transaction compression type");
    }
 }
 
@@ -500,7 +501,7 @@ fc::variant push_transaction( signed_transaction& trx, const std::vector<public_
       if (!tx_return_packed) {
          try {
             fc::variant unpacked_data_trx;
-            abi_serializer::to_variant(trx, unpacked_data_trx, abi_serializer_resolver, abi_serializer_max_time);
+            abi_serializer::to_variant(trx, unpacked_data_trx, abi_serializer_resolver, abi_serializer::create_yield_function(abi_serializer_max_time));
             return unpacked_data_trx;
          } catch (...) {
             return fc::variant(trx);
@@ -3175,7 +3176,6 @@ int main( int argc, char** argv ) {
       }
    });
 
-   auto getSchedule = get_schedule_subcommand{get};
    auto getTransactionId = get_transaction_id_subcommand{get};
 
    // set subcommand


### PR DESCRIPTION
Resolved https://github.com/eosnetworkfoundation/mandel/issues/619

Fixed the following warnings. Now `cleos main.cpp` compiles without any warnings.

```
.../programs/cleos/main.cpp: In function ‘fc::variant push_transaction(eosio::chain::signed_transaction&, const std::vector<fc::crypto::public_key>&)’:
.../programs/cleos/main.cpp:503:112: warning: ‘static void eosio::chain::abi_serializer::to_variant(const T&, fc::variant&, Resolver, const fc::microseconds&) [with T = eosio::chain::signed_transaction; Resolver = <lambda(const eosio::chain::name&)>]’ is deprecated: use the overload with yield_function_t[=create_yield_function(max_serialization_time)] [-Wdeprecated-declarations]
  503 |             abi_serializer::to_variant(trx, unpacked_data_trx, abi_serializer_resolver, abi_serializer_max_time);
      |                                                                                                                ^
In file included from .../libraries/chain/include/eosio/chain/controller.hpp:9,
                 from .../plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp:7,
                 from .../programs/cleos/main.cpp:83:
.../libraries/chain/include/eosio/chain/abi_serializer.hpp:947:6: note: declared here
  947 | void abi_serializer::to_variant( const T& o, fc::variant& vo, Resolver resolver, const fc::microseconds& max_serialization_time ) {
      |      ^~~~~~~~~~~~~~
.../programs/cleos/main.cpp:503:112: warning: ‘static void eosio::chain::abi_serializer::to_variant(const T&, fc::variant&, Resolver, const fc::microseconds&) [with T = eosio::chain::signed_transaction; Resolver = <lambda(const eosio::chain::name&)>]’ is deprecated: use the overload with yield_function_t[=create_yield_function(max_serialization_time)] [-Wdeprecated-declarations]
  503 |             abi_serializer::to_variant(trx, unpacked_data_trx, abi_serializer_resolver, abi_serializer_max_time);
      |                                                                                                                ^
In file included from /.../libraries/chain/include/eosio/chain/controller.hpp:9,
                 from .../plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp:7,
                 from .../programs/cleos/main.cpp:83:
.../libraries/chain/include/eosio/chain/abi_serializer.hpp:947:6: note: declared here
  947 | void abi_serializer::to_variant( const T& o, fc::variant& vo, Resolver resolver, const fc::microseconds& max_serialization_time ) {
      |      ^~~~~~~~~~~~~~
.../programs/cleos/main.cpp: In function ‘int main(int, char**)’:
.../programs/cleos/main.cpp:3178:9: warning: variable ‘getSchedule’ set but not used [-Wunused-but-set-variable]
 3178 |    auto getSchedule = get_schedule_subcommand{get};
      |         ^~~~~~~~~~~
.../programs/cleos/main.cpp: In function ‘eosio::chain::packed_transaction::compression_type to_compression_type(tx_compression_type)’:
.../programs/cleos/main.cpp:216:1: warning: control reaches end of non-void function [-Wreturn-type]
  216 | }
      | ^
```

