### PR TITLE
[3.1] Add subjective limit to mod_exp host function

### DIFF
--- a/libraries/chain/webassembly/crypto.cpp
+++ b/libraries/chain/webassembly/crypto.cpp
@@ -158,6 +158,14 @@ namespace eosio { namespace chain { namespace webassembly {
                               span<const char> exp,
                               span<const char> modulus,
                               span<char> out) const {
+      if (context.control.is_producing_block()) {
+         static constexpr int byte_size_limit = 256; // Allow up to 2048-bit values for base, exp, and modulus.
+
+         if (std::max(std::max(base.size(), exp.size()), modulus.size()) > byte_size_limit) {
+            EOS_THROW(subjective_block_production_exception, "Bit size too large for values passed into mod_exp");
+         }
+      }
+
       bytes bbase(base.data(), base.data() + base.size());
       bytes bexp(exp.data(), exp.data() + exp.size());
       bytes bmod(modulus.data(), modulus.data() + modulus.size());


### PR DESCRIPTION
Based on benchmarking (see fc changes for details) and a desire to prevent deadline overruns longer than 5 ms (to protect timely block delivery), we decided to enforce a subjective limit of at most 2048 bits on any of the base, exponent, or modulus.

This can be adjusted in the future (higher or lower) without a consensus change since it is a subjective limitation. In the future, we may wish to solve the above concern in a more flexible way as described in https://github.com/eosnetworkfoundation/mandel/issues/738.

This PR also adds a test case to test that the subjective limit is enforced.