### PR TITLE
[3.2] disable appbase's automatic version discovery via git

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory( wasm-jit )
 remove_definitions( -w )
 
 add_subdirectory( chainbase )
+set(APPBASE_ENABLE_AUTO_VERSION OFF CACHE BOOL "enable automatic discovery of version via 'git describe'")
 add_subdirectory( appbase )
 add_subdirectory( chain )
 add_subdirectory( testing )


### PR DESCRIPTION
> Once upon a time in an eosio version long ago, the sole mechanism to populate the version displayed by, say, nodeos --version was via appbase discovering the version by git describe. At some point we changed this up a bit and the bottom line is that libraries/version is the only location that probes git for creating a string ultimately baked in to the build.
> 
> This makes the git describe in appbase a complete waste as its output is never included in to final executables. Since this git describe is run literally every time performing a make, seemed worth the trouble to disable it.



Needs https://github.com/eosnetworkfoundation/mandel-appbase/pull/9

Resolves https://github.com/eosnetworkfoundation/mandel/issues/442