### PR TITLE
[3.2] Enhancement: Add unique error message for subjective billing in the transaction trace logs

### DIFF
--- a/libraries/chain/include/eosio/chain/transaction_context.hpp
+++ b/libraries/chain/include/eosio/chain/transaction_context.hpp
@@ -111,9 +111,9 @@ namespace eosio { namespace chain {
          void schedule_transaction();
          void record_transaction( const transaction_id_type& id, fc::time_point_sec expire );
 
-         void validate_cpu_usage_to_bill( int64_t billed_us, int64_t account_cpu_limit, bool check_minimum )const;
-         void validate_account_cpu_usage( int64_t billed_us, int64_t account_cpu_limit )const;
-         void validate_account_cpu_usage_estimate( int64_t billed_us, int64_t account_cpu_limit )const;
+         void validate_cpu_usage_to_bill( int64_t billed_us, int64_t account_cpu_limit, bool check_minimum, int64_t subjective_billed_us )const;
+         void validate_account_cpu_usage( int64_t billed_us, int64_t account_cpu_limit,  int64_t subjective_billed_us )const;
+         void validate_account_cpu_usage_estimate( int64_t billed_us, int64_t account_cpu_limit, int64_t subjective_billed_us )const;
 
          void disallow_transaction_extensions( const char* error_msg )const;
 

--- a/libraries/chain/transaction_context.cpp
+++ b/libraries/chain/transaction_context.cpp
@@ -492,24 +492,28 @@ namespace eosio { namespace chain {
                         ("billed", billed_us)( "billable", objective_duration_limit.count() )
             );
          } else {
-            auto check_cpu_limit = [&](bool graylisted, bool subjective) {
+            auto assert_msg =  [&](bool graylisted, bool subjective) {
                std::string assert_msg =   "billed CPU time (${billed} us) is greater than the maximum";
                assert_msg += graylisted ? " greylisted" : "";
                assert_msg +=              " billable CPU time for the transaction (${billable} us)";
                assert_msg += subjective ? " with a subjective cpu of (${subjective} us)" : "";
-               // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
-               auto limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());                            
-               if (graylisted)
-                  EOS_ASSERT( billed_us <= limit,
-                              greylist_cpu_usage_exceeded, 
-                              assert_msg,
-                              ("billed", billed_us)("billable", limit)("subjective", subjective_billed_us));
-               else
-                  EOS_ASSERT( billed_us <= limit,
-                              tx_cpu_usage_exceeded,
-                              assert_msg, ("billed", billed_us)("billable", limit)("subjective", subjective_billed_us));
+               return assert_msg;
             };
-            check_cpu_limit(cpu_limit_due_to_greylist && cpu_limited_by_account,  subjective_billed_us > 0); // graylisted, subjective
+            auto graylisted = cpu_limit_due_to_greylist && cpu_limited_by_account;
+            auto subjective =  subjective_billed_us > 0;
+            // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
+            auto limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count()); 
+           
+            if (graylisted)
+               EOS_ASSERT( billed_us <= limit,
+                           greylist_cpu_usage_exceeded, 
+                           assert_msg(graylisted, subjective),
+                           ("billed", billed_us)("billable", limit)("subjective", subjective_billed_us));
+            else
+               EOS_ASSERT( billed_us <= limit,
+                           tx_cpu_usage_exceeded,
+                           assert_msg(graylisted, subjective), 
+                           ("billed", billed_us)("billable", limit)("subjective", subjective_billed_us));           
          }
       }
    }
@@ -525,25 +529,29 @@ namespace eosio { namespace chain {
                         "estimated CPU time (${billed} us) is not less than the billable CPU time left in the block (${billable} us)",
                         ("billed", prev_billed_us)( "billable", objective_duration_limit.count() )
             );
-         } else {             
-            auto check_cpu_limit = [&](bool graylisted, bool subjective) {
+         } else {
+            auto assert_msg =  [&](bool graylisted, bool subjective) {
                std::string assert_msg =   "estimated CPU time (${billed} us) is not less than the maximum";
                assert_msg += graylisted ? " greylisted" : "";
                assert_msg +=              " billable CPU time for the transaction (${billable} us)";
                assert_msg += subjective ? " with a subjective cpu of (${subjective} us)" : "";
-               // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
-               auto limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());                            
-               if (graylisted)
-                  EOS_ASSERT( prev_billed_us < limit,
-                              greylist_cpu_usage_exceeded, 
-                              assert_msg,
-                              ("billed", prev_billed_us)("billable", limit)("subjective", subjective_billed_us));
-               else
-                  EOS_ASSERT( prev_billed_us < limit,
-                              tx_cpu_usage_exceeded,
-                              assert_msg, ("billed", prev_billed_us)("billable", limit)("subjective", subjective_billed_us));
+               return assert_msg;
             };
-            check_cpu_limit(cpu_limit_due_to_greylist && cpu_limited_by_account,  subjective_billed_us > 0); // graylisted, subjective
+            auto graylisted = cpu_limit_due_to_greylist && cpu_limited_by_account;
+            auto subjective =  subjective_billed_us > 0;
+            // exceeds trx.max_cpu_usage_ms or cfg.max_transaction_cpu_usage if objective_duration_limit is greater
+            auto limit = graylisted ? account_cpu_limit : (cpu_limited_by_account ? account_cpu_limit : objective_duration_limit.count());
+                     
+            if (graylisted)
+               EOS_ASSERT( prev_billed_us < limit,
+                           greylist_cpu_usage_exceeded, 
+                           assert_msg(graylisted, subjective),
+                           ("billed", prev_billed_us)("billable", limit)("subjective", subjective_billed_us));
+            else
+               EOS_ASSERT( prev_billed_us < limit,
+                           tx_cpu_usage_exceeded,
+                           assert_msg(graylisted, subjective),
+                           ("billed", prev_billed_us)("billable", limit)("subjective", subjective_billed_us));          
          }
       }
    }


### PR DESCRIPTION
Decision was made not to change exception, just a message, in particular:

Functions affected: validate_account_cpu_usage, validate_account_cpu_usage_estimate and checktime()

It is suggested that error messages with the condition of subjective_billed_us > 0 should be amended with following string:

" with a subjective cpu of (${subjective} us)"

for example, in validate_account_cpu_usage message should be updated as following:

Old:
"estimated CPU time (${billed} us) is not less than the maximum billable CPU time for the transaction (${billable} us)"

New:
"estimated CPU time (${billed} us) is not less than the maximum billable CPU time for the transaction (${billable} us) with a subjective cpu of (${subjective} us)"

Provisions has been made to avoid unneeded duplication of messages in a code.
