### PR TITLE
[3.2] Backport action serialization to always include hex_data.

### DIFF
--- a/libraries/chain/include/eosio/chain/abi_serializer.hpp
+++ b/libraries/chain/include/eosio/chain/abi_serializer.hpp
@@ -493,7 +493,6 @@ namespace impl {
                      binary_to_variant_context _ctx(*abi, ctx, type);
                      _ctx.short_path = true; // Just to be safe while avoiding the complexity of threading an override boolean all over the place
                      mvo( "data", abi->_binary_to_variant( type, act.data, _ctx ));
-                     set_hex_data(mvo, "hex_data", act.data);
                   } catch(...) {
                      // any failure to serialize data, then leave as not serailzed
                      set_hex_data(mvo, "data", act.data);
@@ -507,6 +506,7 @@ namespace impl {
          } catch(...) {
             set_hex_data(mvo, "data", act.data);
          }
+         set_hex_data(mvo, "hex_data", act.data);
          out(name, std::move(mvo));
       }
 

--- a/unittests/abi_tests.cpp
+++ b/unittests/abi_tests.cpp
@@ -2307,10 +2307,9 @@ BOOST_AUTO_TEST_CASE(abi_large_signature)
       auto stop = fc::time_point::now();
       // Give it a leaway of 50ms
       BOOST_CHECK_LE( (stop - start).count(), 51*1000 );
-      // only contains hex_data if it didn't hit the deadline
       if( check_data ) {
          BOOST_CHECK( var.get_object().contains( "data" ) );
-         BOOST_CHECK( !var.get_object().contains( "hex_data" ) );
+         BOOST_CHECK( var.get_object().contains( "hex_data" ) );
       }
    } FC_LOG_AND_RETHROW()
 }
@@ -2917,7 +2916,8 @@ inline std::pair<action_trace, std::string> generate_action_trace(const std::opt
       <<                 "\"actor\":\"acctest\","
       <<                 "\"permission\":\"active\""
       <<             "}],"
-      <<             "\"data\":\"09746573745f64617461\""
+      <<             "\"data\":\"09746573745f64617461\","
+      <<             "\"hex_data\":\"09746573745f64617461\""
       <<         "},"
       <<         "\"context_free\":false,"
       <<         "\"elapsed\":3,"


### PR DESCRIPTION
Backport of action serialization to always include hex_data.

Resolves: https://github.com/eosnetworkfoundation/mandel/issues/659