### PR TITLE
[3.2] Add chain api get_consensus_parameters

### DIFF
--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -132,6 +132,8 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required)
+      CHAIN_RO_CALL(get_all_accounts, 200, http_params_types::params_required),
+      CHAIN_RO_CALL(get_consensus_parameters, 200, http_params_types::no_params_required)
    });
 
    if (chain.account_queries_enabled()) {

--- a/plugins/chain_api_plugin/chain_api_plugin.cpp
+++ b/plugins/chain_api_plugin/chain_api_plugin.cpp
@@ -131,9 +131,8 @@ void chain_api_plugin::plugin_startup() {
       CHAIN_RW_CALL_ASYNC(push_transaction, chain_apis::read_write::push_transaction_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(push_transactions, chain_apis::read_write::push_transactions_results, 202, http_params_types::params_required),
       CHAIN_RW_CALL_ASYNC(send_transaction, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required),
-      CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required)
-      CHAIN_RO_CALL(get_all_accounts, 200, http_params_types::params_required),
-      CHAIN_RO_CALL(get_consensus_parameters, 200, http_params_types::no_params_required)
+      CHAIN_RW_CALL_ASYNC(send_transaction2, chain_apis::read_write::send_transaction_results, 202, http_params_types::params_required),
+      CHAIN_RO_CALL(get_consensus_parameters, 200, http_params_types::no_params)
    });
 
    if (chain.account_queries_enabled()) {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -15,7 +15,7 @@
 #include <eosio/chain/deep_mind.hpp>
 #include <eosio/chain_plugin/trx_finality_status_processing.hpp>
 #include <eosio/chain/permission_link_object.hpp>
-
+#include <eosio/chain/global_property_object.hpp>
 #include <eosio/chain/eosio_contract.hpp>
 
 #include <eosio/resource_monitor_plugin/resource_monitor_plugin.hpp>

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2742,6 +2742,17 @@ chain::symbol read_only::extract_core_symbol()const {
    return core_symbol;
 }
 
+read_only::get_consensus_parameters_results
+read_only::get_consensus_parameters(const get_consensus_parameters_params& ) const {
+   get_consensus_parameters_results results;
+
+   results.chain_config = db.get_global_properties().configuration;
+   results.kv_database_config = db.get_global_properties().kv_configuration;
+   results.wasm_config = db.get_global_properties().wasm_configuration;
+
+   return results;
+}
+
 } // namespace chain_apis
 
 fc::variant chain_plugin::get_log_trx_trace(const transaction_trace_ptr& trx_trace ) const {

--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -2747,7 +2747,6 @@ read_only::get_consensus_parameters(const get_consensus_parameters_params& ) con
    get_consensus_parameters_results results;
 
    results.chain_config = db.get_global_properties().configuration;
-   results.kv_database_config = db.get_global_properties().kv_configuration;
    results.wasm_config = db.get_global_properties().wasm_configuration;
 
    return results;

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -671,6 +671,33 @@ public:
 
    chain::symbol extract_core_symbol()const;
 
+   struct get_all_accounts_result {
+      struct account_result {
+         chain::name                          name;
+         chain::block_timestamp_type          creation_date;
+      };
+
+      std::vector<account_result> accounts;
+
+      std::optional<chain::name> more;
+   };
+
+   struct get_all_accounts_params {
+      uint32_t                    limit = 10;
+      std::optional<chain::name>  lower_bound;
+      std::optional<chain::name>  upper_bound;
+      bool                        reverse = false;
+   };
+
+   get_all_accounts_result get_all_accounts( const get_all_accounts_params& params)  const;
+
+   using get_consensus_parameters_params = empty;
+   struct get_consensus_parameters_results {
+     chain::chain_config        chain_config;
+     chain::kv_database_config  kv_database_config;
+     chain::wasm_config         wasm_config;
+   };
+   get_consensus_parameters_results get_consensus_parameters(const get_consensus_parameters_params&) const;
 };
 
 class read_write {
@@ -905,4 +932,7 @@ FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_params, (transaction))
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_results, (transaction_id)(processed) )
-
+FC_REFLECT( eosio::chain_apis::read_only::get_all_accounts_params, (limit)(lower_bound)(upper_bound)(reverse) )
+FC_REFLECT( eosio::chain_apis::read_only::get_all_accounts_result::account_result, (name)(creation_date))
+FC_REFLECT( eosio::chain_apis::read_only::get_all_accounts_result, (accounts)(more))
+FC_REFLECT( eosio::chain_apis::read_only::get_consensus_parameters_results, (chain_config)(kv_database_config)(wasm_config))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -12,6 +12,7 @@
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/fixed_bytes.hpp>
+#include <eosio/chain/kv_config.hpp>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -671,26 +672,6 @@ public:
 
    chain::symbol extract_core_symbol()const;
 
-   struct get_all_accounts_result {
-      struct account_result {
-         chain::name                          name;
-         chain::block_timestamp_type          creation_date;
-      };
-
-      std::vector<account_result> accounts;
-
-      std::optional<chain::name> more;
-   };
-
-   struct get_all_accounts_params {
-      uint32_t                    limit = 10;
-      std::optional<chain::name>  lower_bound;
-      std::optional<chain::name>  upper_bound;
-      bool                        reverse = false;
-   };
-
-   get_all_accounts_result get_all_accounts( const get_all_accounts_params& params)  const;
-
    using get_consensus_parameters_params = empty;
    struct get_consensus_parameters_results {
      chain::chain_config        chain_config;
@@ -932,7 +913,4 @@ FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_params, (transaction))
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_results, (transaction_id)(processed) )
-FC_REFLECT( eosio::chain_apis::read_only::get_all_accounts_params, (limit)(lower_bound)(upper_bound)(reverse) )
-FC_REFLECT( eosio::chain_apis::read_only::get_all_accounts_result::account_result, (name)(creation_date))
-FC_REFLECT( eosio::chain_apis::read_only::get_all_accounts_result, (accounts)(more))
 FC_REFLECT( eosio::chain_apis::read_only::get_consensus_parameters_results, (chain_config)(kv_database_config)(wasm_config))

--- a/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
+++ b/plugins/chain_plugin/include/eosio/chain_plugin/chain_plugin.hpp
@@ -12,7 +12,6 @@
 #include <eosio/chain/plugin_interface.hpp>
 #include <eosio/chain/types.hpp>
 #include <eosio/chain/fixed_bytes.hpp>
-#include <eosio/chain/kv_config.hpp>
 
 #include <boost/container/flat_set.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
@@ -675,7 +674,6 @@ public:
    using get_consensus_parameters_params = empty;
    struct get_consensus_parameters_results {
      chain::chain_config        chain_config;
-     chain::kv_database_config  kv_database_config;
      chain::wasm_config         wasm_config;
    };
    get_consensus_parameters_results get_consensus_parameters(const get_consensus_parameters_params&) const;
@@ -913,4 +911,4 @@ FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_params, (transaction
 FC_REFLECT( eosio::chain_apis::read_only::get_required_keys_result, (required_keys) )
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_params, (transaction))
 FC_REFLECT( eosio::chain_apis::read_only::compute_transaction_results, (transaction_id)(processed) )
-FC_REFLECT( eosio::chain_apis::read_only::get_consensus_parameters_results, (chain_config)(kv_database_config)(wasm_config))
+FC_REFLECT( eosio::chain_apis::read_only::get_consensus_parameters_results, (chain_config)(wasm_config))

--- a/plugins/net_api_plugin/net_api_plugin.cpp
+++ b/plugins/net_api_plugin/net_api_plugin.cpp
@@ -44,7 +44,7 @@ using namespace eosio;
      eosio::detail::net_api_plugin_empty result;
 
 #define INVOKE_V_V(api_handle, call_name) \
-     body = parse_params<std::string, http_params_types::no_params_required>(body); \
+     body = parse_params<std::string, http_params_types::no_params>(body); \
      api_handle.call_name(); \
      eosio::detail::net_api_plugin_empty result;
 

--- a/programs/cleos/httpc.hpp
+++ b/programs/cleos/httpc.hpp
@@ -81,6 +81,7 @@ namespace eosio { namespace client { namespace http {
    const string chain_func_base = "/v1/chain";
    const string get_info_func = chain_func_base + "/get_info";
    const string get_transaction_status_func = chain_func_base + "/get_transaction_status";
+   const string get_consensus_parameters_func = chain_func_base + "/get_consensus_parameters";
    const string send_txn_func = chain_func_base + "/send_transaction";
    const string push_txn_func = chain_func_base + "/push_transaction";
    const string send2_txn_func = chain_func_base + "/send_transaction2";

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -346,6 +346,10 @@ template<>
 fc::variant call( const std::string& url,
                   const std::string& path) { return call( url, path, fc::variant() ); }
 
+eosio::chain_apis::read_only::get_consensus_parameters_results get_consensus_parameters() {
+   return call(default_url, get_consensus_parameters_func).as<eosio::chain_apis::read_only::get_consensus_parameters_results>();
+}
+
 eosio::chain_apis::read_only::get_info_results get_info() {
    return call(url, get_info_func).as<eosio::chain_apis::read_only::get_info_results>();
 }
@@ -2794,6 +2798,11 @@ int main( int argc, char** argv ) {
       }
       auto arg= fc::mutable_variant_object( "id", status_transaction_id);
       std::cout << fc::json::to_pretty_string(call(get_transaction_status_func, arg)) << std::endl;
+   });
+
+   // get consensus parameters
+   get->add_subcommand("consensus_parameters", localized("Get current blockchain consensus parameters"))->callback([] {
+      std::cout << fc::json::to_pretty_string(get_consensus_parameters()) << std::endl;
    });
 
    // get block

--- a/programs/cleos/main.cpp
+++ b/programs/cleos/main.cpp
@@ -347,7 +347,7 @@ fc::variant call( const std::string& url,
                   const std::string& path) { return call( url, path, fc::variant() ); }
 
 eosio::chain_apis::read_only::get_consensus_parameters_results get_consensus_parameters() {
-   return call(default_url, get_consensus_parameters_func).as<eosio::chain_apis::read_only::get_consensus_parameters_results>();
+   return call(url, get_consensus_parameters_func).as<eosio::chain_apis::read_only::get_consensus_parameters_results>();
 }
 
 eosio::chain_apis::read_only::get_info_results get_info() {


### PR DESCRIPTION
> https://github.com/EOSIO/eos/pull/10898
> 
> Add chain api endpoint and cleos get command to retrieve consensus parameters.

Resolves https://github.com/eosnetworkfoundation/mandel/issues/453