### PR TITLE
documentation fixes to power developer doc portal

### DIFF
--- a/docs/00_install/01_build-from-source/00_build-unsupported-os.md
+++ b/docs/00_install/01_build-from-source/00_build-unsupported-os.md
@@ -4,6 +4,10 @@ content_title: Build EOSIO from Source on Other Unix-based OS
 
 **Please keep in mind that instructions for building from source on other  unsupported operating systems provided here should be considered experimental and provided AS-IS on a best-effort basis and may not be fully featured.**
 
+### Using DUNE
+
+For the official multi-platform support try [Docker Utilities for Node Execution](https://github.com/eosnetworkfoundation/DUNE) which runs in an ubuntu image via a docker container.  
+
 **A Warning On Parallel Compilation Jobs (`-j` flag)**: When building C/C++ software often the build is performed in parallel via a command such as `make -j $(nproc)` which uses the number of CPU cores as the number of compilation jobs to perform simultaneously. However, be aware that some compilation units (.cpp files) in mandel are extremely complex and will consume nearly 4GB of memory to compile. You may need to reduce the level of parallelization depending on the amount of memory on your build host. e.g. instead of `make -j $(nproc)` run `make -j2`. Failures due to memory exhaustion will typically but not always manifest as compiler crashes.
 
 Generally we recommend performing what we refer to as a "pinned build" which ensures the compiler and boost version remain the same between builds of different mandel versions (mandel requires these versions remain the same otherwise its state needs to be repopulated from a portable snapshot).
@@ -11,7 +15,7 @@ Generally we recommend performing what we refer to as a "pinned build" which ens
 <details>
   <summary>FreeBSD 13.1 Build Instructions</summary>
 
-Install required dependencies: 
+Install required dependencies:
 ```
 pkg update && pkg install   \
     git                     \

--- a/docs/00_install/01_build-from-source/index.md
+++ b/docs/00_install/01_build-from-source/index.md
@@ -4,6 +4,10 @@ content_title: Build EOSIO from Source
 
 The shell scripts previously recommended for building the software have been removed in favor of a build process entirely driven by CMake. Those wishing to build from source are now responsible for installing the necessary dependencies. The list of dependencies and the recommended build procedure are in the README.md file. Instructions are also included for efficiently running the tests.
 
+### Using DUNE
+
+As an alternative to building from source try [Docker Utilities for Node Execution](https://github.com/eosnetworkfoundation/DUNE) for the easiest way to get started, and for multi-platform support.  
+
 ### Building From Source
 
 Recent Ubuntu LTS releases are the only Linux distributions that we fully support. Other Linux distros and other POSIX operating systems (such as macOS) are tended to on a best-effort basis and may not be full featured. Notable requirements to build are:
@@ -30,7 +34,7 @@ The binary package will be produced in the mandel build directory that was suppl
 <details>
   <summary>Ubuntu 20.04 & 22.04 Build Instructions</summary>
 
-Install required dependencies: 
+Install required dependencies:
 ```
 apt-get update && apt-get install   \
         build-essential             \
@@ -58,7 +62,7 @@ make -j $(nproc) package
 <details>
   <summary>Ubuntu 18.04 Build Instructions</summary>
 
-Install required dependencies. You will need to build Boost from source on this distribution. 
+Install required dependencies. You will need to build Boost from source on this distribution.
 ```
 apt-get update && apt-get install   \
         build-essential             \
@@ -74,7 +78,7 @@ apt-get update && apt-get install   \
         pkg-config                  \
         python3                     \
         zlib1g-dev
-        
+
 curl -L https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.bz2 | tar jx && \
    cd boost_1_79_0 &&                                                                                     \
    ./bootstrap.sh --prefix=$HOME/boost1.79 &&                                                             \

--- a/docs/01_nodeos/02_usage/03_development-environment/index.md
+++ b/docs/01_nodeos/02_usage/03_development-environment/index.md
@@ -8,18 +8,18 @@ There are several ways to configure a `nodeos` environment for development and t
 
 This is the go-to option for smart contract developers, aspiring Block Producers or Non-Producing Node operators. It has the most simple configuration with the least number of requirements.
 
-* [Configure Nodeos as a Local Single-node Testnet](00_local-single-node-testnet.md) 
+* [Configure Nodeos as a Local Single-node Testnet](00_local-single-node-testnet.md)
 
 ## Local Multi-Node Testnet
 
 While this option can technically be used for smart contract development, it may be overkill. This is most beneficial for those who are working on aspects of core development, such as benchmarking, optimization and experimentation. It's also a good option for hands-on learning and concept proofing.
 
 * [Configure Nodeos as a Local Two-Node Testnet](01_local-multi-node-testnet.md)
-* [Configure Nodeos as a Local 21-Node Testnet](https://github.com/eosnetworkfoundation/mandel/tree/main/tutorials/bios-boot-tutorial)
+* [Configure Nodeos as a Local 21-Node Testnet](/tutorials/bios-boot-tutorial.md)
 
-## Official Testnet
+## Official Testing Node
 
-The official testnet for testing EOSIO dApps and smart contracts will be available soon
+Try [Docker Utilities for Node Execution](https://github.com/eosnetworkfoundation/DUNE) for the easiest way to get started, and for multi-platform support.  
 
 ## Third-Party Testnets
 

--- a/docs/01_nodeos/03_plugins/history_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/history_api_plugin/index.md
@@ -12,9 +12,6 @@ It provides four RPC API endpoints:
 * get_key_accounts
 * get_controlled_accounts
 
-[[info | More Info]]
-| See HISTORY section of [RPC API](https://developers.eos.io/eosio-nodeos/reference).
-
 The four actions listed above are used by the following `cleos` commands (matching order):
 
 * get actions

--- a/docs/01_nodeos/03_plugins/net_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/net_api_plugin/index.md
@@ -8,7 +8,7 @@ The `net_api_plugin` provides four RPC API endpoints:
 * connections
 * status
 
-See [Net API Reference Documentation](https://developers.eos.io/manuals/eos/latest/nodeos/plugins/net_api_plugin/api-reference/index).
+See [Net API Reference Documentation](http://docs.eosnetwork.com/reference/mandel-plugins/net_api.html).
 
 [[caution | Caution]]
 | This plugin exposes endpoints that allow management of p2p connections. Running this plugin on a publicly accessible node is not recommended as it can be exploited.

--- a/docs/01_nodeos/03_plugins/net_api_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/net_api_plugin/index.md
@@ -8,7 +8,7 @@ The `net_api_plugin` provides four RPC API endpoints:
 * connections
 * status
 
-See [Net API Reference Documentation](http://docs.eosnetwork.com/reference/mandel-plugins/net_api.html).
+See [Net API Reference Documentation](https://docs.eosnetwork.com/reference/mandel-plugins/net_api.html).
 
 [[caution | Caution]]
 | This plugin exposes endpoints that allow management of p2p connections. Running this plugin on a publicly accessible node is not recommended as it can be exploited.

--- a/docs/01_nodeos/03_plugins/net_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/net_plugin/index.md
@@ -23,77 +23,77 @@ Config Options for eosio::net_plugin:
   --p2p-listen-endpoint arg (=0.0.0.0:9876)
                                         The actual host:port used to listen for
                                         incoming p2p connections.
-  --p2p-server-address arg              An externally accessible host:port for 
-                                        identifying this node. Defaults to 
+  --p2p-server-address arg              An externally accessible host:port for
+                                        identifying this node. Defaults to
                                         p2p-listen-endpoint.
-  --p2p-peer-address arg                The public endpoint of a peer node to 
-                                        connect to. Use multiple 
-                                        p2p-peer-address options as needed to 
+  --p2p-peer-address arg                The public endpoint of a peer node to
+                                        connect to. Use multiple
+                                        p2p-peer-address options as needed to
                                         compose a network.
                                           Syntax: host:port[:<trx>|<blk>]
-                                          The optional 'trx' and 'blk' 
-                                        indicates to node that only 
-                                        transactions 'trx' or blocks 'blk' 
+                                          The optional 'trx' and 'blk'
+                                        indicates to node that only
+                                        transactions 'trx' or blocks 'blk'
                                         should be sent.  Examples:
-                                            p2p.eos.io:9876
-                                            p2p.trx.eos.io:9876:trx
-                                            p2p.blk.eos.io:9876:blk
-                                        
+                                            p2p.domain.io:9876
+                                            p2p.trx.domaine.io:9876:trx
+                                            p2p.blk.domain.io:9876:blk
+
   --p2p-max-nodes-per-host arg (=1)     Maximum number of client nodes from any
                                         single IP address
-  --p2p-accept-transactions arg (=1)    Allow transactions received over p2p 
-                                        network to be evaluated and relayed if 
+  --p2p-accept-transactions arg (=1)    Allow transactions received over p2p
+                                        network to be evaluated and relayed if
                                         valid.
   --agent-name arg (="EOS Test Agent")  The name supplied to identify this node
                                         amongst the peers.
-  --allowed-connection arg (=any)       Can be 'any' or 'producers' or 
-                                        'specified' or 'none'. If 'specified', 
-                                        peer-key must be specified at least 
-                                        once. If only 'producers', peer-key is 
-                                        not required. 'producers' and 
+  --allowed-connection arg (=any)       Can be 'any' or 'producers' or
+                                        'specified' or 'none'. If 'specified',
+                                        peer-key must be specified at least
+                                        once. If only 'producers', peer-key is
+                                        not required. 'producers' and
                                         'specified' may be combined.
-  --peer-key arg                        Optional public key of peer allowed to 
+  --peer-key arg                        Optional public key of peer allowed to
                                         connect.  May be used multiple times.
-  --peer-private-key arg                Tuple of [PublicKey, WIF private key] 
+  --peer-private-key arg                Tuple of [PublicKey, WIF private key]
                                         (may specify multiple times)
-  --max-clients arg (=25)               Maximum number of clients from which 
-                                        connections are accepted, use 0 for no 
+  --max-clients arg (=25)               Maximum number of clients from which
+                                        connections are accepted, use 0 for no
                                         limit
-  --connection-cleanup-period arg (=30) number of seconds to wait before 
+  --connection-cleanup-period arg (=30) number of seconds to wait before
                                         cleaning up dead connections
   --max-cleanup-time-msec arg (=10)     max connection cleanup time per cleanup
                                         call in milliseconds
   --p2p-dedup-cache-expire-time-sec arg (=10)
-                                        Maximum time to track transaction for 
+                                        Maximum time to track transaction for
                                         duplicate optimization
-  --net-threads arg (=2)                Number of worker threads in net_plugin 
+  --net-threads arg (=2)                Number of worker threads in net_plugin
                                         thread pool
   --sync-fetch-span arg (=100)          number of blocks to retrieve in a chunk
-                                        from any individual peer during 
+                                        from any individual peer during
                                         synchronization
-  --use-socket-read-watermark arg (=0)  Enable experimental socket read 
+  --use-socket-read-watermark arg (=0)  Enable experimental socket read
                                         watermark optimization
   --peer-log-format arg (=["${_name}" ${_ip}:${_port}])
-                                        The string used to format peers when 
+                                        The string used to format peers when
                                         logging messages about them.  Variables
                                         are escaped with ${<variable name>}.
                                         Available Variables:
                                            _name  self-reported name
-                                        
-                                           _id    self-reported ID (64 hex 
+
+                                           _id    self-reported ID (64 hex
                                                   characters)
-                                        
-                                           _sid   first 8 characters of 
+
+                                           _sid   first 8 characters of
                                                   _peer.id
-                                        
+
                                            _ip    remote IP address of peer
-                                        
+
                                            _port  remote port number of peer
-                                        
+
                                            _lip   local IP address connected to
                                                   peer
-                                        
-                                           _lport local port number connected 
+
+                                           _lport local port number connected
                                                   to peer                                        
 ```
 

--- a/docs/01_nodeos/03_plugins/net_plugin/index.md
+++ b/docs/01_nodeos/03_plugins/net_plugin/index.md
@@ -35,9 +35,9 @@ Config Options for eosio::net_plugin:
                                         indicates to node that only
                                         transactions 'trx' or blocks 'blk'
                                         should be sent.  Examples:
-                                            p2p.domain.io:9876
-                                            p2p.trx.domaine.io:9876:trx
-                                            p2p.blk.domain.io:9876:blk
+                                            p2p.example.org:9876
+                                            p2p.trx.example.org:9876:trx
+                                            p2p.blk.example.org:9876:blk
 
   --p2p-max-nodes-per-host arg (=1)     Maximum number of client nodes from any
                                         single IP address

--- a/docs/01_nodeos/03_plugins/state_history_plugin/10_how-to-fast-start-without-old-history.md
+++ b/docs/01_nodeos/03_plugins/state_history_plugin/10_how-to-fast-start-without-old-history.md
@@ -20,7 +20,7 @@ This procedure records the current chain state and future history, without previ
 
 2. Make sure `data/state` does not exist
 
-3. Start `nodeos` with the `--snapshot` option, and the options listed in the [`state_history_plugin`](#index.md).
+3. Start `nodeos` with the `--snapshot` option, and the options listed in the [`state_history_plugin`](index.md).
 
 4. Look for `Placing initial state in block n` in the log, where n is the start block number.
 

--- a/docs/01_nodeos/03_plugins/state_history_plugin/40_how-to-restore-snapshot-with-full-history.md
+++ b/docs/01_nodeos/03_plugins/state_history_plugin/40_how-to-restore-snapshot-with-full-history.md
@@ -21,7 +21,7 @@ This procedure restores an existing snapshot with full history, so the node can 
 
 2. Make sure `data/state` does not exist
 
-3. Start `nodeos` with the `--snapshot` option, and the options listed in the [`state_history_plugin`](#index.md).
+3. Start `nodeos` with the `--snapshot` option, and the options listed in the [`state_history_plugin`](index.md).
 
 4. Do not stop `nodeos` until it has received at least 1 block from the network, or it won't be able to restart.
 

--- a/docs/01_nodeos/07_concepts/05_storage-and-read-modes.md
+++ b/docs/01_nodeos/07_concepts/05_storage-and-read-modes.md
@@ -17,7 +17,7 @@ Every `nodeos` instance creates some internal files to housekeep the blockchain 
 
 ## EOSIO Interfaces
 
-EOSIO provides a set of [services](../../) and [interfaces](https://developers.eos.io/manuals/eosio.cdt/latest/files) that enable contract developers to persist state across action, and consequently transaction, boundaries. Contracts may use these services and interfaces for various purposes. For example, `eosio.token` contract keeps balances for all users in the chain database. Each instance of `nodeos` keeps the database in memory, so contracts can read and write data with ease.
+EOSIO provides a set of [services](../../) and [interfaces](http://docs.eosnetwork.com/reference/mandel-cdt/files.html) that enable contract developers to persist state across action, and consequently transaction, boundaries. Contracts may use these services and interfaces for various purposes. For example, `eosio.token` contract keeps balances for all users in the chain database. Each instance of `nodeos` keeps the database in memory, so contracts can read and write data with ease.
 
 ### Nodeos RPC API
 
@@ -40,7 +40,7 @@ Clients such as `cleos` and the RPC API, will see database state as of the curre
 
 Speculative mode is low latency but fragile, there is no guarantee that the transactions reflected in the state will be included in the chain OR that they will reflected in the same order the state implies.  
 
-This mode features the lowest latency, but is the least consistent. 
+This mode features the lowest latency, but is the least consistent.
 
 In speculative mode `nodeos` is able to execute transactions which have TaPoS (Transaction as Proof of Stake) pointing to any valid block in a fork considered to be the best fork by this node.
 
@@ -61,7 +61,7 @@ Clients such as `cleos` and the RPC API will see database state as of the curren
 
 ### Irreversible Mode
 
-When `nodeos` is configured to be in irreversible read mode, it will still track the most up-to-date blocks in the fork database, but the state will lag behind the current best head block, sometimes referred to as the fork DB head, to always reflect the state of the last irreversible block. 
+When `nodeos` is configured to be in irreversible read mode, it will still track the most up-to-date blocks in the fork database, but the state will lag behind the current best head block, sometimes referred to as the fork DB head, to always reflect the state of the last irreversible block.
 
 Clients such as `cleos` and the RPC API will see database state as of the current head block of the chain. It **will not** include changes made by transactions known to this node but not included in the chain, such as unconfirmed transactions.
 

--- a/docs/01_nodeos/07_concepts/05_storage-and-read-modes.md
+++ b/docs/01_nodeos/07_concepts/05_storage-and-read-modes.md
@@ -17,7 +17,7 @@ Every `nodeos` instance creates some internal files to housekeep the blockchain 
 
 ## EOSIO Interfaces
 
-EOSIO provides a set of [services](../../) and [interfaces](http://docs.eosnetwork.com/reference/mandel-cdt/files.html) that enable contract developers to persist state across action, and consequently transaction, boundaries. Contracts may use these services and interfaces for various purposes. For example, `eosio.token` contract keeps balances for all users in the chain database. Each instance of `nodeos` keeps the database in memory, so contracts can read and write data with ease.
+EOSIO provides a set of [services](../../) and [interfaces](https://docs.eosnetwork.com/reference/mandel-cdt/files.html) that enable contract developers to persist state across action, and consequently transaction, boundaries. Contracts may use these services and interfaces for various purposes. For example, `eosio.token` contract keeps balances for all users in the chain database. Each instance of `nodeos` keeps the database in memory, so contracts can read and write data with ease.
 
 ### Nodeos RPC API
 

--- a/docs/01_nodeos/08_troubleshooting/index.md
+++ b/docs/01_nodeos/08_troubleshooting/index.md
@@ -4,7 +4,7 @@ content_title: Nodeos Troubleshooting
 
 ### "Database dirty flag set (likely due to unclean shutdown): replay required"
 
-`nodeos` needs to be shut down cleanly. To ensure this is done, send a `SIGTERM`, `SIGQUIT` or `SIGINT` and wait for the process to shutdown. Failing to do this will result in this error. If you get this error, your only recourse is to replay by starting `nodeos` with `--replay-blockchain` 
+`nodeos` needs to be shut down cleanly. To ensure this is done, send a `SIGTERM`, `SIGQUIT` or `SIGINT` and wait for the process to shutdown. Failing to do this will result in this error. If you get this error, your only recourse is to replay by starting `nodeos` with `--replay-blockchain`
 
 ### "Memory does not match data" Error at Restart
 
@@ -12,15 +12,15 @@ If you get an error such as `St9exception: content of memory does not match data
 
 ```
 Command Line Options for eosio::chain_plugin:
-    --force-all-checks                    do not skip any checks that can be 
-                                          skipped while replaying irreversible 
+    --force-all-checks                    do not skip any checks that can be
+                                          skipped while replaying irreversible
                                           blocks
-    --replay-blockchain                   clear chain state database and replay 
+    --replay-blockchain                   clear chain state database and replay
                                           all blocks
-    --hard-replay-blockchain              clear chain state database, recover as 
-                                          many blocks as possible from the block 
+    --hard-replay-blockchain              clear chain state database, recover as
+                                          many blocks as possible from the block
                                           log, and then replay those blocks
-    --delete-all-blocks                   clear chain state database and block 
+    --delete-all-blocks                   clear chain state database and block
                                           log
 ```
 
@@ -44,4 +44,4 @@ cleos --url http://localhost:8888 get info | grep server_version
 
 ### Error 3070000: WASM Exception Error
 
-If you try to deploy the `eosio.bios` contract or `eosio.system` contract in an attempt to boot an EOSIO-based blockchain and you get the following error or similar: `Publishing contract... Error 3070000: WASM Exception Error Details: env.set_proposed_producers_ex unresolveable`, it is because you have to activate the `PREACTIVATE_FEATURE` protocol first. More details about it and how to enable it can be found in the [Bios Boot Sequence Tutorial](https://developers.eos.io/welcome/latest/tutorials/bios-boot-sequence/#112-set-the-eosiosystem-contract). For more information, you may also visit the [Nodeos Upgrade Guides](https://developers.eos.io/manuals/eos/latest/nodeos/upgrade-guides/).
+If you try to deploy the `eosio.bios` contract or `eosio.system` contract in an attempt to boot an EOSIO-based blockchain and you get the following error or similar: `Publishing contract... Error 3070000: WASM Exception Error Details: env.set_proposed_producers_ex unresolveable`, it is because you have to activate the `PREACTIVATE_FEATURE` protocol first. 

--- a/docs/02_cleos/02_how-to-guides/how-to-create-a-wallet.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-create-a-wallet.md
@@ -13,9 +13,9 @@ Make sure you meet the following requirements:
 [[info | Note]]
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
 
-* Understand what an [account](https://developers.eos.io/welcome/latest/glossary/index/#account) is and its role in the blockchain.
-* Understand [Accounts and Permissions](https://developers.eos.io/welcome/latest/protocol-guides/accounts_and_permissions) in the protocol documents.
-* Understand what a [public](https://developers.eos.io/welcome/latest/glossary/index/#public-key) and [private](https://developers.eos.io/welcome/latest/glossary/index/#private-key) key pair is.
+* Understand what an [account](/glossary.md#account) is and its role in the blockchain.
+* Understand [Accounts and Permissions](/protocol-guides/04_accounts_and_permissions.md) in the protocol documents.
+* Understand what a [public](/glossary.md#public-key) and [private](/glossary.md#private-key) key pair is.
 
 ## Steps
 

--- a/docs/02_cleos/02_how-to-guides/how-to-create-an-account.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-create-an-account.md
@@ -2,7 +2,7 @@
 
 This how-to guide provides instructions on how to create a new EOSIO blockchain account using the `cleos` CLI tool. You can use accounts to deploy smart contracts and perform other related blockchain operations. Create one or multiple accounts as part of your development environment setup.
 
-The example in this how-to guide creates a new account named **bob**, authorized by the default system account **eosio**, using the `cleos` CLI tool. 
+The example in this how-to guide creates a new account named **bob**, authorized by the default system account **eosio**, using the `cleos` CLI tool.
 
 ## Before you Begin
 
@@ -10,9 +10,9 @@ Make sure you meet the following requirements:
 
 * Install the currently supported version of `cleos`.
 [[info | Note]]
-| The cleos tool is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install the cleos tool. 
-* Learn about [EOSIO Accounts and Permissions](https://developers.eos.io/welcome/v2.1/protocol/accounts_and_permissions)
-* Learn about Asymmetric Cryptography - [public key](https://developers.eos.io/welcome/v2.1/glossary/index#public-key) and [private key](https://developers.eos.io/welcome/v2.1/glossary/index#private-key) pairs.
+| The cleos tool is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install the cleos tool.
+* Learn about [EOSIO Accounts and Permissions](/protocol-guides/04_accounts_and_permissions.md)
+* Learn about Asymmetric Cryptography - [public key](/glossary.md#public-key) and [private key](/glossary.md#private-key) pairs.
 * Create public/private keypairs for the `owner` and `active` permissions of an account.
 
 ## Command Reference
@@ -31,7 +31,7 @@ cleos create account eosio bob EOS87TQktA5RVse2EguhztfQVEh6XXxBmgkU8b4Y5YnGvtYAo
 ```
 **Where**:
 * `eosio` = the system account that authorizes the creation of a new account
-* `bob` = the name of the new account conforming to [account naming conventions](https://developers.eos.io/welcome/v2.1/protocol-guides/accounts_and_permissions#2-accounts)
+* `bob` = the name of the new account conforming to [account naming conventions](/protocol-guides/04_accounts_and_permissions.md#2-accounts)
 * `EOS87TQ...AoLGNN` = the owner public key or permission level for the new account (**required**)
 [[info | Note]]
 | To create a new account in the EOSIO blockchain, an existing account, also referred to as a creator account, is required to authorize the creation of a new account. For a newly created EOSIO blockchain, the default system account used to create a new account is **eosio**.

--- a/docs/02_cleos/02_how-to-guides/how-to-delegate-CPU-resource.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-delegate-CPU-resource.md
@@ -13,9 +13,9 @@ Make sure you meet the following requirements:
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
 
 * Ensure the reference system contracts from [`eosio.contracts`](https://github.com/eosnetworkfoundation/mandel-contracts) repository is deployed and used to manage system resources.
-* Understand what an [account](https://developers.eos.io/welcome/latest/glossary/index/#account) is and its role in the blockchain.
-* Understand [CPU bandwidth](https://developers.eos.io/welcome/latest/glossary/index/#cpu) in an EOSIO blockchain.
-* Understand [NET bandwidth](https://developers.eos.io/welcome/latest/glossary/index/#net) in an EOSIO blockchain.
+* Understand what an [account](/glossary.md#account) is and its role in the blockchain.
+* Understand [CPU bandwidth](/glossary.md#cpu) in an EOSIO blockchain.
+* Understand [NET bandwidth](/glossary.md#net) in an EOSIO blockchain.
 
 ## Steps
 

--- a/docs/02_cleos/02_how-to-guides/how-to-delegate-net-resource.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-delegate-net-resource.md
@@ -13,9 +13,9 @@ Make sure you meet the following requirements:
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
 
 * Ensure the reference system contracts from [`eosio.contracts`](https://github.com/eosnetworkfoundation/mandel-contracts) repository is deployed and used to manage system resources.
-* Understand what an [account](https://developers.eos.io/welcome/latest/glossary/index/#account) is and its role in the blockchain.
-* Understand [NET bandwidth](https://developers.eos.io/welcome/latest/glossary/index/#net) in an EOSIO blockchain.
-* Understand [CPU bandwidth](https://developers.eos.io/welcome/latest/glossary/index/#cpu) in an EOSIO blockchain.
+* Understand what an [account](/glossary.md#account) is and its role in the blockchain.
+* Understand [NET bandwidth](/glossary.md#net) in an EOSIO blockchain.
+* Understand [CPU bandwidth](/glossary.md#cpu) in an EOSIO blockchain.
 
 ## Steps
 

--- a/docs/02_cleos/02_how-to-guides/how-to-get-account-information.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-get-account-information.md
@@ -1,15 +1,15 @@
 ## Overview
 
-This how-to guide provides instructions on how to query infomation of an EOSIO account. The example in this how-to guide retrieves information of the `eosio` account. 
+This how-to guide provides instructions on how to query infomation of an EOSIO account. The example in this how-to guide retrieves information of the `eosio` account.
 
 ## Before you begin
 
 * Install the currently supported version of `cleos`
 
 [[info | Note]]
-| The cleos tool is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install the cleos tool. 
+| The cleos tool is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install the cleos tool.
 
-* Acquire functional understanding of [EOSIO Accounts and Permissions](https://developers.eos.io/welcome/v2.1/protocol/accounts_and_permissions)
+* Acquire functional understanding of [EOSIO Accounts and Permissions](/protocol-guides/04_accounts_and_permissions.md)
 
 ## Command Reference
 

--- a/docs/02_cleos/02_how-to-guides/how-to-get-block-information.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-get-block-information.md
@@ -12,8 +12,8 @@ Make sure to meet the following requirements:
 [[info | Note]]
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
 
-* Understand what a [block](https://developers.eos.io/welcome/latest/glossary/index/#block) is and its role in the blockchain.
-* Understand the [block lifecycle](https://developers.eos.io/welcome/latest/protocol-guides/consensus_protocol/#5-block-lifecycle) in the EOSIO consensus protocol.
+* Understand what a [block](/glossary.md#block) is and its role in the blockchain.
+* Understand the [block lifecycle](/protocol-guides/01_consensus_protocol.md#5-block-lifecycle) in the EOSIO consensus protocol.
 
 ## Steps
 
@@ -34,8 +34,10 @@ Some examples are provided below:
 **Example Output**
 
 ```sh
-cleos -u https://api.testnet.eos.io get block 48351112
+cleos -u https://choiceofyourprovider get block 48351112
 ```
+Reference to [testnet providers](/resources/index.md)
+
 ```json
 {
   "timestamp": "2021-01-28T17:58:59.500",
@@ -59,7 +61,7 @@ cleos -u https://api.testnet.eos.io get block 48351112
 **Example Output**
 
 ```sh
-cleos -u https://api.testnet.eos.io get block 02e1c7888a92206573ae38d00e09366c7ba7bc54cd8b7996506f7d2a619c43ba
+cleos -u https://choiceofyourprovider get block 02e1c7888a92206573ae38d00e09366c7ba7bc54cd8b7996506f7d2a619c43ba
 ```
 ```json
 {

--- a/docs/02_cleos/02_how-to-guides/how-to-get-transaction-information.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-get-transaction-information.md
@@ -2,7 +2,7 @@
 
 This how-to guide provides instructions on how to retrieve infomation of an EOSIO transaction using a transaction ID.
 
-The example in this how-to retrieves transaction information associated with the creation of the account **bob**. 
+The example in this how-to retrieves transaction information associated with the creation of the account **bob**.
 
 ## Before you begin
 
@@ -10,7 +10,7 @@ Make sure you meet the following requirements:
 * Install the currently supported version of `cleos`.
 [[info | Note]]
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
-* Understand how transactions work in an EOSIO blockchain. For more information on transactions, see the [Transactions Protocol](https://developers.eos.io/welcome/latest/protocol-guides/transactions_protocol) section.
+* Understand how transactions work in an EOSIO blockchain. For more information on transactions, see the [Transactions Protocol](/protocol-guides/02_transactions_protocol.md) section.
 
 ## Command Reference
 
@@ -25,7 +25,7 @@ The following step shows how to retrieve transaction information associated with
 ```sh
 cleos get transaction 870a6b6e3882061ff0f64016e1eedfdd9439e2499bf978c3fb29fcedadada9b1
 ```
-* Where `870a6b6e38...dada9b1`= The transaction ID associated with the creation of account **bob**. 
+* Where `870a6b6e38...dada9b1`= The transaction ID associated with the creation of account **bob**.
 
 **Example Output**
 
@@ -179,7 +179,7 @@ The `cleos` command returns detailed information of the transaction:
 
 ## Summary
 
-By following these instructions, you are able to retrieve transaction information using a transaction ID. 
+By following these instructions, you are able to retrieve transaction information using a transaction ID.
 
 ## Trobleshooting
 
@@ -195,4 +195,4 @@ Error Details:
 History API plugin is not enabled
 ```
 
-To troubleshoot this error, enable the [history plugin](../../01_nodeos/03_plugins/history_plugin/index.md) and [history API plugin](../../01_nodeos/03_plugins/history_api_plugin/index.md), then run the command again. 
+To troubleshoot this error, enable the [history plugin](../../01_nodeos/03_plugins/history_plugin/index.md) and [history API plugin](../../01_nodeos/03_plugins/history_api_plugin/index.md), then run the command again.

--- a/docs/02_cleos/02_how-to-guides/how-to-import-a-key.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-import-a-key.md
@@ -1,18 +1,18 @@
 ## Overview
 
-This how-to guide provides instructions on how to import a private key into the `keosd` default wallet. You can use the private key to authorize transactions in an EOSIO blockchain. 
+This how-to guide provides instructions on how to import a private key into the `keosd` default wallet. You can use the private key to authorize transactions in an EOSIO blockchain.
 
 ## Before you Begin
 
 Make sure you meet the following requirements:
 
-* Create a default wallet using the `cleos wallet create` command. See the [How to Create a Wallet](../02_how-to-guides/how-to-create-a-wallet.md) section for instructions. 
+* Create a default wallet using the `cleos wallet create` command. See the [How to Create a Wallet](../02_how-to-guides/how-to-create-a-wallet.md) section for instructions.
 * Open and unlock the created wallet.
 * Familiarize with the [`cleos wallet import`](../03_command-reference/wallet/import.md) command.
 * Install the currently supported version of `cleos`.
 [[info | Note]]
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
-* Understand what a [public key](https://developers.eos.io/welcome/latest/glossary/index/#public-key) and [private key](https://developers.eos.io/welcome/latest/glossary/index/#private-key) is.
+* Understand what a [public key](/glossary.md#public-key) and [private key](/glossary.md#private-key) is.
 
 ## Command Reference
 
@@ -31,7 +31,7 @@ cleos wallet import
 private key:
 ```
 
-2. Enter the private key and hit Enter. 
+2. Enter the private key and hit Enter.
 ```sh
 ***
 ```
@@ -44,4 +44,4 @@ imported private key for: EOS8FBXJUfbANf3xeDWPoJxnip3Ych9HjzLBr1VaXRQFdkVAxwLE7
 
 ## Summary
 
-By following these instructions, you are able to import a private key to the default wallet. 
+By following these instructions, you are able to import a private key to the default wallet.

--- a/docs/02_cleos/02_how-to-guides/how-to-list-all-key-pairs.md
+++ b/docs/02_cleos/02_how-to-guides/how-to-list-all-key-pairs.md
@@ -1,6 +1,6 @@
 ## Overview
 
-This how-to guide provides instructions on how to list all public keys and public/private key pairs within the `keosd` default wallet. You can use the public and private keys to authorize transactions in an EOSIO blockchain. 
+This how-to guide provides instructions on how to list all public keys and public/private key pairs within the `keosd` default wallet. You can use the public and private keys to authorize transactions in an EOSIO blockchain.
 
 The example in this how-to guide displays all public keys and public/private key pairs stored within the existing default wallet.
 
@@ -8,13 +8,13 @@ The example in this how-to guide displays all public keys and public/private key
 
 Make sure you meet the following requirements:
 
-* Create a default wallet using the `cleos wallet create` command. See the [How to Create a Wallet](../02_how-to-guides/how-to-create-a-wallet.md) section for instructions. 
+* Create a default wallet using the `cleos wallet create` command. See the [How to Create a Wallet](../02_how-to-guides/how-to-create-a-wallet.md) section for instructions.
 * [Create a keypair](../03_command-reference/wallet/create_key.md) within the default wallet.
 * Familiarize with the [`cleos wallet`](../03_command-reference/wallet/index.md) commands.
 * Install the currently supported version of `cleos`.
 [[info | Note]]
 | `cleos` is bundled with the EOSIO software. [Installing EOSIO](../../00_install/index.md) will also install `cleos`.
-* Understand what a [public key](https://developers.eos.io/welcome/latest/glossary/index/#public-key) and [private key](https://developers.eos.io/welcome/latest/glossary/index/#private-key) is.
+* Understand what a [public key](/glossary.md#public-key) and [private key](/glossary.md#private-key) is.
 
 ## Command Reference
 
@@ -71,7 +71,7 @@ cleos wallet private_keys
 password:
 ```
 
-6. Enter the generated password when you created the default wallet: 
+6. Enter the generated password when you created the default wallet:
 ```sh
 ***
 ```
@@ -86,7 +86,7 @@ password: [[
 ```
 
 [[caution | Warning]]
-| Never reveal your private keys in a production environment. 
+| Never reveal your private keys in a production environment.
 
 [[info | Note]]
 | If the above commands does not list any keys, make sure you have created keypairs and imported private keys to your wallet.

--- a/docs/02_cleos/03_command-reference/get/account.md
+++ b/docs/02_cleos/03_command-reference/get/account.md
@@ -17,10 +17,10 @@ cleos get account eosio
 ```
 ```console
 privileged: true
-permissions: 
+permissions:
      owner     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
         active     1:    1 EOS6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5GDW5CV
-memory: 
+memory:
      quota:        -1 bytes  used:      1.22 Mb   
 
 net bandwidth: (averaged over 3 days)
@@ -106,4 +106,4 @@ cleos get account eosio --json
 ```
 
 ## See Also
-- [Accounts and Permissions](https://developers.eos.io/welcome/latest/protocol/accounts_and_permissions) protocol document.
+- [Accounts and Permissions](/protocol-guides/04_accounts_and_permissions.md) protocol document.

--- a/docs/02_cleos/03_command-reference/net/peers.md
+++ b/docs/02_cleos/03_command-reference/net/peers.md
@@ -111,4 +111,4 @@ cleos -u http://127.0.0.1:8001 net peers
 ]
 ```
 
-**Note:** The `last_handshake` field contains the chain state of each connected peer as of the last handshake message with the node. For more information read the [Handshake Message](https://developers.eos.io/welcome/latest/protocol/network_peer_protocol#421-handshake-message) in the *Network Peer Protocol* document.
+**Note:** The `last_handshake` field contains the chain state of each connected peer as of the last handshake message with the node. For more information read the [Handshake Message](/protocol-guides/03_network_peer_protocol.md#421-handshake-message) in the *Network Peer Protocol* document.

--- a/docs/02_cleos/03_command-reference/net/status.md
+++ b/docs/02_cleos/03_command-reference/net/status.md
@@ -67,4 +67,4 @@ cleos -u http://127.0.0.1:8002 net status localhost:9001
 }
 ```
 
-**Note:** The `last_handshake` field contains the chain state of the specified peer as of the last handshake message with the node. For more information read the [Handshake Message](https://developers.eos.io/welcome/latest/protocol/network_peer_protocol#421-handshake-message) in the *Network Peer Protocol* document.
+**Note:** The `last_handshake` field contains the chain state of the specified peer as of the last handshake message with the node. For more information read the [Handshake Message](/protocol-guides/03_network_peer_protocol.md#421-handshake-message) in the *Network Peer Protocol* document.

--- a/docs/02_cleos/03_command-reference/set/set-account.md
+++ b/docs/02_cleos/03_command-reference/set/set-account.md
@@ -88,4 +88,4 @@ The authority JSON object ...
 ```
 
 ## See Also
-- [Accounts and Permissions](https://developers.eos.io/welcome/latest/protocol/accounts_and_permissions) protocol document.
+- [Accounts and Permissions](/protocol-guides/04_accounts_and_permissions.md) protocol document.

--- a/docs/02_cleos/03_command-reference/set/set-action.md
+++ b/docs/02_cleos/03_command-reference/set/set-action.md
@@ -40,7 +40,7 @@ cleos set action permission
 
 `-f,--force-unique` - force the transaction to be unique. this will consume extra bandwidth and remove any protections against accidently issuing the same transaction multiple times
 
-`-s,--skip-sign` Specify if unlocked wallet keys 
+`-s,--skip-sign` Specify if unlocked wallet keys
 should be used to sign transaction
 
 `-j,--json` print result as json
@@ -65,9 +65,9 @@ should be used to sign transaction
 #Link a `voteproducer` action to the 'voting' permissions
 cleos set action permission sandwichfarm eosio.system voteproducer voting -p sandwichfarm@voting
 
-#Now can execute the transaction with the previously set permissions. 
+#Now can execute the transaction with the previously set permissions.
 cleos system voteproducer approve sandwichfarm someproducer -p sandwichfarm@voting
 ```
 
 ## See Also
-- [Accounts and Permissions](https://developers.eos.io/welcome/latest/protocol/accounts_and_permissions) protocol document.
+- [Accounts and Permissions](/protocol-guides/04_accounts_and_permissions.md) protocol document.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Additional EOSIO Resources:
 * [EOSIO Utilities](10_utilities/index.md) - Utilities that complement the EOSIO software.  
 
 [//]: # (THIS IS A COMMENT REMOVING BROKEN LINKS)  
-[//]: #Upgrade-Guide-20_upgrade-guide/index.md-EOSIO-version/protocol-upgrade-guide.  
+[//]: # (Upgrade-Guide-20_upgrade-guide/index.md-EOSIO-version/protocol-upgrade-guide.)  
 [//]: # (Release Notes 30_release-notes/index.md  - All release notes for this EOSIO version.)  
 
 [[info | What's Next?]]

--- a/tutorials/bios-boot-tutorial/README.md
+++ b/tutorials/bios-boot-tutorial/README.md
@@ -19,28 +19,14 @@ The `bios-boot-tutorial.py` script simulates the bios boot sequence.
 ``Steps``:
 
 1. Install mandel binaries by following the steps outlined in below tutorial
-[Install mandel binaries](https://github.com/eosnetworkfoundation/mandel/tree/release/3.0.x#Building).
+[Install mandel binaries](https://github.com/eosnetworkfoundation/mandel/releases).
 
-2. Install mandel.cdt version 1.8.1 binaries by following the steps outlined in below tutorial
-[Install mandel.cdt binaries](https://github.com/eosnetworkfoundation/mandel.cdt/tree/v1.8.1#binary-releases).
+2. Install mandel.cdt version 3.0 binaries by following the steps outlined in below tutorial
+[Install mandel.cdt binaries](https://github.com/eosnetworkfoundation/mandel.cdt/releases).
 
-3. Compile `mandel-contracts` version 3.0.x
+3. [Compile mandel-contracts](https://github.com/eosnetworkfoundation/mandel-contracts#build-system-contracts)
 
-```bash
-$ cd ~
-$ git clone https://github.com/eosnetworkfoundation/mandel-contracts mandel.contracts-3.0.x
-$ cd ./mandel.contracts-3.0.x/
-$ git checkout release/3.0.x
-$ ./build.sh
-$ cd ./build/contracts/
-$ pwd
-
-```
-
-4. Make note of the directory where the contracts were compiled
-The last command in the previous step printed on the bash console the contracts' directory, make note of it, we'll reference it from now on as `CONTRACTS_DIRECTORY`
-
-5. Launch the `bios-boot-tutorial.py` script.
+4. Launch the `bios-boot-tutorial.py` script.
 The command line to launch the script, make sure you replace `CONTRACTS_DIRECTORY` with the actual directory path.
 
 ```bash
@@ -50,5 +36,3 @@ $ cd ./mandel/tutorials/bios-boot-tutorial/
 $ python3 bios-boot-tutorial.py --cleos=cleos --nodeos=nodeos --keosd=keosd --contracts-dir="CONTRACTS_DIRECTORY" -w -a
 
 ```
-
-See [Developer Portal: Bios Boot Sequence](https://developers.eos.io/welcome/latest/tutorials/bios-boot-sequence) for additional information.


### PR DESCRIPTION
**Summary**
* Support MDX parsing
* Replace github references to EOS Network Foundation
* Replace references to old documentation portal
* Fix broken links

**Impacted files**: markdown files under `docs` and under `tutorial`
<hr/>
The developer documentation portal is powered by markdown files. These files are parsed to create a nice looking web site. We use MDX as the parsing engine. MDX requires all html tags are closed. We went through all the files removing unneeded &lt;hr&gt; tags, enclosing angle brackets in quotes, and closing img tags.

Many times we found documentation pointing to old repositories that had not been updated in years. We updated the links and pointed to repositories that are better maintained.

We made sure links to the documentation portal did not leak back to older, previous versions.

We found relative links that no longer existed. We made sure to point the links to best location. Sometimes the links broke because were missing a key file extension. We made sure to add back the file extenstion.

**Note:** This is essentially a no-op; however summarizing here for anyone following the commit history. Glossary and Protocol Guides were added and removed during the course of development. We had added a Glossary and Protocol Guides , and we decided to utilize the welcome repository as the source for both.
<hr/>
commit ba20420c42f2f8bbf3396102d3ac22261028af30
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Thu Aug 4 12:46:52 2022 -0700

    Testsnets anchor link was not working rm it

commit d5de39dbbe250d2a9878c82de990c086c3b7b122
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Thu Aug 4 10:27:42 2022 -0700

    adding missing .md ext

commit 9dbb885d2eb308e60a2db909c9aed7b5dcb4289a
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Thu Aug 4 10:24:49 2022 -0700

    found another eos.io reference to replace

commit 6a10c44b5863552c85c283db5b6d24e84b84f2cf
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Thu Aug 4 08:47:02 2022 -0700

    moved away from eos testnet

commit 023c8e50724b766b0b9c8ce859d106101bc90fc8
Merge: 9d486ab51 6514a7d63
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Thu Aug 4 08:33:00 2022 -0700

    Merge remote-tracking branch 'origin/main' into documentation-fixes

    Fixing docs by removing eosio references, need resync with main to catch merge issues early

commit 9d486ab51aa399a4e5c7a038c19531071a88e900
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Aug 2 08:19:36 2022 -0700

    updated protocol-guides links to include number

commit 907d9e2af8796087ba830f10f53df0063d0a621d
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Fri Jul 29 16:23:41 2022 -0700

    removed general_info replaced by welcome repository markdown

commit 07efa3fb831ef2d57f68be0ef3aa21e28c346a80
Merge: 056239ccc d36ca7a52
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Fri Jul 29 07:10:24 2022 -0700

    merging with upstream/main keeping up to date

commit 056239cccb5e3337b5598364190cd4dc9d16a281
Merge: b921bdf98 b378866ef
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 17:08:43 2022 -0700

    Merge remote-tracking branch 'refs/remotes/origin/documentation-fixes' into documentation-fixes

    Note pulled in "changes to lower bound description" 766C6164
    Resolved Conflicts No Changes:
    	docs/general_info/glossary.md
    	docs/general_info/protocol-guides/consensus_protocol.md
    	docs/general_info/protocol-guides/network_peer_protocol.md
    	docs/general_info/protocol-guides/transactions_protocol.md
    Changes to be committed:
    	modified:   docs/general_info/protocol-guides/accounts_and_permissions.md
    	modified:   libraries/chain/include/eosio/chain/webassembly/interface.hpp

commit b921bdf987c0206b6704968eaca3bc05c505d469
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 16:44:25 2022 -0700

    removed eos.io from markdown

    - Added docs/general_info/glossary.md
    - Added docs/general_info/protocol-guides
         - overview only for accounts_and_permissions.md
         - overview only for transactions_protocol.md
         - overview only for network_peer_protocol.md
         - overview only for consensus_protocol.md
    - Updated glossary.md to relative path (no more eos.io)
    - Fixed links adding missing .md extenstion
    - Updated protocol-guides to relative path (no more eos.io)
    - Included BiosBoot tutorial on main document portal
    - Fixed or removed broken links inside newly added glossary, guides, and tutorials

    Note: squashed commits on branch down to single commit, less noise, easier to cherry-pick

commit b378866eff4be5cd3986c88a6d6ff39a802fee57
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 15:36:42 2022 -0700

    adding back more missing .md extenstions, and simplying bios-boot-tutorial

commit 2f7c0e65cbf360ba13102c8a5341714c4ce1159d
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 15:14:16 2022 -0700

    fixing more missing .md ext

commit 07b1f16962921acdd35d24c87e6a87378c7a10fc
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 15:03:06 2022 -0700

    updated with .md ext

commit 002b01ddc81e67d09dba40fae9cc2303b4efed7b
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 14:29:33 2022 -0700

    updated formate for glossary links to include .md

commit bf344ae16c76ca1109672b8e9cccc5a69527e3d3
Merge: 3bbb956b5 0cb196b7f
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 08:48:05 2022 -0700

    merging main into documentation-fixes, after removing eso.io references adding glossary and guides

commit 3bbb956b524267c788dd9614011abeda1be96b93
Author: Eric Passmore <eric.passmore@gmail.com>
Date:   Tue Jul 26 08:47:12 2022 -0700

    remove eos.io references, added glossary, guides