### PR TITLE
[3.2] Add tests for creating public key with no private key

### DIFF
--- a/unittests/auth_tests.cpp
+++ b/unittests/auth_tests.cpp
@@ -226,6 +226,44 @@ try {
 
 } FC_LOG_AND_RETHROW() }
 
+BOOST_AUTO_TEST_CASE(update_auth_unknown_private_key) {
+   try {
+      TESTER chain;
+      chain.create_account(name("alice"));
+
+      // Change owner permission
+      const auto new_owner_priv_key = chain.get_private_key(name("alice"), "new_owner");
+
+      // public key with no corresponding private key
+      fc::ecc::public_key_data data;
+      data.data[0] = 0x80; // not necessary, 0 also works
+      fc::sha256 hash = fc::sha256::hash("unknown key");
+      std::memcpy(&data.data[1], hash.data(), hash.data_size() );
+      fc::ecc::public_key_shim shim(data);
+      fc::crypto::public_key new_owner_pub_key(std::move(shim));
+
+      chain.set_authority(name("alice"), name("owner"), authority(new_owner_pub_key), {});
+      chain.produce_blocks();
+
+      // Ensure the permission is updated
+      permission_object::id_type owner_id;
+      {
+         auto obj = chain.find<permission_object, by_owner>(boost::make_tuple(name("alice"), name("owner")));
+         BOOST_TEST(obj != nullptr);
+         BOOST_TEST(obj->owner == name("alice"));
+         BOOST_TEST(obj->name == name("owner"));
+         BOOST_TEST(obj->parent == 0);
+         owner_id = obj->id;
+         auto auth = obj->auth.to_authority();
+         BOOST_TEST(auth.threshold == 1u);
+         BOOST_TEST(auth.keys.size() == 1u);
+         BOOST_TEST(auth.accounts.size() == 0u);
+         BOOST_TEST(auth.keys[0].key == new_owner_pub_key);
+         BOOST_TEST(auth.keys[0].weight == 1);
+      }
+   } FC_LOG_AND_RETHROW()
+}
+
 BOOST_AUTO_TEST_CASE(link_auths) { try {
    TESTER chain;
 

--- a/unittests/misc_tests.cpp
+++ b/unittests/misc_tests.cpp
@@ -1199,6 +1199,26 @@ BOOST_AUTO_TEST_CASE(bad_alloc_test) {
    BOOST_CHECK( ptr == nullptr );
 }
 
+BOOST_AUTO_TEST_CASE(public_key_from_hash) {
+   auto private_key_string = std::string("5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3");
+   auto expected_public_key = std::string("EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV");
+   auto test_private_key = fc::crypto::private_key(private_key_string);
+   auto test_public_key = test_private_key.get_public_key();
+   fc::crypto::public_key eos_pk(expected_public_key);
+
+   BOOST_CHECK_EQUAL(private_key_string, test_private_key.to_string());
+   BOOST_CHECK_EQUAL(expected_public_key, test_public_key.to_string());
+   BOOST_CHECK_EQUAL(expected_public_key, eos_pk.to_string());
+
+   fc::ecc::public_key_data data;
+   data.data[0] = 0x80; // not necessary, 0 also works
+   fc::sha256 hash = fc::sha256::hash("unknown private key");
+   std::memcpy(&data.data[1], hash.data(), hash.data_size() );
+   fc::ecc::public_key_shim shim(data);
+   fc::crypto::public_key eos_unknown_pk(std::move(shim));
+   ilog( "public key with no known private key: ${k}", ("k", eos_unknown_pk) );
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace eosio


### PR DESCRIPTION
> Demonstrate creating a public key directly from a hash with no known private key.
> public key with no known private key: EOS5JU1RRZkMdzuRFubAXFasH2WfvPdJ8fKesxfJgh1dhcmkUfuw5Y
> https://github.com/EOSIO/eos/pull/10838
Resolves https://github.com/eosnetworkfoundation/mandel/issues/452