### PR TITLE
[3.1] set prune logs at debug level except for the initial log when enabling pruning

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -107,7 +107,7 @@ namespace eosio { namespace chain {
 
             void append(const signed_block_ptr& b);
 
-            void prune();
+            void prune(const fc::log_level& loglevel);
 
             void vacuum();
 
@@ -331,7 +331,7 @@ namespace eosio { namespace chain {
 
          if(!is_currently_pruned && my->prune_config) {
             //need to convert non-pruned log to pruned log. prune any blocks to start with
-            my->prune();
+            my->prune(fc::log_level::info);
 
             //update version
             my->block_file.seek(0);
@@ -387,7 +387,7 @@ namespace eosio { namespace chain {
 
          if(prune_config) {
             if((pos&prune_config->prune_threshold) != (end&prune_config->prune_threshold))
-               prune();
+               prune(fc::log_level::debug);
 
             const uint32_t num_blocks_in_log = chain::block_header::num_from_id(head_id) - first_block_num + 1;
             fc::raw::pack(block_file, num_blocks_in_log);
@@ -398,7 +398,7 @@ namespace eosio { namespace chain {
       FC_LOG_AND_RETHROW()
    }
 
-   void detail::block_log_impl::prune() {
+   void detail::block_log_impl::prune(const fc::log_level& loglevel) {
       if(!head)
          return;
       const uint32_t head_num = chain::block_header::num_from_id(head_id);
@@ -418,7 +418,8 @@ namespace eosio { namespace chain {
       first_block_num = prune_to_num;
       block_file.flush();
 
-      ilog("blocks.log pruned to blocks ${b}-${e}", ("b", first_block_num)("e", head_num));
+      fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
+                      "blocks.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("b", first_block_num)("e", head_num));
    }
 
    void block_log::flush() {

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -418,10 +418,9 @@ namespace eosio { namespace chain {
       first_block_num = prune_to_num;
       block_file.flush();
 
-      const auto log_msg = fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
-                                          "blocks.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("b", first_block_num)("e", head_num));
-      if(auto l = fc::logger::get(); l.is_enabled(log_msg.get_context().get_log_level()))
-         l.log(log_msg);
+      if(auto l = fc::logger::get(); l.is_enabled(loglevel))
+         l.log(fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
+                               "blocks.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("b", first_block_num)("e", head_num)));
    }
 
    void block_log::flush() {

--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -418,8 +418,10 @@ namespace eosio { namespace chain {
       first_block_num = prune_to_num;
       block_file.flush();
 
-      fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
-                      "blocks.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("b", first_block_num)("e", head_num));
+      const auto log_msg = fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
+                                          "blocks.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("b", first_block_num)("e", head_num));
+      if(auto l = fc::logger::get(); l.is_enabled(log_msg.get_context().get_log_level()))
+         l.log(log_msg);
    }
 
    void block_log::flush() {

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -103,7 +103,7 @@ class state_history_log {
 
          if((is_ship_log_pruned(first_header.magic) == false) && prune_config) {
             //need to convert non-pruned to pruned; first prune any ranges we can (might be none)
-            prune();
+            prune(fc::log_level::info);
 
             //update first header to indicate prune feature is enabled
             log.seek(0);
@@ -200,7 +200,7 @@ class state_history_log {
 
       if(prune_config) {
          if((pos&prune_config->prune_threshold) != (log.tellp()&prune_config->prune_threshold))
-            prune();
+            prune(fc::log_level::debug);
 
          const uint32_t num_blocks_in_log = _end_block - _begin_block;
          fc::raw::pack(log, num_blocks_in_log);
@@ -250,7 +250,7 @@ class state_history_log {
       return true;
    }
 
-   void prune() {
+   void prune(const fc::log_level& loglevel) {
       if(!prune_config)
          return;
       if(_end_block - _begin_block <= prune_config->prune_blocks)
@@ -264,7 +264,8 @@ class state_history_log {
       _begin_block = prune_to_num;
       log.flush();
 
-      ilog("${name}.log pruned to blocks ${b}-${e}", ("name", name)("b", _begin_block)("e", _end_block - 1));
+      fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
+                      "${name}.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("name", name)("b", _begin_block)("e", _end_block - 1));
    }
 
    //only works on non-pruned logs

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -264,10 +264,9 @@ class state_history_log {
       _begin_block = prune_to_num;
       log.flush();
 
-      const auto log_msg = fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
-                                           "${name}.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("name", name)("b", _begin_block)("e", _end_block - 1));
-      if(auto l = fc::logger::get(); l.is_enabled(log_msg.get_context().get_log_level()))
-         l.log(log_msg);
+      if(auto l = fc::logger::get(); l.is_enabled(loglevel))
+         l.log(fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
+                               "${name}.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("name", name)("b", _begin_block)("e", _end_block - 1)));
    }
 
    //only works on non-pruned logs

--- a/libraries/state_history/include/eosio/state_history/log.hpp
+++ b/libraries/state_history/include/eosio/state_history/log.hpp
@@ -264,8 +264,10 @@ class state_history_log {
       _begin_block = prune_to_num;
       log.flush();
 
-      fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
-                      "${name}.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("name", name)("b", _begin_block)("e", _end_block - 1));
+      const auto log_msg = fc::log_message(fc::log_context(loglevel, __FILE__, __LINE__, __func__),
+                                           "${name}.log pruned to blocks ${b}-${e}", fc::mutable_variant_object()("name", name)("b", _begin_block)("e", _end_block - 1));
+      if(auto l = fc::logger::get(); l.is_enabled(log_msg.get_context().get_log_level()))
+         l.log(log_msg);
    }
 
    //only works on non-pruned logs


### PR DESCRIPTION
Resolves #714. Log message when enabling pruning will now be at info level, continual logging messages that are rather spammy will be at debug level instead.