### PR TITLE
[3.1] Reduce net_plugin handshake messages in case of unavailable blocks

### DIFF
--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1300,8 +1300,10 @@ namespace eosio {
             });
          } else {
             c->strand.post( [c, num]() {
-               peer_ilog( c, "enqueue sync, unable to fetch block ${num}", ("num", num) );
-               c->send_handshake();
+               peer_ilog( c, "enqueue sync, unable to fetch block ${num}, sending benign_other go away", ("num", num) );
+               c->peer_requested.reset(); // unable to provide requested blocks
+               c->no_retry = benign_other;
+               c->enqueue( go_away_message( benign_other ) );
             });
          }
       });


### PR DESCRIPTION
In the case the full block log is not available, prevent handshake message being sent sync-fetch count times to peer. For example, if the client requested 1000 blocks not available by the node, `net_plugin` would respond with 1000 handshake messages. Disconnect from peer with `benign_other` so the peer will move on to a different peer to sync from. This is what we already do for `blk_send_branch` when a block is not available.

Resolves #790 