### PR TITLE
[3.1] remove broad 'using namespace boost' causing float128_t conflict; fixes builds w/ boost 1.80

### DIFF
--- a/libraries/chain/abi_serializer.cpp
+++ b/libraries/chain/abi_serializer.cpp
@@ -5,13 +5,11 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <fc/io/varint.hpp>
 
-using namespace boost;
-
-
 namespace eosio { namespace chain {
 
    const size_t abi_serializer::max_recursion_depth;
 
+   using boost::algorithm::starts_with;
    using boost::algorithm::ends_with;
    using std::string;
    using std::string_view;


### PR DESCRIPTION
`abi_serializer.cpp` does a
```c++
using namespace boost;
```

Apparently something internal to boost has been reorganized and when building with boost 1.80 beta it appears this `pack_unpack<float128_t>()` is getting confused with `boost::float128_t`  (gets a `template argument deduction/substitution failed` error).

Remove the broad `using namespace boost` to eliminate the conflict. This is arguably a cleaner short term spot fix than #638. If accepted I will open a ticket for a more broad fix across the code base in 3.2 (likely via a `softfloat` namespace or such)