### PR TITLE
[3.1 -> main] Attempt connection retries for duplicate connections

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -2280,6 +2280,7 @@ namespace eosio {
          case no_reason:
          case wrong_version:
          case benign_other:
+         case duplicate: // attempt reconnect in case connection has been dropped, should quickly disconnect if duplicate
             break;
          default:
             fc_dlog( logger, "Skipping connect due to go_away reason ${r}",("r", reason_str( no_retry )));


### PR DESCRIPTION
Attempt a re-connect for duplicate connections so that any registered duplicate connections have an opportunity to re-establish a connection for the corner case of one side disconnecting as a duplicate simply because it had not yet closed its end of the connection. The re-connect will happen during the normal re-connect interval configured by connection-cleanup-period.

Resolves https://github.com/eosnetworkfoundation/mandel/issues/755