### PR TITLE
Perf harness parts integration

### DIFF
--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -68,9 +68,10 @@ try:
     node0 = cluster.getNode()
     info = node0.getInfo()
     chainId = info['chain_id']
+    lib_id = info['last_irreversible_block_id']
 
-    if Utils.Debug: Print(f'Running trx_generator: ./tests/trx_generator/trx_generator  --chain-id {chainId} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name} --priv-keys {account1PrivKey},{account2PrivKey}')
-    Utils.runCmdReturnStr(f'./tests/trx_generator/trx_generator  --chain-id {chainId} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name} --priv-keys {account1PrivKey},{account2PrivKey}')
+    if Utils.Debug: Print(f'Running trx_generator: ./tests/trx_generator/trx_generator  --chain-id {chainId} --last-irreversible-block-id {lib_id} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name} --priv-keys {account1PrivKey},{account2PrivKey}')
+    Utils.runCmdReturnStr(f'./tests/trx_generator/trx_generator  --chain-id {chainId} --last-irreversible-block-id {lib_id} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name} --priv-keys {account1PrivKey},{account2PrivKey}')
 
     testSuccessful = True
 finally:

--- a/tests/performance_tests/performance_test_basic.py
+++ b/tests/performance_tests/performance_test_basic.py
@@ -62,12 +62,15 @@ try:
     account1Name = cluster.accounts[0].name
     account2Name = cluster.accounts[1].name
 
+    account1PrivKey = cluster.accounts[0].activePrivateKey
+    account2PrivKey = cluster.accounts[1].activePrivateKey
+
     node0 = cluster.getNode()
     info = node0.getInfo()
     chainId = info['chain_id']
 
-    if Utils.Debug: Print(f'Running trx_generator with chain-id:{chainId} handler-account:{cluster.eosioAccount.name} accounts:{account1Name},{account2Name}')
-    Utils.runCmdReturnStr(f'./tests/trx_generator/trx_generator  --chain-id {chainId} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name}')
+    if Utils.Debug: Print(f'Running trx_generator: ./tests/trx_generator/trx_generator  --chain-id {chainId} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name} --priv-keys {account1PrivKey},{account2PrivKey}')
+    Utils.runCmdReturnStr(f'./tests/trx_generator/trx_generator  --chain-id {chainId} --handler-account {cluster.eosioAccount.name} --accounts {account1Name},{account2Name} --priv-keys {account1PrivKey},{account2PrivKey}')
 
     testSuccessful = True
 finally:

--- a/tests/trx_generator/main.cpp
+++ b/tests/trx_generator/main.cpp
@@ -28,7 +28,7 @@ using namespace eosio::testing;
 using namespace eosio::chain;
 using namespace eosio;
 
-vector<pair<eosio::chain::action, eosio::chain::action>> create_transfer_actions(const std::string& salt, const uint64_t& period, const name& newaccountT, const vector<name>& accounts, const fc::microseconds& abi_serializer_max_time) {
+vector<pair<eosio::chain::action, eosio::chain::action>> create_initial_transfer_actions(const std::string& salt, const uint64_t& period, const name& newaccountT, const vector<name>& accounts, const fc::microseconds& abi_serializer_max_time) {
    vector<pair<eosio::chain::action, eosio::chain::action>> actions_pairs_vector;
 
    abi_serializer eosio_token_serializer{fc::json::from_string(contracts::eosio_token_abi().data()).as<abi_def>(), abi_serializer::create_yield_function(abi_serializer_max_time)};
@@ -36,7 +36,7 @@ vector<pair<eosio::chain::action, eosio::chain::action>> create_transfer_actions
    for(size_t i = 0; i < accounts.size(); ++i) {
       for(size_t j = i + 1; j < accounts.size(); ++j) {
          //create the actions here
-         ilog("create_transfer_actions: creating transfer from ${acctA} to ${acctB}", ("acctA", accounts.at(i))("acctB", accounts.at(j)));
+         ilog("create_initial_transfer_actions: creating transfer from ${acctA} to ${acctB}", ("acctA", accounts.at(i))("acctB", accounts.at(j)));
          action act_a_to_b;
          act_a_to_b.account = newaccountT;
          act_a_to_b.name = "transfer"_n;
@@ -46,7 +46,7 @@ vector<pair<eosio::chain::action, eosio::chain::action>> create_transfer_actions
                                                                     fc::mutable_variant_object()("from", accounts.at(i).to_string())("to", accounts.at(j).to_string())("l", salt))),
                                                                     abi_serializer::create_yield_function(abi_serializer_max_time));
 
-         ilog("create_transfer_actions: creating transfer from ${acctB} to ${acctA}", ("acctB", accounts.at(j))("acctA", accounts.at(i)));
+         ilog("create_initial_transfer_actions: creating transfer from ${acctB} to ${acctA}", ("acctB", accounts.at(j))("acctA", accounts.at(i)));
          action act_b_to_a;
          act_b_to_a.account = newaccountT;
          act_b_to_a.name = "transfer"_n;
@@ -59,7 +59,7 @@ vector<pair<eosio::chain::action, eosio::chain::action>> create_transfer_actions
          actions_pairs_vector.push_back(make_pair(act_a_to_b, act_b_to_a));
       }
    }
-   ilog("create_transfer_actions: total action pairs created: ${pairs}", ("pairs", actions_pairs_vector.size()));
+   ilog("create_initial_transfer_actions: total action pairs created: ${pairs}", ("pairs", actions_pairs_vector.size()));
    return actions_pairs_vector;
 }
 
@@ -242,7 +242,8 @@ int main(int argc, char** argv) {
       // block_id_type reference_block_id = cc.get_block_id_for_num(reference_block_num);
       block_id_type reference_block_id = make_block_id(reference_block_num);
 
-      const auto action_pairs_vector = create_transfer_actions(salt, period, handlerAcct, accounts, abi_serializer_max_time);
+      std::cout << "Create All Initial Transfer Action/Reaction Pairs (acct 1 -> acct 2, acct 2 -> acct 1) between all provided accounts." << std::endl;
+      const auto action_pairs_vector = create_initial_transfer_actions(salt, period, handlerAcct, accounts, abi_serializer_max_time);
 
       std::cout << "Stop Generation." << std::endl;
       stop_generation();

--- a/tests/trx_generator/main.cpp
+++ b/tests/trx_generator/main.cpp
@@ -109,7 +109,7 @@ void send_transaction_batch(std::function<void(const fc::exception_ptr&)> next, 
          {
             signed_transaction trx;
             trx.actions.push_back(action_pairs_vector.at(action_pair_index).first);
-            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) + std::to_string(nonce++))));
+            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) +":"+ std::to_string(++nonce))));
             trx.set_reference_block(reference_block_id);
             trx.expiration = fc::time_point::now() + trx_expiration;
             trx.max_net_usage_words = 100;
@@ -120,7 +120,7 @@ void send_transaction_batch(std::function<void(const fc::exception_ptr&)> next, 
          {
             signed_transaction trx;
             trx.actions.push_back(action_pairs_vector.at(action_pair_index).second);
-            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) + std::to_string(nonce++))));
+            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix)  +":"+ std::to_string(++nonce))));
             trx.set_reference_block(reference_block_id);
             trx.expiration = fc::time_point::now() + trx_expiration;
             trx.max_net_usage_words = 100;

--- a/tests/trx_generator/main.cpp
+++ b/tests/trx_generator/main.cpp
@@ -75,11 +75,11 @@ vector<signed_transaction> create_intial_transfer_transactions(uint64_t nonce_pr
 
       static uint64_t nonce = static_cast<uint64_t>(fc::time_point::now().sec_since_epoch()) << 32;
 
-      for(action_pair acts : action_pairs_vector) {
+      for(action_pair acts: action_pairs_vector) {
          {
             signed_transaction trx;
             trx.actions.push_back(acts.first);
-            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) +":"+ std::to_string(++nonce)+":"+fc::time_point::now().time_since_epoch().count())));
+            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) + ":" + std::to_string(++nonce) + ":" + fc::time_point::now().time_since_epoch().count())));
             trx.set_reference_block(reference_block_id);
             trx.expiration = fc::time_point::now() + trx_expiration;
             trx.max_net_usage_words = 100;
@@ -90,7 +90,7 @@ vector<signed_transaction> create_intial_transfer_transactions(uint64_t nonce_pr
          {
             signed_transaction trx;
             trx.actions.push_back(acts.second);
-            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) +":"+ std::to_string(++nonce)+":"+fc::time_point::now().time_since_epoch().count())));
+            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) + ":" + std::to_string(++nonce) + ":" + fc::time_point::now().time_since_epoch().count())));
             trx.set_reference_block(reference_block_id);
             trx.expiration = fc::time_point::now() + trx_expiration;
             trx.max_net_usage_words = 100;
@@ -116,12 +116,12 @@ void update_resign_transactions(const vector<signed_transaction>& trxs, uint64_t
       static uint64_t nonce = static_cast<uint64_t>(fc::time_point::now().sec_since_epoch()) << 32;
       static fc::crypto::private_key a_priv_key = fc::crypto::private_key::regenerate(fc::sha256(std::string(64, 'a')));
 
-      for (signed_transaction strx : trxs) {
-            strx.context_free_actions.clear();
-            strx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) +":"+ std::to_string(++nonce)+":"+fc::time_point::now().time_since_epoch().count())));
-            strx.set_reference_block(reference_block_id);
-            strx.expiration = fc::time_point::now() + trx_expiration;
-            strx.sign(a_priv_key, chain_id);
+      for(signed_transaction strx: trxs) {
+         strx.context_free_actions.clear();
+         strx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) + ":" + std::to_string(++nonce) + ":" + fc::time_point::now().time_since_epoch().count())));
+         strx.set_reference_block(reference_block_id);
+         strx.expiration = fc::time_point::now() + trx_expiration;
+         strx.sign(a_priv_key, chain_id);
       }
    } catch(const std::bad_alloc&) {
       throw;
@@ -281,8 +281,7 @@ int main(int argc, char** argv) {
       std::cout << "send all initial transactions via p2p transaction provider" << std::endl;
       std::vector<signed_transaction> single_send = std::vector<signed_transaction>();
       single_send.reserve(1);
-      for(signed_transaction trx : trxs)
-      {
+      for(signed_transaction trx: trxs) {
          single_send.emplace_back(trx);
          provider.send(single_send);
          single_send.clear();

--- a/tests/trx_generator/main.cpp
+++ b/tests/trx_generator/main.cpp
@@ -109,7 +109,7 @@ void send_transaction_batch(std::function<void(const fc::exception_ptr&)> next, 
          {
             signed_transaction trx;
             trx.actions.push_back(action_pairs_vector.at(action_pair_index).first);
-            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) +":"+ std::to_string(++nonce))));
+            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix) +":"+ std::to_string(++nonce)+":"+fc::time_point::now().time_since_epoch().count())));
             trx.set_reference_block(reference_block_id);
             trx.expiration = fc::time_point::now() + trx_expiration;
             trx.max_net_usage_words = 100;
@@ -120,7 +120,7 @@ void send_transaction_batch(std::function<void(const fc::exception_ptr&)> next, 
          {
             signed_transaction trx;
             trx.actions.push_back(action_pairs_vector.at(action_pair_index).second);
-            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix)  +":"+ std::to_string(++nonce))));
+            trx.context_free_actions.emplace_back(action({}, config::null_account_name, name("nonce"), fc::raw::pack(std::to_string(nonce_prefix)  +":"+ std::to_string(++nonce)+":"+fc::time_point::now().time_since_epoch().count())));
             trx.set_reference_block(reference_block_id);
             trx.expiration = fc::time_point::now() + trx_expiration;
             trx.max_net_usage_words = 100;

--- a/tests/trx_generator/trx_provider.cpp
+++ b/tests/trx_generator/trx_provider.cpp
@@ -46,7 +46,7 @@ namespace eosio::testing {
          packed_transaction pt(t);
          net_message msg{std::move(pt)};
 
-         _peer_connection.send_transaction()
+         _peer_connection.send_transaction(pt);
       }
    }
 


### PR DESCRIPTION
Working to connect the `performance_test_basic.py` to the `trx_generator` as well as make use of the `trx_provider` interface provided.

Update message in context free action of the transaction to be easier to parse in the future by delimiting with `:` and adding the current timestamp for future latency calculations.

Added command line arguments:

- `priv-keys` - comma-separated list of private keys in same order of accounts list that will be used to sign transactions. Minimum required: 2.
- `last-irreversible-block-id` - Current last-irreversible-block-id (LIB ID) to use for transactions.

Cleanup currently unused code/ideas like batching and previous implementations of push transaction(s).

Implement initial use of `trx_provider` to send transactions to the p2p interface.  Currently will send an initial batch of transfer transactions between the configured accounts.

Add ability to update transaction collection prior to send to update uniqueness fields and tracking timestamps and re-signing prior to sending.