### PR TITLE
[3.2] Merge pull request #10727 from EOSIO/keke_epe948

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -211,6 +211,19 @@ namespace eosio { namespace chain {
       return ends_with(type, "[]");
    }
 
+   bool abi_serializer::is_szarray(const string_view& type)const {
+      auto pos1 = type.find_last_of('[');
+      auto pos2 = type.find_last_of(']');
+      if(pos1 == string_view::npos || pos2 == string_view::npos) return false;
+      auto pos = pos1 + 1;
+      if(pos == pos2) return false;
+      while(pos < pos2) {
+         if( ! (type[pos] >= '0' && type[pos] <= '9') ) return false;
+         ++pos;
+      }
+      return true;
+   }
+
    bool abi_serializer::is_optional(const string_view& type)const {
       return ends_with(type, "?");
    }
@@ -227,6 +240,8 @@ namespace eosio { namespace chain {
    std::string_view abi_serializer::fundamental_type(const std::string_view& type)const {
       if( is_array(type) ) {
          return type.substr(0, type.size()-2);
+      } else if (is_szarray (type) ){
+         return type.substr(0, type.find_last_of('['));
       } else if ( is_optional(type) ) {
          return type.substr(0, type.size()-1);
       } else {

--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -45,6 +45,7 @@ struct abi_serializer {
    /// @return string_view of `t` or internal string type
    std::string_view resolve_type(const std::string_view& t)const;
    bool      is_array(const std::string_view& type)const;
+   bool      is_szarray(const std::string_view& type)const;
    bool      is_optional(const std::string_view& type)const;
    bool      is_type( const std::string_view& type, const yield_function_t& yield )const;
    [[deprecated("use the overload with yield_function_t[=create_yield_function(max_serialization_time)]")]]


### PR DESCRIPTION
Partly support using std::array in smart contract

```
Now std::array can be used in function, in struct, and also OK to nested using.
However, std::array can't be as parameter or return of an ACTION so far.
```

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/526

Relates to: https://github.com/eosnetworkfoundation/mandel.cdt/pull/36