### PR TITLE
[3.1 -> main] Fix trx_finality_status_test

### DIFF
--- a/tests/trx_finality_status_test.py
+++ b/tests/trx_finality_status_test.py
@@ -47,7 +47,6 @@ dontKill=args.leave_running
 prodCount=1
 killAll=args.clean_run
 walletPort=TestHelper.DEFAULT_WALLET_PORT
-totalNodes=pnodes+1
 
 walletMgr=WalletMgr(True, port=walletPort)
 testSuccessful=False


### PR DESCRIPTION
Remove hardcoded `totalNodes`. Test was designed to have at least 2 more speculative nodes than block producers. Looks like an accidental hardcoded value as introduced into the test.

Resolves #677 