### PR TITLE
[3.2] FIFO (named pipe) support for deep-mind logging

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/TestHelper.py ${CMAKE_CURRENT_BINARY_
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/p2p_tests/dawn_515/test.sh ${CMAKE_CURRENT_BINARY_DIR}/p2p_tests/dawn_515/test.sh COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/block_log_util_test.py ${CMAKE_CURRENT_BINARY_DIR}/block_log_util_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/block_log_retain_blocks_test.py ${CMAKE_CURRENT_BINARY_DIR}/block_log_retain_blocks_test.py COPYONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/deep_mind_test.py ${CMAKE_CURRENT_BINARY_DIR}/deep_mind_test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/distributed-transactions-test.py ${CMAKE_CURRENT_BINARY_DIR}/distributed-transactions-test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/distributed-transactions-remote-test.py ${CMAKE_CURRENT_BINARY_DIR}/distributed-transactions-remote-test.py COPYONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sample-cluster-map.json ${CMAKE_CURRENT_BINARY_DIR}/sample-cluster-map.json COPYONLY)
@@ -80,6 +81,8 @@ add_test(NAME block_log_util_test COMMAND tests/block_log_util_test.py -v --clea
 set_property(TEST block_log_util_test PROPERTY LABELS nonparallelizable_tests)
 add_test(NAME block_log_retain_blocks_test COMMAND tests/block_log_retain_blocks_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 set_property(TEST block_log_retain_blocks_test PROPERTY LABELS nonparallelizable_tests)
+add_test(NAME deep_mind_test COMMAND tests/deep_mind_test.py -v --clean-run --dump-error-detail WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+set_property(TEST deep_mind_test PROPERTY LABELS nonparallelizable_tests)
 
 option(ABIEOS_ONLY_LIBRARY "define and build the ABIEOS library" ON)
 set(ABIEOS_INSTALL_COMPONENT "dev")

--- a/tests/deep_mind_test.py
+++ b/tests/deep_mind_test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+
+from testUtils import Utils
+from Cluster import Cluster
+from WalletMgr import WalletMgr
+from TestHelper import TestHelper
+
+import random
+import os
+import subprocess
+import tempfile
+import signal
+import time
+
+###############################################################
+# deep_mind_test.py
+#
+# This tests deep mind logging via FIFO related functionalities:
+#   * FIFO exists before nodeos starts
+#   * FIFO does not exist before nodeos starts
+#
+###############################################################
+
+Print=Utils.Print
+errorExit=Utils.errorExit
+
+args=TestHelper.parse_args({"--keep-logs" ,"--dump-error-details","-v","--leave-running","--clean-run"})
+debug=args.v
+killEosInstances= not args.leave_running
+dumpErrorDetails=args.dump_error_details
+keepLogs=args.keep_logs
+killAll=args.clean_run
+
+seed=1
+Utils.Debug=debug
+testSuccessful=False
+
+random.seed(seed) # Use a fixed seed for repeatability.
+cluster=Cluster(walletd=True)
+walletMgr=WalletMgr(True)
+
+pnodes=1
+total_nodes=pnodes
+
+try:
+    TestHelper.printSystemInfo("BEGIN")
+
+    cluster.setWalletMgr(walletMgr)
+
+    cluster.killall(allInstances=killAll)
+    cluster.cleanup()
+    walletMgr.killall(allInstances=killAll)
+    walletMgr.cleanup()
+
+    tmpdir = tempfile.mkdtemp()
+    fifoFile = os.path.join(tmpdir, 'fifo')
+
+    # Test 1: FIFO exists before nodeos starts
+    os.mkfifo(fifoFile)
+
+    specificExtraNodeosArgs={}
+    # A non-existing logging.json makes nodeos initializing deep mind at startup
+    fakeLoggingJson = os.path.join(tmpdir, 'logging.json')
+    specificExtraNodeosArgs[0]=f' --logconf {fakeLoggingJson} --deep-mind-fifo {fifoFile} '
+
+    extraNodeosArgs=f' --plugin eosio::trace_api_plugin --trace-no-abis '
+
+    Print("Stand up cluster")
+    if cluster.launch(pnodes=pnodes, totalNodes=total_nodes, extraNodeosArgs=extraNodeosArgs, specificExtraNodeosArgs=specificExtraNodeosArgs) is False:
+       errorExit("Failed to stand up eos cluster.")
+
+    Print ("Wait for Cluster stabilization")
+    # wait for cluster to start producing blocks
+    if not cluster.waitOnClusterBlockNumSync(3):
+       errorExit("Cluster never stabilized")
+    Print ("Cluster stabilized")
+
+    # FIFO should have deep mind logs, each of which starts with DMLOG
+    with open(fifoFile, "r") as f:
+       if 'DMLOG' not in f.readline():
+          errorExit("No deep mind logging found in FIFO exists before nodeos starts test")
+    Print ("Test 1 (FIFO exists before nodeos start succeeded)") 
+
+    # Test 2: FIFO does not exist before nodeos starts
+    node = cluster.getNode(0)
+    node.kill(signal.SIGTERM)
+    # remove FIFO file so that no FIFO exists before nodeos starts
+    os.remove(fifoFile)
+    node.relaunch()
+    time.sleep(3)
+    with open(fifoFile, "r") as f:
+       if 'DMLOG' not in f.readline():
+          errorExit("No deep mind logging found in FIFO does not exist before nodeos starts test")
+    Print ("Test 2 (FIFO does not exist before nodeos start succeeded)") 
+
+    testSuccessful=True
+finally:
+    TestHelper.shutdown(cluster, walletMgr, testSuccessful=testSuccessful, killEosInstances=killEosInstances, killWallet=killEosInstances, keepLogs=keepLogs, cleanRun=killAll, dumpErrorDetails=dumpErrorDetails)
+
+exitCode = 0 if testSuccessful else 1
+exit(exitCode)


### PR DESCRIPTION
Resolve https://github.com/eosnetworkfoundation/mandel/issues/221.

A `nodeos` new option is added to support FIFO deep-mind logging:

```
  --deep-mind-fifo arg                     FIFO (named pipe) path for deep-mind
                                           logging. It is created either via
                                           mkfifo beforehand or dynamically. Only
                                           one of deep-mind and deep-mind-fifo can
                                           be enabled
```

Unit tests and integration tests are added.

https://github.com/eosnetworkfoundation/mandel-fc/pull/49 is the changes required in FC submodule.