### PR TITLE
[3.2] controller::extract_chain_id_from_db() does not properly handle dirty db

### DIFF
--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3480,10 +3480,7 @@ std::optional<chain_id_type> controller::extract_chain_id_from_db( const path& s
       if (gpo==nullptr) return {};
 
       return gpo->chain_id;
-
-   } catch (std::system_error &) {   
-   
-   } 
+   } catch (std::system_error &) {} //  do not propagate db_error_code::not_found" for absent db, so it will be created 
 
    return {};
 }

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -3476,11 +3476,14 @@ std::optional<chain_id_type> controller::extract_chain_id_from_db( const path& s
 
       if( db.revision() < 1 ) return {};
 
-      return db.get<global_property_object>().chain_id;
-   } catch( const bad_database_version_exception& ) {
-      throw;
-   } catch( ... ) {
-   }
+      auto * gpo = db.find<global_property_object>();
+      if (gpo==nullptr) return {};
+
+      return gpo->chain_id;
+
+   } catch (std::system_error &) {   
+   
+   } 
 
    return {};
 }


### PR DESCRIPTION
This change adds following logic:
- all exceptions  except system_error are propagated. system_error happens for example if database do not exist and needs to be created
- if chain_id cannot be retrieved empty variant returned, get replaced with find