### PR TITLE
[3.2] Backport: fix wrong cleos version returned in getClientVersion of tests/Cluster.py

### DIFF
--- a/tests/Cluster.py
+++ b/tests/Cluster.py
@@ -603,16 +603,23 @@ class Cluster(object):
         return ret
 
     @staticmethod
-    def getClientVersion(verbose=False):
+    def getClientVersion(fullVersion=False):
         """Returns client version (string)"""
+        p = re.compile(r'^v?(.+)\n$')
         try:
             cmd="%s version client" % (Utils.EosClientPath)
-            if verbose: Utils.Print("cmd: %s" % (cmd))
+            if fullVersion: cmd="%s version full" % (Utils.EosClientPath)
+            if Utils.Debug: Utils.Print("cmd: %s" % (cmd))
             response=Utils.checkOutput(cmd.split())
             assert(response)
             assert(isinstance(response, str))
-            if verbose: Utils.Print("response: <%s>" % (response))
-            verStr=response.strip()
+            if Utils.Debug: Utils.Print("response: <%s>" % (response))
+            m=p.match(response)
+            if m is None:
+                Utils.Print("ERROR: client version regex mismatch")
+                return None
+
+            verStr=m.group(1)
             return verStr
         except subprocess.CalledProcessError as ex:
             msg=ex.output.decode("utf-8")


### PR DESCRIPTION
Fix `getClientVersion`.

`getClientVersion` now returns a version format as expected from `cleos version client`  (ex. `3.2.0-dev`)

If `fullVersion` is enabled (`fullVersion=True`), `cleos version full` will be returned which includes commit version (ex. `3.2.0-dev-f04f8baed26b2c56ae67d51f2ba6d41e494c0f47-dirty`)

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/465