### PR TITLE
[3.2] insert comments in the kv_config header file indicating it is not in use

### DIFF
--- a/libraries/chain/include/eosio/chain/kv_config.hpp
+++ b/libraries/chain/include/eosio/chain/kv_config.hpp
@@ -6,11 +6,14 @@
 namespace eosio { namespace chain {
 
    /**
-    * @brief limits for a kv database.
+    * @brief limits for a kv database: NOT IN USE for mandel
     *
     * Each database (ram or disk, currently) has its own limits for these parameters.
     * The key and value limits apply when adding or modifying elements.  They may be reduced
     * below existing database entries.
+    * 
+    * This has been marked for removal at a later date, when v7 snapshots are deemed necessary.
+    * kv_database_config will be removed as part of that effort.
     */
    struct kv_database_config {
       std::uint32_t max_key_size   = 0; ///< the maximum size in bytes of a key


### PR DESCRIPTION
As per the discussion on https://github.com/eosnetworkfoundation/mandel/issues/763, the comment in the header has been updated to indicate that it is not in use.  Removal of `kv_database_config` will cause snapshots to need to be updated, which is not desirable at this time. 

When some later change causes the need for v7 snapshots, that would be when the removal should occur.