### PR TITLE
[3.2] Backport: move fc::blob to/from_variant out of libchain to fc

### DIFF
--- a/libraries/chain/include/eosio/chain/database_utils.hpp
+++ b/libraries/chain/include/eosio/chain/database_utils.hpp
@@ -186,17 +186,6 @@ namespace fc {
       b = eosio::chain::shared_blob(_s.begin(), _s.end(), b.get_allocator());
    }
 
-   inline
-   void to_variant( const blob& b, variant& v ) {
-      v = variant(base64_encode(b.data.data(), b.data.size()));
-   }
-
-   inline
-   void from_variant( const variant& v, blob& b ) {
-      string _s = base64_decode(v.as_string());
-      b.data = std::vector<char>(_s.begin(), _s.end());
-   }
-
    template<typename T>
    void to_variant( const eosio::chain::shared_vector<T>& sv, variant& v ) {
       to_variant(std::vector<T>(sv.begin(), sv.end()), v);


### PR DESCRIPTION
Resolves: https://github.com/eosnetworkfoundation/mandel/issues/439

Needs: https://github.com/eosnetworkfoundation/mandel-fc/pull/42