### PR TITLE
[3.1 -> main] Increase default transaction-retry-max-expiration-sec from 90 to 120. Added file package to the list of installable packages.

### DIFF
--- a/plugins/chain_plugin/chain_plugin.cpp
+++ b/plugins/chain_plugin/chain_plugin.cpp
@@ -324,7 +324,7 @@ void chain_plugin::set_program_options(options_description& cli, options_descrip
           "Maximum size (in GiB) allowed to be allocated for the Transaction Retry feature. Setting above 0 enables this feature.")
          ("transaction-retry-interval-sec", bpo::value<uint32_t>()->default_value(20),
           "How often, in seconds, to resend an incoming transaction to network if not seen in a block.")
-         ("transaction-retry-max-expiration-sec", bpo::value<uint32_t>()->default_value(90),
+         ("transaction-retry-max-expiration-sec", bpo::value<uint32_t>()->default_value(120),
           "Maximum allowed transaction expiration for retry transactions, will retry transactions up to this value.")
          ("transaction-finality-status-max-storage-size-gb", bpo::value<uint64_t>(),
           "Maximum size (in GiB) allowed to be allocated for the Transaction Finality Status feature. Setting above 0 enables this feature.")

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -3,4 +3,4 @@
 apt-get update
 apt-get update --fix-missing
 DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
-apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libcurl4-openssl-dev libgmp-dev libssl-dev libusb-1.0.0-dev libzstd-dev time pkg-config zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3
+apt-get -y install zip unzip libncurses5 wget git build-essential cmake curl libcurl4-openssl-dev libgmp-dev libssl-dev libusb-1.0.0-dev libzstd-dev time pkg-config zlib1g-dev libtinfo-dev bzip2 libbz2-dev python3 file


### PR DESCRIPTION
Merge 3.1 PR https://github.com/eosnetworkfoundation/mandel/pull/809 to main (resolving Resolve https://github.com/eosnetworkfoundation/mandel/issues/800.). The merge also gets changes from https://github.com/eosnetworkfoundation/mandel/pull/807.