### PR TITLE
[3.1] Use signed transaction for PUSH_CREATE action deep-mind logging.

### DIFF
--- a/libraries/chain/deep_mind.cpp
+++ b/libraries/chain/deep_mind.cpp
@@ -225,6 +225,23 @@ namespace eosio::chain {
          ("trx", fc::to_hex(gto.packed_trx.data(), gto.packed_trx.size()))
       );
    }
+   void deep_mind_handler::on_create_deferred(operation_qualifier qual, const generated_transaction_object& gto, const packed_transaction& packed_trx)
+   {
+      auto packed_signed_trx = fc::raw::pack(packed_trx.get_signed_transaction());
+
+      fc_dlog(_logger, "DTRX_OP ${qual}CREATE ${action_id} ${sender} ${sender_id} ${payer} ${published} ${delay} ${expiration} ${trx_id} ${trx}",
+         ("qual", prefix(qual))
+         ("action_id", _action_id)
+         ("sender", gto.sender)
+         ("sender_id", gto.sender_id)
+         ("payer", gto.payer)
+         ("published", gto.published)
+         ("delay", gto.delay_until)
+         ("expiration", gto.expiration)
+         ("trx_id", gto.trx_id)
+         ("trx", fc::to_hex(packed_signed_trx.data(), packed_signed_trx.size()))
+      );
+   }
    void deep_mind_handler::on_fail_deferred()
    {
       fc_dlog(_logger, "DTRX_OP FAILED ${action_id}",

--- a/libraries/chain/include/eosio/chain/deep_mind.hpp
+++ b/libraries/chain/include/eosio/chain/deep_mind.hpp
@@ -14,6 +14,7 @@ class permission_object;
 struct block_state;
 struct protocol_feature;
 struct signed_transaction;
+struct packed_transaction;
 struct transaction_trace;
 struct ram_trace;
 namespace resource_limits {
@@ -72,6 +73,7 @@ public:
    void on_send_context_free_inline();
    void on_cancel_deferred(operation_qualifier qual, const generated_transaction_object& gto);
    void on_send_deferred(operation_qualifier qual, const generated_transaction_object& gto);
+   void on_create_deferred(operation_qualifier qual, const generated_transaction_object& gto, const packed_transaction& packed_trx);
    void on_fail_deferred();
    void on_create_table(const table_id_object& tid);
    void on_remove_table(const table_id_object& tid);

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -695,7 +695,7 @@ namespace eosio { namespace chain {
         if (auto dm_logger = control.get_deep_mind_logger()) {
            std::string event_id = RAM_EVENT_ID("${id}", ("id", gto.id));
 
-           dm_logger->on_send_deferred(deep_mind_handler::operation_qualifier::push, gto);
+           dm_logger->on_create_deferred(deep_mind_handler::operation_qualifier::push, gto, packed_trx);
            dm_logger->on_ram_trace(std::move(event_id), "deferred_trx", "push", "deferred_trx_pushed");
         }
       });


### PR DESCRIPTION
Resolves: https://github.com/eosnetworkfoundation/mandel/issues/651

Looking at the deep-mind plugin, the version that has been integrated into eosio v2.1 writes signed transactions into the dmlog on `PUSH_CREATE` deferred transactions, see [here](https://github.com/EOSIO/eos/blob/release/2.1.x/libraries/chain/transaction_context.cpp#L695).

The current mandel seems to use the packed transaction instead though, see [here](https://github.com/eosnetworkfoundation/mandel/blob/main/libraries/chain/deep_mind.cpp#L225). This should be only used for `MODIFY_CREATE` while `PUSH_CREATE` should write the signed transaction.